### PR TITLE
extract-content-strings write directly to file

### DIFF
--- a/content/Makefile.am
+++ b/content/Makefile.am
@@ -51,7 +51,7 @@ content_files = $(default_app_json) $(default_links_json)
 content_headers = $(content_files:.json=.json.h)
 %.json.h: %.json extract-content-strings$(BUILD_EXEEXT)
 	$(AM_V_GEN) $(MKDIR_P) $(@D) && \
-	./extract-content-strings$(BUILD_EXEEXT) $< >$@
+	./extract-content-strings$(BUILD_EXEEXT) $< $@
 
 all-local: $(content_headers)
 


### PR DESCRIPTION
Before wrote to stdout and was piped to a file in the Makefile,
writing directory to file avoids encoding issues where stdout
does not support UTF8
[endlessm/eos-shell#1590]
