### PR TITLE
Avoid overly long desktop names for Brazil apps

### DIFF
--- a/content/Default/apps/content.json
+++ b/content/Default/apps/content.json
@@ -2027,7 +2027,7 @@
     "tryexec":"",
     "folder":"desktop",
     "desktop-position":"99",
-    "title":"My Documents",
+    "title":"Documents",
     "subtitle":"File manager",
     "description":"No description necessary -- this is not available via the app store",
     "personalities":[

--- a/data/applications/eos-app-eos-file-manager.desktop
+++ b/data/applications/eos-app-eos-file-manager.desktop
@@ -1,8 +1,8 @@
 [Desktop Entry]
 Version=1.0
-Name=My Documents
+Name=Documents
 Name[es]=Documentos
-Name[pt]=Meus Documentos
+Name[pt]=Documentos
 Comment=File manager
 Comment[es]=Administrador de archivos
 Comment[pt]=Gerenciador de Arquivos

--- a/data/applications/eos-app-gimp.desktop
+++ b/data/applications/eos-app-gimp.desktop
@@ -2,7 +2,7 @@
 Version=1.0
 Name=GIMP
 Name[es]=GIMP
-Name[pt]=GIMP (edição de imagem)
+Name[pt]=GIMP
 Comment= Image retouching and editing tool
 Comment[es]=Edita tus fotos como un profesional 
 Comment[pt]=Ferramenta de edição e retoque de imagens

--- a/po/es.po
+++ b/po/es.po
@@ -15,8 +15,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: eos-shell-content\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-11-08 23:57-0800\n"
-"PO-Revision-Date: 2013-11-09 08:03+0000\n"
+"POT-Creation-Date: 2013-11-19 13:47-0800\n"
+"PO-Revision-Date: 2013-11-19 21:51+0000\n"
 "Last-Translator: rshuler <roddy@endlessm.com>\n"
 "Language-Team: Spanish (http://www.transifex.com/projects/p/teams/language/es/)\n"
 "MIME-Version: 1.0\n"
@@ -1228,7 +1228,7 @@ msgstr "¡El mundo es un lugar bello y extraordinario! Comienza a explorarlo con
 
 #: ../content/Default/apps/content.json.h:175
 msgctxt "title"
-msgid "My Documents"
+msgid "Documents"
 msgstr "Documentos"
 
 #: ../content/Default/apps/content.json.h:176

--- a/po/pt.po
+++ b/po/pt.po
@@ -13,8 +13,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: eos-shell-content\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-11-08 23:57-0800\n"
-"PO-Revision-Date: 2013-11-18 16:17+0000\n"
+"POT-Creation-Date: 2013-11-19 13:47-0800\n"
+"PO-Revision-Date: 2013-11-19 21:49+0000\n"
 "Last-Translator: rshuler <roddy@endlessm.com>\n"
 "Language-Team: Portuguese (http://www.transifex.com/projects/p/teams/language/pt/)\n"
 "MIME-Version: 1.0\n"
@@ -360,7 +360,7 @@ msgstr "Com mais de 100 jogos e atividades este aplicativo torna o aprendizado d
 #: ../content/Default/apps/content.json.h:52
 msgctxt "title"
 msgid "GIMP"
-msgstr "GIMP (edição de imagem)"
+msgstr "GIMP"
 
 #: ../content/Default/apps/content.json.h:53
 msgctxt "subtitle"
@@ -1226,8 +1226,8 @@ msgstr "O mundo é um lugar surpreendente e lindo! Comece a explorá-lo com este
 
 #: ../content/Default/apps/content.json.h:175
 msgctxt "title"
-msgid "My Documents"
-msgstr "Meus Documentos"
+msgid "Documents"
+msgstr "Documentos"
 
 #: ../content/Default/apps/content.json.h:176
 msgctxt "subtitle"


### PR DESCRIPTION
As part of this, clean up the English name for the file manager
from 'My Documents' to 'Documents'.  (The Spanish translation
was already correct, but it still had to be updated in Transifex
due to the changed source string.)

[endlessm/eos-shell#1524]
