### PR TITLE
Add a substitutions file

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -13,6 +13,9 @@ folders_DATA = $(wildcard folders/*.directory)
 settingsdir = $(datadir)/EndlessOS/personality-defaults
 settings_DATA = $(wildcard settings/icon-grid-*.json)
 
+substitutionsdir = $(datadir)/EndlessOS
+substitutions_DATA = eos-desktop-substitutions.ini
+
 do_subst = sed \
 	-e 's|@DATA_DIR[@]|$(datadir)|g' \
 	-e 's|@SYSCONF_DIR[@]|$(sysconfdir)|g'
@@ -29,6 +32,7 @@ EXTRA_DIST = \
     $(desktops_DATA) \
     $(folders_DATA) \
     $(settings_DATA) \
+    $(substitutions_DATA) \
     eos-exec-localized \
     eos-select-personality.in \
     eos-save-icon-grid.in \

--- a/data/eos-desktop-substitutions.ini
+++ b/data/eos-desktop-substitutions.ini
@@ -1,0 +1,2 @@
+[Desktop Substitutions]
+eos-app-com.endlessm.endless-photos.desktop=eos-app-com.endlessm.photos.desktop


### PR DESCRIPTION
Install a GKeyFile in $(datadir)/EndlessOS containing substitutions to
apply to the desktop file names.

[endlessm/eos-shell#1673]
