### PR TITLE
Remove health from Brazil image

### DIFF
--- a/content/Default/apps/content.json
+++ b/content/Default/apps/content.json
@@ -1440,8 +1440,7 @@
     "subtitle":"Live a healthy life with this app, packed with tips and resources",
     "description":"Your health is one of the most important aspects of daily life, and you need resources to make sure you understand how to lead a healthy lifestyle and stay well. With this health app, you\u2019ll have access to information about a range of health topics. Learn about how to keep yourself and your family from getting sick, and how to take care of minor ailments when they occur. This app is your indispensable resource to learn how to live a healthy life.",
     "personalities":[
-      "Default",
-      "Brazil"
+      "Default"
     ],
     "splash-screen-type":"Default",
     "custom-splash-screen":"",

--- a/data/settings/icon-grid-Brazil.json
+++ b/data/settings/icon-grid-Brazil.json
@@ -59,7 +59,6 @@
   ],
   "eos-folder-curiosity.directory" : [
     "eos-app-com.endlessm.brazil.desktop",
-    "eos-app-com.endlessm.health.desktop",
     "eos-app-com.endlessm.futbol.desktop",
     "eos-app-com.endlessm.travel.desktop",
     "eos-app-com.endlessm.cooking.desktop",


### PR DESCRIPTION
App will still be installed, but will not show up in the desktop
curiosity folder or in the app store.

[endlessm/eos-shell#1529]
