### PR TITLE
Add programming app to Positivo desktop

### DIFF
--- a/data/settings/icon-grid-Positivo.json
+++ b/data/settings/icon-grid-Positivo.json
@@ -68,6 +68,7 @@
     "eos-app-com.endlessm.science.desktop",
     "eos-app-com.endlessm.endless-english.desktop",
     "eos-app-com.endlessm.khanacademy.desktop",
+    "eos-app-com.endlessm.programming.desktop",
     "eos-link-ted.desktop",
     "eos-app-com.endlessm.endless-translation.desktop",
     "eos-app-com.endlessm.typing.desktop"


### PR DESCRIPTION
In the Curiosity folder.
Still leaving off the desktop for Guatemala and Brazil images
due to issues running on Odroid.

[endlessm/eos-shell#1898]
