### PR TITLE
Disable splash screen for billard-gl

### DIFF
--- a/content/Default/apps/content.json
+++ b/content/Default/apps/content.json
@@ -282,7 +282,7 @@
     "personalities":[
       "All"
     ],
-    "splash-screen-type":"Default",
+    "splash-screen-type":"None",
     "custom-splash-screen":"",
     "icon":"billard-gl-icon.png",
     "square_img":"billard-gl-thumb.jpg",

--- a/data/applications/eos-app-billard-gl.desktop
+++ b/data/applications/eos-app-billard-gl.desktop
@@ -11,4 +11,4 @@ Exec=billard-gl
 Icon=eos-app-billard-gl
 Categories=Leisure;
 X-Endless-ShowInAppStore=true
-X-Endless-SplashScreen=true
+X-Endless-SplashScreen=false


### PR DESCRIPTION
The application does not properly notify the shell when
the window has loaded, and thus the splash screen remains
until the use closes it.  The application loads fast enough
that a splash screen is not that critical, so at least for now
let's simply disable the splash screen rather than patch the app.

[endlessm/eos-shell#2260]
