### PR TITLE
build: use AC_PROG_CC_C99 to enable C99 features

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -42,13 +42,13 @@ AC_SUBST(GLIB_COMPILE_RESOURCES)
 
 AC_CACHE_SAVE
 
+AC_PROG_CC_C99
+
 AC_ARG_ENABLE([maintainer-cflags],
               [AS_HELP_STRING([--enable-maintainer-cflags],
                               [Enable more compiler warnings])],
               [],
               [enable_maintainer_cflags=yes])
-
-MAINTAINER_CFLAGS="-std=c99"
 AS_IF([test "x$enable_maintainer_cflags" = "xyes"],
       [
         MAINTAINER_CFLAGS="$MAINTAINER_CFLAGS -Wall"


### PR DESCRIPTION
[endlessm/eos-shell#4106]
