### PR TITLE
Fix generation of content.json.h file for links

### DIFF
--- a/content/Makefile.am
+++ b/content/Makefile.am
@@ -60,7 +60,7 @@ DISTCLEANFILES += extract-content-strings$(BUILD_EXEEXT)
 content_files = $(default_app_json) $(default_links_json)
 content_headers = $(content_files:.json=.json.h)
 %.json.h: $(content_files) extract-content-strings$(BUILD_EXEEXT)
-	$(AM_V_GEN) test -f $(addprefix $(srcdir)/,$@) || ./extract-content-strings$(BUILD_EXEEXT) $< > $@
+	$(AM_V_GEN) test -f $(addprefix $(srcdir)/,$@) || ./extract-content-strings$(BUILD_EXEEXT) $(addsuffix .json,$*) > $@
 
 all-local: $(content_headers)
 


### PR DESCRIPTION
Even if it's currently not used for translations, this was always using
the first prerequisite as an input to the extract script, so we would
generate two identical files.

[endlessm/eos-shell#1452]
