### PR TITLE
Script to select app server (staging vs. production)

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -20,6 +20,10 @@ do_subst = sed \
 	-e 's|@DATA_DIR[@]|$(datadir)|g' \
 	-e 's|@SYSCONF_DIR[@]|$(sysconfdir)|g'
 
+eos-select-app-server: eos-select-app-server.in Makefile
+	$(AM_V_GEN) $(do_subst) $< > $@
+	chmod +x $@
+
 eos-select-personality: eos-select-personality.in Makefile
 	$(AM_V_GEN) $(do_subst) $< > $@
 	chmod +x $@
@@ -34,17 +38,20 @@ EXTRA_DIST = \
     $(settings_DATA) \
     $(substitutions_DATA) \
     eos-exec-localized \
+    eos-select-app-server.in \
     eos-select-personality.in \
     eos-save-icon-grid.in \
     $(NULL)
 
 bin_SCRIPTS = \
     eos-exec-localized \
+    eos-select-app-server \
     eos-select-personality \
     eos-save-icon-grid \
     $(NULL)
 
 CLEANFILES = \
+    eos-select-app-server \
     eos-select-personality \
     eos-save-icon-grid \
     $(NULL)

--- a/data/eos-select-app-server.in
+++ b/data/eos-select-app-server.in
@@ -1,0 +1,80 @@
+#!/usr/bin/gjs
+// -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
+
+// Script to select the app server
+//
+// Usage:
+//   eos-select-app-server [default | <app server>]
+//
+// For example:
+//   eos-select-app-server              -- prompts user to select app server
+//   eos-select-app-server default      -- reset to the default app server
+//   eos-select-app-server staging-dev  -- select the staging-dev server
+
+const Gio = imports.gi.Gio;
+const GLib = imports.gi.GLib;
+
+const CONFIG_PATH ='@SYSCONF_DIR@/eos-app-manager';
+
+const servers =
+    ' TRUE appupdates.endlessm.com' +
+    ' FALSE staging-dev.endlessm-sf.com'
+
+const selectServer = function() {
+    let command = 'zenity --list --title="App server" --text="Select an option and hit OK\n(Cancel to keep existing configuration)" --radiolist --hide-header --column=button --column=selection' + servers;
+
+    let response;
+    try {
+        response = GLib.spawn_command_line_sync(command);
+    } catch (e) {
+        logError(e, 'Error executing \'' + localizedExec + '\'');
+        return null;
+    }
+
+    const STATUS = 3;
+    const SELECTION = 1;
+    let status = response[STATUS];
+    let server;
+    if (status == 0) {
+        // User hit OK
+        let selection = response[SELECTION];
+        // Convert to string and trim the new line
+        server = String(selection).trim();
+    } else {
+        // User canceled
+        server = null;
+    }
+    return server;
+}
+
+const getServer = function(args) {
+    let server;
+    if (args.length == 0) {
+        server = selectServer();
+    } else if (args.length == 1) {
+        server = args[0];
+    } else {
+        throw new Error('Invalid command-line: only 0 or 1 argument allowed');
+    }
+    return server;
+}
+
+let server = getServer(ARGV);
+
+if (server) {
+    // Read in existing config file
+    let configFilePath = CONFIG_PATH + '/eam-default.cfg';
+    let configKeyFile = new GLib.KeyFile();
+
+    configKeyFile.load_from_file(configFilePath,
+                                 GLib.KeyFileFlags.KEEP_COMMENTS |
+                                 GLib.KeyFileFlags.KEEP_TRANSLATIONS);
+
+    configKeyFile.set_string("eam", "serveraddress", server);
+
+    // Write out new config file
+    let configFile = Gio.File.new_for_path(configFilePath);
+    let configFileData = configKeyFile.to_data()[0];
+    configFile.replace_contents(configFileData, null, true,
+                                Gio.FileCreateFlags.NONE, null);
+}


### PR DESCRIPTION
For now, the only options are staging-dev and appupdates.
Will need to be modified once we separate staging from dev.

[endlessm/eos-shell#2847]
