### PR TITLE
Fix typo in english football app id

### DIFF
--- a/bundle/manifests/bundle-manifest-Global.txt
+++ b/bundle/manifests/bundle-manifest-Global.txt
@@ -19,7 +19,7 @@ com.endlessm.english
 com.endlessm.farming-en
 com.endlessm.finance
 com.endlessm.fitness-en
-com.endlessm.futbol-en
+com.endlessm.football-en
 com.endlessm.geography-en
 com.endlessm.guatemala-en
 com.endlessm.guatemalan-curriculum

--- a/bundle/manifests/bundle-manifest-all.txt
+++ b/bundle/manifests/bundle-manifest-all.txt
@@ -39,7 +39,7 @@ com.endlessm.finance
 com.endlessm.fitness-en
 com.endlessm.fitness-es
 com.endlessm.fitness-pt
-com.endlessm.futbol-en
+com.endlessm.football-en
 com.endlessm.futbol-es
 com.endlessm.futbol-pt
 com.endlessm.geography-en


### PR DESCRIPTION
Kind of unfortunate that we named the spanish one futbol-es, but
this at least follows the convention of english work plus locale.

Also agrees with the actual app content as committed into
eos-knowledge-apps
[endlessm/eos-sdk#2644]
