### PR TITLE
Remove bad dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,5 @@ Homepage: http://www.endlessm.com
 
 Package: eos-shell-content
 Architecture: all
-Depends: glib,
-	 json-glib
 Description: Endless OS Shell Content installation package
  This package will install the content for the app store


### PR DESCRIPTION
Binary packages with these names don't exist, breaking the build.

Looking at the built contents of this package, actually nothing there
depends on glib or json-glib. The contents are entirely simple files
(jpeg, json files, etc).

[endlessm/eos-shell#1346]
