### PR TITLE
Map deprecated app IDs

### DIFF
--- a/content/Default/apps/content.json
+++ b/content/Default/apps/content.json
@@ -1243,6 +1243,39 @@
     "tryexec": ""
   }, 
   {
+    "application-id": "com.endlessm.futbol", 
+    "category": "Resources", 
+    "core": false, 
+    "custom-splash-screen": "com.endlessm.soccer-splash.jpg", 
+    "description": "If you have internet access, there may be a newer version of this application available to download and install. In the meantime, you may continue to use this version that is already installed on your computer.", 
+    "displayShape": "b1", 
+    "exec": "eos-soccer", 
+    "featured_img": "", 
+    "icon": "com.endlessm.soccer-icon.png", 
+    "is_featured": false, 
+    "is_offline": true, 
+    "personalities": [
+      "All"
+    ], 
+    "screenshots": {
+      "C": [
+        "com.endlessm.soccer-screenshot1.jpg", 
+        "com.endlessm.soccer-screenshot2.jpg", 
+        "com.endlessm.soccer-screenshot3.jpg"
+      ], 
+      "es": [
+        "com.endlessm.soccer-screenshot1.jpg", 
+        "com.endlessm.soccer-screenshot2.jpg", 
+        "com.endlessm.soccer-screenshot3.jpg"
+      ]
+    }, 
+    "splash-screen-type": "Custom", 
+    "square_img": "com.endlessm.soccer-thumb.jpg", 
+    "subtitle": "Deprecated version", 
+    "title": "Football", 
+    "tryexec": ""
+  }, 
+  {
     "application-id": "com.endlessm.soccer", 
     "category": "Resources", 
     "core": false, 
@@ -1339,6 +1372,39 @@
     "square_img": "com.endlessm.socialsciences-thumb.jpg", 
     "subtitle": "Subjects that explore the individual and society", 
     "title": "Social Sciences", 
+    "tryexec": ""
+  }, 
+  {
+    "application-id": "gt-textbooks", 
+    "category": "Education", 
+    "core": false, 
+    "custom-splash-screen": "com.endlessm.textbooks-splash.jpg", 
+    "description": "If you have internet access, there may be a newer version of this application available to download and install. In the meantime, you may continue to use this version that is already installed on your computer.", 
+    "displayShape": "b1", 
+    "exec": "eos-textbooks", 
+    "featured_img": "", 
+    "icon": "com.endlessm.textbooks-icon.png", 
+    "is_featured": false, 
+    "is_offline": false, 
+    "personalities": [
+      "Global"
+    ], 
+    "screenshots": {
+      "C": [
+        "com.endlessm.textbooks-screenshot1.jpg", 
+        "com.endlessm.textbooks-screenshot2.jpg", 
+        "com.endlessm.textbooks-screenshot3.jpg"
+      ], 
+      "es": [
+        "com.endlessm.textbooks-screenshot1.jpg", 
+        "com.endlessm.textbooks-screenshot2.jpg", 
+        "com.endlessm.textbooks-screenshot3.jpg"
+      ]
+    }, 
+    "splash-screen-type": "Custom", 
+    "square_img": "com.endlessm.textbooks-thumb.jpg", 
+    "subtitle": "Deprecated version", 
+    "title": "Textbooks", 
     "tryexec": ""
   }, 
   {
@@ -1567,6 +1633,41 @@
     "square_img": "com.endlessm.weather-thumb.jpg", 
     "subtitle": "Get daily local forecasts from trusted sources", 
     "title": "Weather", 
+    "tryexec": ""
+  }, 
+  {
+    "application-id": "gt-literature", 
+    "category": "Education", 
+    "core": false, 
+    "custom-splash-screen": "", 
+    "description": "If you have internet access, there may be a newer version of this application available to download and install. In the meantime, you may continue to use this version that is already installed on your computer.", 
+    "displayShape": "b1", 
+    "exec": "eos-world-literature", 
+    "featured_img": "", 
+    "icon": "com.endlessm.world-literature-icon.png", 
+    "is_featured": false, 
+    "is_offline": false, 
+    "personalities": [
+      "Global", 
+      "Guatemala", 
+      "Mexico"
+    ], 
+    "screenshots": {
+      "C": [
+        "com.endlessm.world-literature-screenshot1.jpg", 
+        "com.endlessm.world-literature-screenshot2.jpg", 
+        "com.endlessm.world-literature-screenshot3.jpg"
+      ], 
+      "es": [
+        "com.endlessm.world-literature-screenshot1.jpg", 
+        "com.endlessm.world-literature-screenshot2.jpg", 
+        "com.endlessm.world-literature-screenshot3.jpg"
+      ]
+    }, 
+    "splash-screen-type": "None", 
+    "square_img": "com.endlessm.world-literature-thumb.jpg", 
+    "subtitle": "Deprecated version", 
+    "title": "World Literature", 
     "tryexec": ""
   }, 
   {

--- a/po/ar.po
+++ b/po/ar.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: eos-shell-content\n"
 "Report-Msgid-Bugs-To: https://www.transifex.com/projects/p/eos-shell-content/\n"
-"POT-Creation-Date: 2015-02-24 12:56-0800\n"
-"PO-Revision-Date: 2015-02-24 21:02+0000\n"
+"POT-Creation-Date: 2015-02-24 16:21-0800\n"
+"PO-Revision-Date: 2015-02-25 00:22+0000\n"
 "Last-Translator: Roddy Shuler <roddy@endlessm.com>\n"
 "Language-Team: Arabic (http://www.transifex.com/projects/p/eos-shell-content/language/ar/)\n"
 "MIME-Version: 1.0\n"
@@ -546,7 +546,7 @@ msgid "Curriculum"
 msgstr "المنهاج"
 
 #: content/Default/apps/content.json.h:83
-#: content/Default/apps/content.json.h:229
+#: content/Default/apps/content.json.h:241
 msgctxt "subtitle"
 msgid "From the Guatemalan Ministry of Education"
 msgstr "من وزارة التربية والتعليم في غواتيمالا"
@@ -844,16 +844,34 @@ msgid ""
 msgstr "أفضل وسيلة لكسب انطباعا كبيرا من أصحاب العمل المحتملين هو أن يكون لديك سيرة ذاتية مميزة، وتم تصميم هذا التطبيق  لمساعدتك على القيام بذلك تماما. فبوجود مثل هذه القوالب الجذابة في متناول اليد، يكون لديك الكثير من النماذج للإستخدام خلال كتابتك للسيرة الذاتية الخاصة بك بشكل ممتاز. تعلم بالضبط ماهية السيرة الذاتية، وما يجب أن تحتوي، وأحصل على نصائح عن كل جزء بها. كما يمكنك الحصول على توجيهات بشأن كيفية الاستعداد لمقابلات العمل. هذا التطبيق يمكن أن يساعدك على الحصول على الوظيفة التي تختارها."
 
 #: content/Default/apps/content.json.h:124
+#: content/Default/apps/content.json.h:127
 msgctxt "title"
 msgid "Football"
 msgstr "كُرَةُ القَدَم"
 
 #: content/Default/apps/content.json.h:125
+#: content/Default/apps/content.json.h:137
+#: content/Default/apps/content.json.h:161
+msgctxt "subtitle"
+msgid "Deprecated version"
+msgstr ""
+
+#: content/Default/apps/content.json.h:126
+#: content/Default/apps/content.json.h:138
+#: content/Default/apps/content.json.h:162
+msgctxt "description"
+msgid ""
+"If you have internet access, there may be a newer version of this "
+"application available to download and install. In the meantime, you may "
+"continue to use this version that is already installed on your computer."
+msgstr ""
+
+#: content/Default/apps/content.json.h:128
 msgctxt "subtitle"
 msgid "Learn about your favorite team and players"
 msgstr "تعرف على فريقك ولاعبيك المفضلين"
 
-#: content/Default/apps/content.json.h:126
+#: content/Default/apps/content.json.h:129
 msgctxt "description"
 msgid ""
 "Football is a major sport with fans all around the world. Are you one of "
@@ -863,17 +881,17 @@ msgid ""
 " with thousands of articles about your favorite sport!"
 msgstr "كرة القدم هي رياضة كبرى بمشجعين في جميع أنحاء العالم. هل أنت واحدٌ منهم؟ إذاً فهذا تطبيقك. يضم كل ما تحتاج معرفته حول الفرق واللاعبين والمسابقات الرئيسية في العالم. تعرف على حقائق عن اللعبة وتاريخها، واكتشف المزيد عن القواعد، وتواكب مع آلاف المقالات عن الرياضة المفضلة لديك!"
 
-#: content/Default/apps/content.json.h:127
+#: content/Default/apps/content.json.h:130
 msgctxt "title"
 msgid "Social Enterprises"
 msgstr "مؤسسات اجتماعية"
 
-#: content/Default/apps/content.json.h:128
+#: content/Default/apps/content.json.h:131
 msgctxt "subtitle"
 msgid "All about non-profit organizations"
 msgstr "كل ما يخص المؤسسات غير الهادفة للربح"
 
-#: content/Default/apps/content.json.h:129
+#: content/Default/apps/content.json.h:132
 msgctxt "description"
 msgid ""
 "Have you thought of starting your own non-profit organization, or of joining"
@@ -883,17 +901,17 @@ msgid ""
 "your impact in the world even larger!"
 msgstr "هل فكرت من قبل في بدء مؤسسة غير هادفة للربح خاصة بك، أو في الانضمام لإحدى هذه المؤسسات؟ تتميز المؤسسات غير الهادفة للربح بفوائد ضريبية خاصة، وتُنشأ غالباً لتحقيق تأثير اجتماعي حقيقي. اقرأ هذه الإرشادات لفهم المزيد عن تنظيم المؤسسات غير الربحية وكيفية تشغيلها، بما يجعل لديك القدرة على البدء في جعل تأثيرك في العالم أكثر قوة!"
 
-#: content/Default/apps/content.json.h:130
+#: content/Default/apps/content.json.h:133
 msgctxt "title"
 msgid "Social Sciences"
 msgstr "العلوم الاجتماعية"
 
-#: content/Default/apps/content.json.h:131
+#: content/Default/apps/content.json.h:134
 msgctxt "subtitle"
 msgid "Subjects that explore the individual and society"
 msgstr "الموضوعات التي تستكشف الفرد والمجتمع"
 
-#: content/Default/apps/content.json.h:132
+#: content/Default/apps/content.json.h:135
 msgctxt "description"
 msgid ""
 "Human beings and the relationships and societies they form are complicated. "
@@ -905,17 +923,39 @@ msgid ""
 "understanding of human behavior."
 msgstr "البشر والعلاقات والمجتمعات التي يشكلونها هي ذات طبيعة معقدة. سوف يعرض لكم هذا التطبيق الكثير من التخصصات التي تبحث في تاريخ البشرية والثقافات والمعاملات. ستتعرف على أساسيات علم النفس وعلم الاجتماع والأنثروبولوجيا والعلوم السياسية، وغيرها. وفهم أساسيات مثل هذه العلوم يساعدك على سبر الطرق التي بها نتفاعل ونكون الصلات مع بعضنا البعض. سوف تخرج بفهمٍ غنيٍ للسلوك البشري."
 
-#: content/Default/apps/content.json.h:133
+#: content/Default/apps/content.json.h:136
+#: content/Default/apps/content.json.h:139
+msgctxt "title"
+msgid "Textbooks"
+msgstr "الكتب المدرسية"
+
+#: content/Default/apps/content.json.h:140
+msgctxt "subtitle"
+msgid "Math and science textbooks"
+msgstr ""
+
+#: content/Default/apps/content.json.h:141
+msgctxt "description"
+msgid ""
+"Find information to help you with your homework, or learn about a subject "
+"you've always wanted to know more about! You can scroll through photos, "
+"tables, and graphs to learn more about each. Not only are these textbooks "
+"very thorough and informative, but they are also easy to read and helpful. "
+"Whether you’re a student, parent, teacher, or just someone eager to learn, "
+"you'll be sure to find something interesting and useful here!"
+msgstr ""
+
+#: content/Default/apps/content.json.h:142
 msgctxt "title"
 msgid "Translate"
 msgstr "ترجم"
 
-#: content/Default/apps/content.json.h:134
+#: content/Default/apps/content.json.h:143
 msgctxt "subtitle"
 msgid "Translate text between many languages instantly"
 msgstr "ترجم النصوص بين عدد كبير من اللغات بشكل فوري"
 
-#: content/Default/apps/content.json.h:135
+#: content/Default/apps/content.json.h:144
 msgctxt "description"
 msgid ""
 "Download this app to help you understand and be understood in virtually any "
@@ -926,17 +966,17 @@ msgid ""
 " – with the world’s languages at your fingertips.  **Requires internet"
 msgstr "قم بتحميل هذا التطبيق لمساعدتك على أن تَفهم وتُفهم في أي لغة تقريباً. يتطلب هذا التطبيق اتصالاً بالإنترنت، وهو سهل الاستعمال جداً. ¡يمكنك إجراء ترجمات بمجرد نقرة زر! ساعد نفسك على تعلم لغة جديدة من خلال تعلم ترجمات ما تكتب، أو استخدمه لمساعدتك على تكوين صلاتٍ دوليةٍ جديدة - وحتى أصدقاء جدد - مع لغات العالم في متناول يدك. ** يتطلب اتصالاً بالإنترنت"
 
-#: content/Default/apps/content.json.h:136
+#: content/Default/apps/content.json.h:145
 msgctxt "title"
 msgid "Travel"
 msgstr "السفر"
 
-#: content/Default/apps/content.json.h:137
+#: content/Default/apps/content.json.h:146
 msgctxt "subtitle"
 msgid "Travel around the world from your living room"
 msgstr "سافر حول العالم من غرفة معيشتك"
 
-#: content/Default/apps/content.json.h:138
+#: content/Default/apps/content.json.h:147
 msgctxt "description"
 msgid ""
 "The world is an amazing and beautiful place! Start exploring it with this "
@@ -947,17 +987,17 @@ msgid ""
 "sites in the world!"
 msgstr "إن العالم مكان رائع وجميل! إبدأ استكشافه مع هذا التطبيق الرائع الذي يتيح لك مشاهدة الصور ومعرفة الحقائق عن المناطق من مختلف أنحاء العالم. كما يوفر معلومات عن المواقع الرئيسية في أماكن مثل الأمريكتين وأوروبا وآسيا وغيرها. تعرف على العجائب الطبيعة، واستكشف ثقافات جديدة، واكتشف بعض المواقع الدينية و المقدسة الأكثر أهمية في العالم!"
 
-#: content/Default/apps/content.json.h:139
+#: content/Default/apps/content.json.h:148
 msgctxt "title"
 msgid "Typing"
 msgstr "الطباعة"
 
-#: content/Default/apps/content.json.h:140
+#: content/Default/apps/content.json.h:149
 msgctxt "subtitle"
 msgid "Learn to type with games and songs"
 msgstr "تعلم الطباعة عن طريق الألعاب والأغاني"
 
-#: content/Default/apps/content.json.h:141
+#: content/Default/apps/content.json.h:150
 msgctxt "description"
 msgid ""
 "How fast can you type? Whether you're already fast or just learning how to "
@@ -968,17 +1008,17 @@ msgid ""
 "now it can be a whole lot of fun too!"
 msgstr "ما مدى السرعة التي يمكنك الكتابة بها؟ سواءً كنت سريعاً بالفعل أو تتعلم فقط كيف تستخدم لوحة المفاتيح، يمكن لهذا التطبيق مساعدتك على تحسين قدرات كتابتك! تعلم كيفية الكتابة بنفسك، أو نافس أصدقائك في سرعات الكتابة، كل هذا في الوقت الذي تتعلم فيه كتابة كلمات أغانيك المفضلة. نعلم جميعاً أن الكتابة هي مهارة قيمة في أي بيئةٍ تعليميةٍ أو مهنيةٍ تقريباً، ولكن يمكن الآن أن يكون بها ذلك الكم الكبير من المرح أيضاً!"
 
-#: content/Default/apps/content.json.h:142
+#: content/Default/apps/content.json.h:151
 msgctxt "title"
 msgid "Virtual School"
 msgstr "المدرسة الافتراضية"
 
-#: content/Default/apps/content.json.h:143
+#: content/Default/apps/content.json.h:152
 msgctxt "subtitle"
 msgid "Free educational videos on almost any subject"
 msgstr "أشرطة فيديو تعليمية مجانية لأي موضوعٍ تقريباً"
 
-#: content/Default/apps/content.json.h:144
+#: content/Default/apps/content.json.h:153
 msgctxt "description"
 msgid ""
 "Learning is easy and fun with video courses on subjects like math, biology, "
@@ -990,17 +1030,17 @@ msgid ""
 " this app and these videos can help you succeed in school and in life!"
 msgstr "التعلم سهل وممتع مع دروس الفيديو في مواد مثل الرياضيات والأحياء والكيمياء والفيزياء وغيرها الكثير! يستخدم الطلاب في جميع أنحاء العالم أشرطة الفيديو هذه بنجاح للتغلب على المواد الصعبة بطريقةٍ ممتعةٍ وجذابة. سواءً كنت تحتاج إلى مساعدة إضافية في واجباتك المدرسية أو تخطط لتعلم شيءٍ جديدٍ بمفردك فستجد ما تبحث عنه هنا. تعلم الموضوعات الصعبة بطريقة مفهومة لك وشاهد كيف يمكن لهذا التطبيق وأشرطة الفيديو هذه أن تساعدك على النجاح في المدرسة وفي الحياة!"
 
-#: content/Default/apps/content.json.h:145
+#: content/Default/apps/content.json.h:154
 msgctxt "title"
 msgid "Sanitation"
 msgstr "الصرف الصحي"
 
-#: content/Default/apps/content.json.h:146
+#: content/Default/apps/content.json.h:155
 msgctxt "subtitle"
 msgid "All about clean water and sanitation"
 msgstr "يتعلق الأمر برمته بالمياه النظيفة والصرف الصحي"
 
-#: content/Default/apps/content.json.h:147
+#: content/Default/apps/content.json.h:156
 msgctxt "description"
 msgid ""
 "Drinking clean water is essential for survival. There can often be terrible "
@@ -1009,17 +1049,17 @@ msgid ""
 "that you create a sanitary environment around you where you can thrive. "
 msgstr "شرب مياه نظيفة أمرٌ ضروري للبقاء على الحياة. تنتشر غالباً الأمراض المريعة مع استخدام مياه غير صالحة، أو عدم وجود صرف صحي جيد في المنطقة الذي يعيش فيها الإنسان. تعلم كيفية التأكد من شرب مياه صالحة وكيفية التأكد من إنشاء بيئةٍ صحيةٍ من حولك لتتمتع بصحةٍ جيدة."
 
-#: content/Default/apps/content.json.h:148
+#: content/Default/apps/content.json.h:157
 msgctxt "title"
 msgid "Weather"
 msgstr "الطقس"
 
-#: content/Default/apps/content.json.h:149
+#: content/Default/apps/content.json.h:158
 msgctxt "subtitle"
 msgid "Get daily local forecasts from trusted sources"
 msgstr "أحصل على النشرة الجوية المحلية اليومية من مصادر موثوقة"
 
-#: content/Default/apps/content.json.h:150
+#: content/Default/apps/content.json.h:159
 msgctxt "description"
 msgid ""
 "“How’s the weather out there?” Answer this question easily, every day, with "
@@ -1029,17 +1069,18 @@ msgid ""
 "about the weather to take advantage of your day!  **Requires internet"
 msgstr "\"كيف حال الطقس هناك؟\" أجب على هذا السؤال بسهولة، كل يوم، بنقرة زر واحدة. يسمح لك تطبيق الطقس البسيط  هذا أن ترى ما يحدث خارج منزلك تماماً. هل سيكون بارداً؟ هل يجب عليك التخطيط للمطر؟ هل هذا يوم مثالي لقضائه في الهواء الطلق؟ تعرف على كل ما تحتاج لمعرفته عن الطقس للاستفادة من يومك! ** يتطلب الاتصال بالإنترنت"
 
-#: content/Default/apps/content.json.h:151
+#: content/Default/apps/content.json.h:160
+#: content/Default/apps/content.json.h:163
 msgctxt "title"
 msgid "World Literature"
 msgstr "الأدب العالمي"
 
-#: content/Default/apps/content.json.h:152
+#: content/Default/apps/content.json.h:164
 msgctxt "subtitle"
 msgid "Read all of the world's great literature"
 msgstr "اقرأ كل الأعمال الأدبية العالمية العظيمة"
 
-#: content/Default/apps/content.json.h:153
+#: content/Default/apps/content.json.h:165
 msgctxt "description"
 msgid ""
 "Find some of your favorite books in this app! To begin browsing, open the "
@@ -1051,17 +1092,17 @@ msgid ""
 "entertained for hours expanding your literary knowledge."
 msgstr "ابحث عن بعض كتبك المفضلة بهذا التطبيق! للبدء في التصفح، افتح المجلد، انقر فوق ملف \"الفهرس\"، وحدد الفئة التي تهمك أكثر من غيرها. ستجد كثيرا من الكتب المشهورة، بما في ذلك العجائب الحديثة التي من المؤكد ستجذب اهتمامك. وتحتوي هذه المكتبة الافتراضية على مجموعة رائعة من الروايات والقصائد والسير الذاتية والقصص والنصوص الأخرى. و سواء وتمكنت من العثور على كتابك المفضل أو اكتشاف كتب جديدة، فسوف تستمع لساعات و انت توسع مدارك معرفتك الأدبية."
 
-#: content/Default/apps/content.json.h:154
+#: content/Default/apps/content.json.h:166
 msgctxt "title"
 msgid "YouVideos"
 msgstr "يوفيديوز"
 
-#: content/Default/apps/content.json.h:155
+#: content/Default/apps/content.json.h:167
 msgctxt "subtitle"
 msgid "Discover and share great videos online"
 msgstr "اكتشف وشارك ملفات الفيديو الرائعة على الانترنت"
 
-#: content/Default/apps/content.json.h:156
+#: content/Default/apps/content.json.h:168
 msgctxt "description"
 msgid ""
 "This app makes finding videos on the popular video site, YouTube, and "
@@ -1072,27 +1113,27 @@ msgid ""
 "family, and the world!  ** Requires internet"
 msgstr "يجعل هذا التطبيق العثور على أشرطة الفيديو على موقع الفيديو الشهير، يوتيوب، وتبادل تلك التي تصنعها أسهل بطريقةٍ جديدةٍ جميلة! شاهد أشرطة الفيديو للفنانين الموسيقيين المفضلين لديك، والدروس التي تعلمك كيف تفعل أي شيء تقريباً، وأشرطة الفيديو المضحكة أو اللطيفة، وأكثر من ذلك بكثير. ستحظى بساعات من المرح، وسوف تكون قادراً على مشاركة جميع الأشياء الرائعة التي تجدها أو تصنعها مع الأصدقاء والأسرة والعالم! ** يتطلب الاتصال بالإنترنت"
 
-#: content/Default/apps/content.json.h:157
+#: content/Default/apps/content.json.h:169
 msgctxt "title"
 msgid "Dropbox"
 msgstr "Dropbox"
 
-#: content/Default/apps/content.json.h:158
+#: content/Default/apps/content.json.h:170
 msgctxt "subtitle"
 msgid "Access your files from any computer"
 msgstr "الوصول إلى ملفاتك من أي كمبيوتر"
 
-#: content/Default/apps/content.json.h:162
+#: content/Default/apps/content.json.h:174
 msgctxt "title"
 msgid "Chat"
 msgstr "دردشة"
 
-#: content/Default/apps/content.json.h:163
+#: content/Default/apps/content.json.h:175
 msgctxt "subtitle"
 msgid "Chat with all of your friends in one place"
 msgstr "دردش مع جميع أصدقائك في مكان واحد"
 
-#: content/Default/apps/content.json.h:164
+#: content/Default/apps/content.json.h:176
 msgctxt "description"
 msgid ""
 "Do you love to chat with friends? And, do you use many different programs to"
@@ -1105,17 +1146,17 @@ msgid ""
 "and family easier than ever before!  **Requires internet"
 msgstr "هل تحب الدردشة مع الأصدقاء؟ و هل تستخدم العديد من البرامج المختلفة للدردشة مع كل منهم؟ الآن يمكنك الجمع بين كل تلك البرامج المختلفة في برنامجٍ واحدٍ بحيث لا يلزمك الاستمرار في التبديل بينهم جميعاً! دردش مع الأصدقاء من الفيسبوك وجابر وام اس ان وايه آي ام وجادو جادو، وأكثر من ذلك - كل ذلك في مكان واحد. يدعم هذا التطبيق الرسائل ودردشات الصوت والفيديو، لذلك ستكون قادراً على القيام بكل ما تريد. وكل ما عليك أن تفعله هو أن تضبط هذا التطبيق مع الحسابات الأخرى الخاصة بك، وسوف تكون مستعداً للتواصل مع أصدقائك وعائلتك بشكل أسهل من أي وقت مضى! ** يتطلب الاتصال بالإنترنت"
 
-#: content/Default/apps/content.json.h:165
+#: content/Default/apps/content.json.h:177
 msgctxt "title"
 msgid "Documents"
 msgstr "وثائق"
 
-#: content/Default/apps/content.json.h:166
+#: content/Default/apps/content.json.h:178
 msgctxt "subtitle"
 msgid "Access all of your documents and files"
 msgstr "تَوصل إلى جميع الوثائق والملفات الخاصة بك"
 
-#: content/Default/apps/content.json.h:167
+#: content/Default/apps/content.json.h:179
 msgctxt "description"
 msgid ""
 "Get organized with this app, which helps you find all of your documents and "
@@ -1126,17 +1167,17 @@ msgid ""
 "special photo again."
 msgstr "قم بتنظيم حياتك مع هذا التطبيق الذي يساعدك على إيجاد جميع الوثائق والملفات الخاصة بك، لا يهم منذ متى قمت بحفظها. نظم الأشياء على نحوٍ تفهمه، مضيفاً ومعيداً تسمية المجلدات بطريقة من شأنها أن تساعدك على البقاء على رأس الصور وأشرطة الفيديو والوثائق الخاصة بك. مع هذا التطبيق، يمكنك تخزين كل شيءٍ في مكانٍ واحد ولن تفقد أبداً ذلك الملف المهم أو تلك الصورة الخاصة مرةً أخرى."
 
-#: content/Default/apps/content.json.h:168
+#: content/Default/apps/content.json.h:180
 msgctxt "title"
 msgid "E-mail"
 msgstr "البريد الإلكتروني"
 
-#: content/Default/apps/content.json.h:169
+#: content/Default/apps/content.json.h:181
 msgctxt "subtitle"
 msgid "Your e-mail, address book and calendar in one place"
 msgstr "البريد الإلكتروني ودفتر العناوين والتقويم الخاص بك في مكانٍ واحد"
 
-#: content/Default/apps/content.json.h:170
+#: content/Default/apps/content.json.h:182
 msgctxt "description"
 msgid ""
 "Staying in touch is an important part of modern life, and email has become "
@@ -1147,17 +1188,17 @@ msgid ""
 "  **Requires internet"
 msgstr "البقاء على اتصالٍ هو جزءٌ مهمٌ من الحياة العصرية، وأصبح البريد الإلكتروني أحد أفضل الطرق للقيام بذلك. قد تتلقى رسائل بريد إلكتروني من قبل الأهل والأصدقاء في أماكن بعيدة أو مجاورة، توصل إلى الرسائل التي تحتوي على طرائف يومية أومفردات لغوية أو أخبار، وحتى تعامل مع المسائل الهامة - كل هذا عبر البريد الإلكتروني. عندما تحتاج إلى فحص بريدك الإلكتروني بسرعة وببساطة، فهذا التطبيق موجود هناك من أجلك. ** يتطلب الاتصال بالإنترنت"
 
-#: content/Default/apps/content.json.h:171
+#: content/Default/apps/content.json.h:183
 msgctxt "title"
 msgid "Tux Racer"
 msgstr "تكس المتسابق"
 
-#: content/Default/apps/content.json.h:172
+#: content/Default/apps/content.json.h:184
 msgctxt "subtitle"
 msgid "Race down icy mountains"
 msgstr "تَسابق أسفل الجبال الجليدية"
 
-#: content/Default/apps/content.json.h:173
+#: content/Default/apps/content.json.h:185
 msgctxt "description"
 msgid ""
 "Make it down a snow and ice-covered mountain as quickly as possible in this "
@@ -1166,17 +1207,17 @@ msgid ""
 "get your heart racing, this game is a must play for any adrenaline addict."
 msgstr "قم به أسفل الثلوج والجبال المغطاة بالجليد في أسرع وقت ممكن في لعبة السباق الرهيبة هذه! ولكن ذلك لن يكون سهلاً! سوف تحتاج إلى تجنب الأشجار والصخور، وحتى عظام الأسماك التي تعترض طريقك وتبطئك. على يقين من دخول قلبك السباق، هذه اللعبة لا بد أن يلعبها أي مدمن للأدرينالين."
 
-#: content/Default/apps/content.json.h:174
+#: content/Default/apps/content.json.h:186
 msgctxt "title"
 msgid "Four in a Row"
 msgstr "أربعة على التوالي "
 
-#: content/Default/apps/content.json.h:175
+#: content/Default/apps/content.json.h:187
 msgctxt "subtitle"
 msgid "A simple and addictive game for kids and adults"
 msgstr "لعبة بسيطة ومحببة للأطفال والكبار"
 
-#: content/Default/apps/content.json.h:176
+#: content/Default/apps/content.json.h:188
 msgctxt "description"
 msgid ""
 "This classic game is great for both children and adults alike! The goal is "
@@ -1188,17 +1229,17 @@ msgid ""
 "fun game!"
 msgstr "تعد هذه اللعبة الكلاسيكية ممتازة للأطفال و البالغين على السواء! و تعد فكرة اللعبة بسيطة، حيث يحتاج اللاعب إذا أراد الفوز إلى إنشاء خطاً مستقيمأ من دوائره الأربعة قبل أن يشكلها اللاعب الآخر. بإمكانك تشكيل الخطوط بشكل أفقي، أو عمودي، أو قطري، مثل لعبة تيك-تاك-تو، و لكن إذا أردت أن تفوز يجب أن تكون حذراً و الانتباه لما يقوم به اللاعب الآخر! و يمكنك أن تلعب ضد الكمبيوتر أو ضد صديق، وقضاء ساعات لعب على هذه اللعبة الممتعة و التي تسبب التعلق الشديد بها !"
 
-#: content/Default/apps/content.json.h:177
+#: content/Default/apps/content.json.h:189
 msgctxt "title"
 msgid "FreeCiv"
 msgstr "فرييسيف"
 
-#: content/Default/apps/content.json.h:178
+#: content/Default/apps/content.json.h:190
 msgctxt "subtitle"
 msgid "Guide your own civilization to greatness"
 msgstr "وجِه الحضارة الخاصة بك نحو العظمة"
 
-#: content/Default/apps/content.json.h:179
+#: content/Default/apps/content.json.h:191
 msgctxt "description"
 msgid ""
 "Create your own world with this action-packed game that lets you travel "
@@ -1210,17 +1251,17 @@ msgid ""
 "conquering the moon and beyond!"
 msgstr "صمِّم العالم الخاص بك مع هذه اللعبة المليئة بالعمل، والتي تتيح لك السفر عبر الزمن وبدء حضارة خاصة بك. عليك أن تبدأ منذ بداية الزمان في ظل عالم عصور ما قبل التاريخ، حيث ستحتاج لإنشاء قبيلة خاصة بك. بعد ذلك، عليك الانتقال إلى العصور الوسطى، والبقاء على قيد الحياة و تجاوز الطاعون وابتكار العجلة. وسوف تستمر على مر العصور حتى تصل إلى العصور الحديثة وتحتاج حينها إلى تحقيق التوازن بين السياسة العالمية و الحفاظ على جدول أعمالك لقيادة شعبك لغزو القمر وما بعده!"
 
-#: content/Default/apps/content.json.h:180
+#: content/Default/apps/content.json.h:192
 msgctxt "title"
 msgid "FreeCol"
 msgstr "فرييكووا"
 
-#: content/Default/apps/content.json.h:181
+#: content/Default/apps/content.json.h:193
 msgctxt "subtitle"
 msgid "Create your own country and conquer the world"
 msgstr "اصنع دولتك واغز العالم"
 
-#: content/Default/apps/content.json.h:182
+#: content/Default/apps/content.json.h:194
 msgctxt "description"
 msgid ""
 "Have you ever wanted to start your own country? Well, now you can. Go back "
@@ -1230,17 +1271,17 @@ msgid ""
 "prosperity? You decide."
 msgstr "هل سبق لك أن رغبت في إنشاء دولتك؟ حسناً، يمكنك ذلك الآن. عد بالزمن إلى عالمٍ بديل حيث لم يتم تحويل أمريكا لمستعمرة حتى الآن وأنشيء البلدات والمدن والولايات التي ستدعم الخطة النهائية الخاصة بك. هل ستحاول الهيمنة على العالم، أم ستعزز السلم والرخاء الدوليين؟ عليك أن تقرر."
 
-#: content/Default/apps/content.json.h:183
+#: content/Default/apps/content.json.h:195
 msgctxt "title"
 msgid "FrostTorrent"
 msgstr "بتتورينت"
 
-#: content/Default/apps/content.json.h:184
+#: content/Default/apps/content.json.h:196
 msgctxt "subtitle"
 msgid "Download nearly anything or share your own files"
 msgstr "قم بتحميل أي شيءٍ تقريباً أو مشاركة الملفات الخاصة بك"
 
-#: content/Default/apps/content.json.h:185
+#: content/Default/apps/content.json.h:197
 msgctxt "description"
 msgid ""
 "Access, download and share almost any file you'd like to with this useful "
@@ -1252,17 +1293,17 @@ msgid ""
 "**Requires Internet"
 msgstr "قم بالدخول والتحميل والمشاركة تقريبا بأي ملف تحب باستخدام هذا التطبيق الذي يتم بين النظراء عبر الانترنت والذي يمكنك من التشارك بالملفات مع أي مستخدمين آخرين\nمتصلين بشبكة بت تورنت. وسيكون باستطاعتك الوصول الى الملفات التي يتشارك بها ملايين المستخدمين على الانترنت والتي تتراوح بين الموسيقى والفيديوهات والألعاب الى تحميلات أكثر تعقيدا مثل البرمجيات. وحتى أن هذا التطبيق يحتوي على مشغل فيديو مدمج بحيث تستطيع المشاهدة  بسهولة لجميع الوسائط التي تقوم بتحميلها. ** الاتصال بالانترنت ضروري"
 
-#: content/Default/apps/content.json.h:186
+#: content/Default/apps/content.json.h:198
 msgctxt "title"
 msgid "Frozen Bubbles"
 msgstr "الفقاعات المتجمدة"
 
-#: content/Default/apps/content.json.h:187
+#: content/Default/apps/content.json.h:199
 msgctxt "subtitle"
 msgid "Pop bubbles before they all come crashing down"
 msgstr "فجر الفقاعات قبل أن تسقط جميعها وتنفجر"
 
-#: content/Default/apps/content.json.h:188
+#: content/Default/apps/content.json.h:200
 msgctxt "description"
 msgid ""
 "Play by yourself or challenge your friends to an exciting game of frozen "
@@ -1271,17 +1312,17 @@ msgid ""
 " have a good strategy and develop a quick trigger finger in order to win!"
 msgstr "العب وحدك أو تحدى أصدقائك في لعبة مثيرة من الفقاعات المجمدة! قم بمطابقة الفقاعات الملونة لتفجيرهم واخراجهم من الطريق قبل أن تتكدس عاليا والاصطدام بك. تحتاج إلى استراتيجية جيدة وتطوير إصبع سريع الكبس على الزناد من أجل الفوز!"
 
-#: content/Default/apps/content.json.h:189
+#: content/Default/apps/content.json.h:201
 msgctxt "title"
 msgid "EduGames"
 msgstr "إيديو غيمز"
 
-#: content/Default/apps/content.json.h:190
+#: content/Default/apps/content.json.h:202
 msgctxt "subtitle"
 msgid "Puzzles, memory games, and more for kids"
 msgstr "الألغاز وألعاب الذاكرة، وغيرها للأطفال"
 
-#: content/Default/apps/content.json.h:191
+#: content/Default/apps/content.json.h:203
 msgctxt "description"
 msgid ""
 "This app makes learning fun for young children with more than 100 games and "
@@ -1291,17 +1332,17 @@ msgid ""
 "him or her throughout life."
 msgstr "يجعل هذا التطبيق التعلم متعة للأطفال الصغار مع أكثر من 100 لعبة ونشاط! وتشمل الموضوعات التعليمية القراءة والجغرافيا والرياضيات، ويضم التطبيق أيضاً ألعاباً مثل الشطرنج وهي عظيمة لأدمغة الصغار. سوف يقضي طفلك وقتاً رائعاً في تطوير مهارات قيمة من شأنها أن تساعده أو تساعدها مدى الحياة."
 
-#: content/Default/apps/content.json.h:192
+#: content/Default/apps/content.json.h:204
 msgctxt "title"
 msgid "EduGames Admin"
 msgstr "مدير ايديوغيمز"
 
-#: content/Default/apps/content.json.h:193
+#: content/Default/apps/content.json.h:205
 msgctxt "subtitle"
 msgid "For teachers to help their students learn"
 msgstr "للمعلمين لمساعدة طلبتهم على التعلم "
 
-#: content/Default/apps/content.json.h:194
+#: content/Default/apps/content.json.h:206
 msgctxt "description"
 msgid ""
 "Use this app to configure the EduGames app and create the exact learning "
@@ -1312,17 +1353,17 @@ msgid ""
 " fun that they'll want to spend hours doing just what you want them to!"
 msgstr "استخدم هذا التطبيق لتهيئة تطبيق \"ايديوغيمز\" لتصميم تجربة التعلم التي تريدها لطلابك! يمكنك تغيير قائمة الأنشطة، أو تغيير ضوابط التطبيق بحيث تبقي طلبتك في تركيز على الألعاب التي تريد لهم استخدامها. من أجل البدء، قم بتحميل هذا التطبيق وتطبيق \"إيديوغيمز\" من قسم 'ألعاب' من متجر التطبيقات.  ستوفر لطلبتك الكثير من المرح بحيث سيرغبون في قضاء ساعات يقومون فقط بما تريد!"
 
-#: content/Default/apps/content.json.h:195
+#: content/Default/apps/content.json.h:207
 msgctxt "title"
 msgid "Gedit"
 msgstr "جيديت"
 
-#: content/Default/apps/content.json.h:196
+#: content/Default/apps/content.json.h:208
 msgctxt "subtitle"
 msgid "A simple text editor for all of your text editing needs"
 msgstr "محرر نصوص بسيط لجميع احتياجاتك التحريرية"
 
-#: content/Default/apps/content.json.h:197
+#: content/Default/apps/content.json.h:209
 msgctxt "description"
 msgid ""
 "Use this simple app to create and edit files that require plain text inputs."
@@ -1331,17 +1372,17 @@ msgid ""
 "should be perfect for all of your text editing needs."
 msgstr "استخدم هذا التطبيق البسيط لإنشاء وتحرير الملفات التي تتطلب ادخالات نص عادي. إذا كنت مبرمجاً أو مبرمجاً طامحاً، فسوف تحتاج هذا التطبيق. مع كفاءة وظيفية قوية وواجهة سهلة الاستخدام، ينبغي أن يكون هذا المحرر النصي مثالياً لجميع احتياجات تحرير النص الخاص بك."
 
-#: content/Default/apps/content.json.h:198
+#: content/Default/apps/content.json.h:210
 msgctxt "title"
 msgid "GIMP"
 msgstr "برنامج معالجة الصور"
 
-#: content/Default/apps/content.json.h:199
+#: content/Default/apps/content.json.h:211
 msgctxt "subtitle"
 msgid "Advanced image editing tool similar to Photoshop"
 msgstr "أداة تحرير صور متطورة تشبه الفوتوشوب"
 
-#: content/Default/apps/content.json.h:200
+#: content/Default/apps/content.json.h:212
 msgctxt "description"
 msgid ""
 "Edit your photos to create even more beautiful works of art with this "
@@ -1353,17 +1394,17 @@ msgid ""
 "images once you get the hang of this helpful editing app!"
 msgstr "حرر الصور الخاصة بك لإنشاء أعمالٍ فنية أكثر جمالاً حتى مع محرر الصور المتقدم هذا. هذا التطبيق متوافق مع أدوبي فوتوشوب، وهو محرر صور شعبي لأجهزة كمبيوتر ويندوز. إذا كنت مستخدماً جديداً، فيمكنه أن يكون بمثابة برنامج رسم أساسي. يمكن للمستخدمين المتقدمين فعل أشياء مثل تحويل صيغ الملفات وتطبيق مجموعة متنوعة من أدوات التنقيح والترشيح اللازمة لإنشاء أعمال فنية. هناك الكثير من الإمكانات لكيفية إنشاء صور رائعة بمجرد تعلمك لتطبيق التحرير المفيد هذا!"
 
-#: content/Default/apps/content.json.h:201
+#: content/Default/apps/content.json.h:213
 msgctxt "title"
 msgid "Calculator"
 msgstr "الآلة الحاسبة"
 
-#: content/Default/apps/content.json.h:202
+#: content/Default/apps/content.json.h:214
 msgctxt "subtitle"
 msgid "A scientific calculator with many bonus tools"
 msgstr "آلة حاسبة علمية مع العديد من الأدوات المجانية"
 
-#: content/Default/apps/content.json.h:203
+#: content/Default/apps/content.json.h:215
 msgctxt "description"
 msgid ""
 "Do you ever consider how often you need to do basic or even complex math in "
@@ -1375,17 +1416,17 @@ msgid ""
 " again as long as you have this calculator app!"
 msgstr "هل فكرت في أي وقت مضى كم عدد المرات التي تحتاج فيها إلى إجراء العمليات الرياضية الأساسية أو حتى المعقدة في الحياة اليومية؟ من حساب ميزانية، لتحويل القياسات في وصفة، لمعرفة الضرائب، وربما كنت تستخدم المعادلات بشكل أكثر انتظاماً مما كنت تعتقد. ولهذا السبب يعتبر تطبيق الآلة الحاسبة هذا في متناول اليدين. أجر العمليات الحسابية البسيطة بسرعة، أو اسمح للآلة الحاسبة بالقيام بعمل أكثر تقدماً اعتماداً على احتياجاتك. لن تضطر أبداً للكفاح من أجل تنفيذ المهام الرياضية مرة أخرى ما دام لديك تطبيق الآلة الحاسبة هذا!"
 
-#: content/Default/apps/content.json.h:204
+#: content/Default/apps/content.json.h:216
 msgctxt "title"
 msgid "Math Plotting"
 msgstr "حبكة الرياضيات"
 
-#: content/Default/apps/content.json.h:205
+#: content/Default/apps/content.json.h:217
 msgctxt "subtitle"
 msgid "Interactive computation and data visualization tool"
 msgstr "الحوسبة التفاعلية وأداة تصوير البيانات"
 
-#: content/Default/apps/content.json.h:206
+#: content/Default/apps/content.json.h:218
 msgctxt "description"
 msgid ""
 "This math application offers advanced mathematical computing functions that "
@@ -1396,17 +1437,17 @@ msgid ""
 "here."
 msgstr "يقدم تطبيق الرياضيات هذا وظائف الحوسبة الرياضية المتقدمة التي يمكن أن تستخدم في عمليات أكثر بكثير من مجرد العمليات الحسابية الأساسية. إذا كنت بارعاً في الرياضيات تحب تجريب هذا التخصص المثير، فهذا تطبيقك. وحتى لو لم تكن، فالتطبيق يعمل بشكلٍ رائعٍ باعتباره آلةً حاسبةً متطورة. كل الأسرار العددية التي تحتاج لمعرفتها هي هنا مباشرة."
 
-#: content/Default/apps/content.json.h:207
+#: content/Default/apps/content.json.h:219
 msgctxt "title"
 msgid "Mines"
 msgstr "ألغام"
 
-#: content/Default/apps/content.json.h:208
+#: content/Default/apps/content.json.h:220
 msgctxt "subtitle"
 msgid "Find and avoid all the dangerous mines to win"
 msgstr "اعثر على كل الألغام الخطيرة وتجنبها  لتفوز"
 
-#: content/Default/apps/content.json.h:209
+#: content/Default/apps/content.json.h:221
 msgctxt "description"
 msgid ""
 "Figure out where the dangerous mines are in order to stay alive and win the "
@@ -1416,17 +1457,17 @@ msgid ""
 " each direction. If you figure out where all the mines are, you'll win!"
 msgstr "حدد أين الألغام الخطيرة من أجل البقاء على قيد الحياة والفوز في المباراة! فكل مربع إما محيط أو لغم، وسوف تحتاج إلى الضغط على المحيطات فقط وإلا فعليك البدء من جديد. وفي كل مرة تنقر فيها على مربع ما، سوف تكتشف ما هو، و سترى كم عدد الألغام المحيطة به وفي كل الإتجاهات. إذا حددت الألغام كلها، سوف تفوز!"
 
-#: content/Default/apps/content.json.h:210
+#: content/Default/apps/content.json.h:222
 msgctxt "title"
 msgid "Screenshot"
 msgstr "لقطة شاشة\t"
 
-#: content/Default/apps/content.json.h:211
+#: content/Default/apps/content.json.h:223
 msgctxt "subtitle"
 msgid "Take a picture of your screen to save"
 msgstr "ألتقط صورة لشاشتك للحفظ"
 
-#: content/Default/apps/content.json.h:212
+#: content/Default/apps/content.json.h:224
 msgctxt "description"
 msgid ""
 "Do you ever wish you could take a picture of your screen to save? Well now "
@@ -1435,18 +1476,18 @@ msgid ""
 "make sure to save just what you need and nothing more."
 msgstr "هل تمنيت في أي وقت مضى أخذ صورة من الشاشة لحفظها؟ حسناً يمكنك ذلك الآن، مع تطبيق لقطة الشاشة سهل الاستخدام هذا. يمكنك اختيار أخذ لقطة من شاشتك بأكملها، أو مجرد واحدة من النوافذ الخاصة بك. وبهذه الطريقة، يمكنك التأكد من حفظ ما تحتاجه فقط ولا شيء أكثر من ذلك."
 
-#: content/Default/apps/content.json.h:213
-#: content/Default/apps/content.json.h:297
+#: content/Default/apps/content.json.h:225
+#: content/Default/apps/content.json.h:306
 msgctxt "title"
 msgid "Sudoku"
 msgstr "سودوكو"
 
-#: content/Default/apps/content.json.h:214
+#: content/Default/apps/content.json.h:226
 msgctxt "subtitle"
 msgid "One of the most popular puzzle games of all time"
 msgstr "أحد ألعاب الألغاز الأكثر شعبية على مر العصور"
 
-#: content/Default/apps/content.json.h:215
+#: content/Default/apps/content.json.h:227
 msgctxt "description"
 msgid ""
 "If you’re a fan of puzzles and math games, the Sudoku app is perfect for "
@@ -1457,17 +1498,17 @@ msgid ""
 "fun solving Sudoku puzzles and exercising your mind!"
 msgstr "إذا كنت من محبي الألغاز وألعاب الرياضيات، فإن تطبيق سودوكو هو التطبيق المثالي لك. ألعاب التفكير هذه ممتعة حيث يجب ترتيب الأرقام 1-9 في شبكة بحيث لا يكون لديك أي تكرارات في أي من الصفوف أو الأعمدة. قد يبدو الأمر معقداً في البداية، ولكن مع هذا التطبيق، سوف تتعلم كيفية اللعب ويمكنك الحصول على تعليق من المباراة في أي وقت من الأوقات. ستحظى بساعات من المرح في حل ألغاز السودوكو وتدريب عقلك قريباً!"
 
-#: content/Default/apps/content.json.h:216
+#: content/Default/apps/content.json.h:228
 msgctxt "title"
 msgid "Terminal"
 msgstr "تيرمينال"
 
-#: content/Default/apps/content.json.h:217
+#: content/Default/apps/content.json.h:229
 msgctxt "subtitle"
 msgid "Use the command line"
 msgstr "استخدم سطر الأوامر"
 
-#: content/Default/apps/content.json.h:218
+#: content/Default/apps/content.json.h:230
 msgctxt "description"
 msgid ""
 "If you're an advanced user and want to display system information and launch"
@@ -1477,17 +1518,17 @@ msgid ""
 "in correctly and to help you easily identify any mistakes you have made."
 msgstr "إذا كنت أحد المستخدمين المتقدمين وترغب في عرض معلومات النظام وإطلاق التطبيقات دون استخدام الفأرة، يمكنك الآن أن تفعل ذلك فقط مع هذا التطبيق الطرفي الأساسي. مع هذا التطبيق الطرفي الحديث، يمكنك مشاهدة كافة الأوامر الخاصة بك وهي تُكتب بألوانٍ مختلفةٍ للمساعدةٍ في التأكد مما إذا كنت تكتبها بشكلٍ صحيح ولمساعدتك على التعرف بسهولة على أي أخطاء قمت بها."
 
-#: content/Default/apps/content.json.h:219
+#: content/Default/apps/content.json.h:231
 msgctxt "title"
 msgid "Tetravex"
 msgstr "تيترافيكس"
 
-#: content/Default/apps/content.json.h:220
+#: content/Default/apps/content.json.h:232
 msgctxt "subtitle"
 msgid "Race the clock in a numerical puzzle game"
 msgstr "سابق الوقت في لعبة اللغز العددية"
 
-#: content/Default/apps/content.json.h:221
+#: content/Default/apps/content.json.h:233
 msgctxt "description"
 msgid ""
 "Try to match up all of the same numbers on the blocks to win this tricky "
@@ -1496,17 +1537,17 @@ msgid ""
 "beat your or your friends' best time!"
 msgstr "حاول أن تطابق كل ما يحمل نفس الأرقام على القطعة للفوز في هذه اللعبة الخادعة. سوف تحتاج إلى التفكير بعناية وبسرعة بغية إتمام هذا اللغز. سيتم توقيت اللعبة لك، لذا تأكد من أن تكون سريعا وذلك للتغلب على أفضل وقت كنت قد حققته أو حققه أصدقائك!"
 
-#: content/Default/apps/content.json.h:222
+#: content/Default/apps/content.json.h:234
 msgctxt "title"
 msgid "Notes"
 msgstr "ملاحظات "
 
-#: content/Default/apps/content.json.h:223
+#: content/Default/apps/content.json.h:235
 msgctxt "subtitle"
 msgid "Never lose a note again"
 msgstr "لن تفقد ملاحظةً مرةً أخرى"
 
-#: content/Default/apps/content.json.h:224
+#: content/Default/apps/content.json.h:236
 msgctxt "description"
 msgid ""
 "Do you find yourself writing down lots of notes on pieces of paper that "
@@ -1517,17 +1558,17 @@ msgid ""
 "notes and stay even more organized!"
 msgstr "هل تجد نفسك تدون الكثير من الملاحظات على قطعة من الورق لا تلبث إلا أن تضيع أو تمزق في وقت لاحق؟ أو، هل هناك الكثير من الملاحظات على مكتبك الذي ضاق بما عليه؟ بغض النظر عن نوع الملاحظات التي تحتاج إلى أن تأخذها، تطبيق المذكرة هذا يمكن أن يساعدك على الاحتفاظ بها جميعاً في مكان واحد. هذا التطبيق لديه أيضا القدرة على ربط الملاحظات معاً بحيث يمكنك الوصول بسهولة إلى كل الملاحظات ذات الصلة، والبقاء حتى أكثر تنظيماً!"
 
-#: content/Default/apps/content.json.h:225
+#: content/Default/apps/content.json.h:237
 msgctxt "title"
 msgid "Dictionary"
 msgstr "معجم"
 
-#: content/Default/apps/content.json.h:226
+#: content/Default/apps/content.json.h:238
 msgctxt "subtitle"
 msgid "A cool dictionary with lots of bonus tools"
 msgstr "معجم رائع مع الكثير من الأدوات المجانية"
 
-#: content/Default/apps/content.json.h:227
+#: content/Default/apps/content.json.h:239
 msgctxt "description"
 msgid ""
 "In reading and conversation, words often come up with which you’re not "
@@ -1537,12 +1578,12 @@ msgid ""
 "word you’re looking for!"
 msgstr "في القراءة والمحادثة، غالباً ما تأتي الكلمات مع التي لم تكن مألوفةً لك ومن الأفضل أن يكون بالقرب منك قاموس بحيث يمكنك تعلم مفردات جديدة وفهم ما تقرأ وما تسمع. تطبيق القاموس هذا سهل الاستخدام والتصفح، لذا لن تجد أبداً صعوبةً في العثور على الكلمة المباشرة التي تبحث عنها!"
 
-#: content/Default/apps/content.json.h:228
+#: content/Default/apps/content.json.h:240
 msgctxt "title"
 msgid "GT Curriculum"
 msgstr "مناهج الطلبة المتميزين"
 
-#: content/Default/apps/content.json.h:230
+#: content/Default/apps/content.json.h:242
 msgctxt "description"
 msgid ""
 "Use this app to find the basic curriculum plan and guidelines for a specific"
@@ -1554,17 +1595,17 @@ msgid ""
 "difference both your child's life and your own."
 msgstr "استخدم هذا التطبيق للعثور على خطة المناهج الدراسية الأساسية والمبادئ التوجيهية لمستوى صفيٍ معين، أو استخدمه للعثور على أوراق العمل التي يمكن أن تساعد الأطفال على تعلم الموضوعات الصعبة. وقد جمعت وزارة التربية والتعليم هذا المورد الثمين لك لتتمكن من استخدامه. اقرأ كتيباتٍ كاملةٍ لتتعلم كيفية هيكلة تعليم الطفل، ولمعرفة كيفية مساعدة الأطفال على النمو بشكلٍ صحي، وللتعرف على مجموعة متنوعة من الموضوعات المهمة الأخرى التي يمكن أن تُحدث فرقاً كبيراً على حدٍ سواء في حياة طفلك وحياتك."
 
-#: content/Default/apps/content.json.h:231
+#: content/Default/apps/content.json.h:243
 msgctxt "title"
 msgid "EduCollections"
 msgstr "مجموعات تعليمية"
 
-#: content/Default/apps/content.json.h:232
+#: content/Default/apps/content.json.h:244
 msgctxt "subtitle"
 msgid "All sorts of information to help better your life"
 msgstr "جميع أنواع المعلومات للمساعدة على تحسين حياتك"
 
-#: content/Default/apps/content.json.h:233
+#: content/Default/apps/content.json.h:245
 msgctxt "description"
 msgid ""
 "This app is full of reliable information sent directly from the Guatemalan "
@@ -1577,17 +1618,17 @@ msgid ""
 "your age."
 msgstr "يمتلئ هذا التطبيق بالمعلومات الموثوقة التي تم إرسالها مباشرة من الحكومة الغواتيمالية لمساعدتك على العيش حياة مليئة بالصحة وأكثر رخاء. ستجد هنا معلومات حول زراعة أنواع مختلفة من المحاصيل، ونصائح للأمهات قبل وبعد الحمل، وأدوات للمعلمين لإعداد المناهج الدراسية، وأوراق العمل للطلاب الذين يرغبون في متابعة التعليم في المدارس الخاصة، ونصوص لتعليم لغة المايا، ومعلومات كثيرة ورائعة. هذا المصدر للمعرفة جاهز وتحت تصرفكم، ويمكن أن يكون وسيلة مفيدة بغض النظر عن عمرك."
 
-#: content/Default/apps/content.json.h:234
+#: content/Default/apps/content.json.h:246
 msgctxt "title"
 msgid "Health Guides"
 msgstr "الإرشادات الصحية"
 
-#: content/Default/apps/content.json.h:235
+#: content/Default/apps/content.json.h:247
 msgctxt "subtitle"
 msgid "Health guides that could save your life"
 msgstr "أدلة صحية يمكن أن تنقذ حياتك"
 
-#: content/Default/apps/content.json.h:236
+#: content/Default/apps/content.json.h:248
 msgctxt "description"
 msgid ""
 "This app contains some of the most life saving documents that you'll ever "
@@ -1596,38 +1637,17 @@ msgid ""
 " learn to help your loved ones, those in your community and even yourself!"
 msgstr "يحتوي هذا التطبيق على بعض من أكثر الوثائق المنقذة للحياة التي ستقرأها في أي وقت على الإطلاق. افتح مجلد مستندات الصحة الهيسبيرية لتعلم أشياء مثل كيفية إجراء الفحوصات والإجراءات البسيطة. سوف تندهش من كم المعلومات التي يمكن أن تتعلمها لمساعدة أحبائك، أولئك الموجودون في مجتمعك وحتى نفسك!"
 
-#: content/Default/apps/content.json.h:237
-msgctxt "title"
-msgid "Textbooks"
-msgstr "الكتب المدرسية"
-
-#: content/Default/apps/content.json.h:238
-msgctxt "subtitle"
-msgid "Textbooks for students, parents and teachers"
-msgstr "الكتب المدرسية للطلاب وأولياء الأمور والمعلمين"
-
-#: content/Default/apps/content.json.h:239
-msgctxt "description"
-msgid ""
-"Select a grade level and prepare yourself to learn directly from your "
-"computer! This app contains textbooks, worksheets and other learning tools, "
-"to teach or supplement your learning. Whether you're a student needing extra"
-" homework help, a parent helping to develop a child's education, or someone "
-"seeking to learn more in their spare time, you'll find this app to be "
-"incredibly useful."
-msgstr "حدد المستوى وجهز نفسك للتعلم مباشرة من جهاز الحاسوب خاصتك! يتضمن هذا التطبيق الكتب المدرسية وأوراق العمل والأدوات التعليمية الأخرى لتعليمك أو تكملة تعليمك. وسواء كنت طالبا تحتاج إلى واجبات منزلية إضافية، أو كنت أحد الوالدين ممن يسعى لتطوير تعليم طفله، أو كنت أي شخص يسعى للمعرفة و المزيد من التعلم في أوقات فراغه، ستجد هذا التطبيق مفيداً بشكل لا يصدق."
-
-#: content/Default/apps/content.json.h:240
+#: content/Default/apps/content.json.h:249
 msgctxt "title"
 msgid "Iagno"
 msgstr "لعبة لاغنو"
 
-#: content/Default/apps/content.json.h:241
+#: content/Default/apps/content.json.h:250
 msgctxt "subtitle"
 msgid "A fun puzzle game that involves lots of thought"
 msgstr "لعبة ألغاز ممتعة تتطلب تفكير كبير"
 
-#: content/Default/apps/content.json.h:242
+#: content/Default/apps/content.json.h:251
 msgctxt "description"
 msgid ""
 "Turn over the pieces in front of you so that they are all the same color. "
@@ -1638,17 +1658,17 @@ msgid ""
 "strategically and see if you can figure this puzzle out!"
 msgstr "تعتمد هذه اللعبة على قلب القطع التي أمامك بحيث تكون كلها بنفس اللون. بسيطة، أليس كذلك؟ ليس على الإطلاق! يمكنك تغيير القطع للون الخاص بك إذا كنت تستطيع وضع واحدة من القطع في مكان بحيث يمكنك تشكيل صف، أو عمود أو خط قطري عبر قطع متتالية من لون آخر. لذلك، تحتاج إلى قلب القطع بعناية في محاولة لجعل \"كل\" القطع تتلون باللون الخاص بك. فكر بطريقة استراتيجية بحتة وراقب إن كان بإمكانك حل هذا اللغز!"
 
-#: content/Default/apps/content.json.h:243
+#: content/Default/apps/content.json.h:252
 msgctxt "title"
 msgid "Inkscape"
 msgstr "برنامج إنكسكيب لتحرير الرسوم"
 
-#: content/Default/apps/content.json.h:244
+#: content/Default/apps/content.json.h:253
 msgctxt "subtitle"
 msgid "An advanced graphic design tool"
 msgstr "أداة متقدمة للتصميم الجرافيكي "
 
-#: content/Default/apps/content.json.h:245
+#: content/Default/apps/content.json.h:254
 msgctxt "description"
 msgid ""
 "This app is for intermediate and advanced graphic designers who need to "
@@ -1659,17 +1679,17 @@ msgid ""
 "presentations and artwork with this great free graphics app!"
 msgstr "صُِمم هذا التطبيق لمصممي الغرافيك في المستويات المتوسطة والمتقدمة و الذين هم بحاجة  إلى إنشاء وتحرير الرسومات والصور. هذا التطبيق يتيح لك ميزات متقدمة ومشابهة لبرنامج أدوب إنديزاين (Adobe InDesign). فعلى سبيل المثال، فإنه يسمح لك إنشاء SVGs (رسومات المتجهات القابلة للتطوير)، والتي تميز رسوماتك الخاصة بجودة عالية بغض النظر عن حجمها. قم بإنشاء إعلانات جميلة والنشرات والعروض التقديمية والأعمال الفنية باستخدام هذا التطبيق المجاني للرسومات!"
 
-#: content/Default/apps/content.json.h:246
+#: content/Default/apps/content.json.h:255
 msgctxt "title"
 msgid "Kalzium"
 msgstr "كالزيوم"
 
-#: content/Default/apps/content.json.h:247
+#: content/Default/apps/content.json.h:256
 msgctxt "subtitle"
 msgid "A fun interactive periodic table of elements"
 msgstr "جدول العناصر الدورية التفاعلي الممتع"
 
-#: content/Default/apps/content.json.h:248
+#: content/Default/apps/content.json.h:257
 msgctxt "description"
 msgid ""
 "The periodic table of the elements is one of the basic building blocks of "
@@ -1682,17 +1702,17 @@ msgid ""
 "simple, and informative app."
 msgstr "يعتبر الجدول الدوري للعناصر واحد من اللبنات الأساسية للعلم، و يمكنك الآن الحصول عليه وأن يكون في متناول يدك.  يتميز هذا التطبيق بجدول دوري مرمز الألوان، و هو الأمر الذي يجعل تعلم كل عنصر أسهل وأكثر متعة. قم بتحديد العناصر لتعلم المعلومات الأساسية عنها، مثل نقاط الذوبان، والكتلة، وغير ذلك. إن توفر المزيد من المعلومات المعقدة، مثل تصور خطوط الطيف للعناصر، يجعل هذا التطبيق مثاليا للاكتشاف العلمي. لن تصدق كم يمكن أن تتعلم مع هذا التطبيق الجميل والبسيط، والغني بالمعلومات."
 
-#: content/Default/apps/content.json.h:249
+#: content/Default/apps/content.json.h:258
 msgctxt "title"
 msgid "Kapman"
 msgstr "كابمان"
 
-#: content/Default/apps/content.json.h:250
+#: content/Default/apps/content.json.h:259
 msgctxt "subtitle"
 msgid "The classic game of ghosts and mazes"
 msgstr "اللعبة الكلاسيكية من الأشباح والمتاهات"
 
-#: content/Default/apps/content.json.h:251
+#: content/Default/apps/content.json.h:260
 msgctxt "description"
 msgid ""
 "If you love Pac-Man, then you you'll love this game too! Eat dots to gain "
@@ -1702,17 +1722,17 @@ msgid ""
 "and family, from kids to grandparents, will love the game, too!"
 msgstr "إذا كنت من محبي لعبة باك مان، فإنك سوف تحب هذه اللعبة أيضا! قم بأكل النقط لكسب النقاط ولكن لا تسمح للأشباح بحصارك وإلا فإتك سوف تخسر. و كلما اكتسبت مهارات وكلما ارتفع المستوى، ستزداد سرعة اللعبة، وبالتالي المزيد من التحدي و الإثارة. و لن ترغب على الإطلاق وقف اللعب، وسوف يحب أصدقائك وعائلتك، أطفالاً كانوا أو أجداد، هذه اللعبة أيضا!"
 
-#: content/Default/apps/content.json.h:252
+#: content/Default/apps/content.json.h:261
 msgctxt "title"
 msgid "KAtomic"
 msgstr "لعبة الكاتوميك"
 
-#: content/Default/apps/content.json.h:253
+#: content/Default/apps/content.json.h:262
 msgctxt "subtitle"
 msgid "A fun way to learn chemistry"
 msgstr "طريقة ممتعة لتعلم الكيمياء"
 
-#: content/Default/apps/content.json.h:254
+#: content/Default/apps/content.json.h:263
 msgctxt "description"
 msgid ""
 "If you’re struggling with concepts in chemistry, or simply looking for a way"
@@ -1724,17 +1744,17 @@ msgid ""
 " a ton!"
 msgstr "إذا كنت تعاني من المفاهيم الواردة في الكيمياء، أو ببساطة تبحث عن وسيلة لتعزيز فهمك،  فقد وجدت التطبيق المناسب لمساعدتك! هذه اللعبة الصعبة تساعدك على إنشاء جزيئات من الذرات - والطريقة المثلى للتعلم من خلال المرح! ستعرض لك الشاشة الشكل الذي سيبدو عليه  الجزيء الخاص بك، ويمكنك تحريك الذرات الخاص بك في جميع الاتجاهات لتشكيل الجزيء الصحيح. هذه اللعبة تتطلب استراتيجية وتفكير سريع، وسوف تعلمك الكثير!"
 
-#: content/Default/apps/content.json.h:255
+#: content/Default/apps/content.json.h:264
 msgctxt "title"
 msgid "KBlackBox"
 msgstr "كي بلاك بوكس"
 
-#: content/Default/apps/content.json.h:256
+#: content/Default/apps/content.json.h:265
 msgctxt "subtitle"
 msgid "Find the pattern and uncover the hidden balls"
 msgstr "ابحث عن النمط و اكشف الكرات المخبأة"
 
-#: content/Default/apps/content.json.h:257
+#: content/Default/apps/content.json.h:266
 msgctxt "description"
 msgid ""
 "This game takes some serious logic, but don’t be scared away – it’s also "
@@ -1744,17 +1764,17 @@ msgid ""
 "hidden ones are placed. The more you get right, the higher your score."
 msgstr "هذه اللعبة تحتاج الى منطق فعلي، ولكن لا تجعل هذا الأمر يخيفك و يبعدك عن اللعبة - فهي أيضا تحتوي على المتعة والمرح. حيث يتم إخفاء الكرات في مربع أسود على الشاشة. ويمكنك استخدام شعاع الليزر للكشف عن مكان وجود هذه الكرات. وعندما تعتقد أنك تعرف النمط، قم بسحب وإسقاط الكرات على الشاشة حيث تتوقع وجودها. وكلما كان توقعك صحيحا، سترتفع درجتك."
 
-#: content/Default/apps/content.json.h:258
+#: content/Default/apps/content.json.h:267
 msgctxt "title"
 msgid "KBruch"
 msgstr "كي بروتش"
 
-#: content/Default/apps/content.json.h:259
+#: content/Default/apps/content.json.h:268
 msgctxt "subtitle"
 msgid "Learn about fractions, percentages and more"
 msgstr "تعلم الكسور، والنسب المئوية وأكثر من ذلك"
 
-#: content/Default/apps/content.json.h:260
+#: content/Default/apps/content.json.h:269
 msgctxt "description"
 msgid ""
 "One of the trickiest parts of the math we do every day is calculating "
@@ -1766,17 +1786,17 @@ msgid ""
 "benefit you in unexpected ways!"
 msgstr "من أصعب أجزاء الرياضيات التي نقوم بها كل يوم هو حساب الكسور والنسب المئوية. والآن لن تضطر أبدا إلى التخمين لمرة ثانية في النتيجة الرياضية! هذا التطبيق يضم الألعاب والتدريبات لصقل مهاراتك، بما في ذلك الحساب، والمقارنة، والتحويل، والتحليل للعوامل. تعلم كل شيء عن الكسور والنسب المئوية، ومارسها بقدر ما تريد. إننا نواجه هذا النوع من الرياضيات كل يوم تقريبا، وبالتالي فإن مهاراتك الجديدة ستفيدك بشكل لن تتوقعه!"
 
-#: content/Default/apps/content.json.h:261
+#: content/Default/apps/content.json.h:270
 msgctxt "title"
 msgid "KSnake"
 msgstr "كي سنيك"
 
-#: content/Default/apps/content.json.h:262
+#: content/Default/apps/content.json.h:271
 msgctxt "subtitle"
 msgid "A fun and very simple game for everyone"
 msgstr "لعبة ممتعة وبسيطة جدا للجميع"
 
-#: content/Default/apps/content.json.h:263
+#: content/Default/apps/content.json.h:272
 msgctxt "description"
 msgid ""
 "Similar to the popular arcade game, Snake, this classic game will help you "
@@ -1785,17 +1805,17 @@ msgid ""
 "snakes grow longer, promising a fun challenge to players of all levels."
 msgstr "على غرار لعبة الورق الشعبية، Snake (الأفعى)، تساعدك هذه اللعبة الكلاسيكية على درء الملل طوال ساعات متواصلة! فعند تناول الأفعى الطعام، تنمو و تكبر، ولكن تصطدم مع ثعبان آخر، وبالتالي يخسر الجميع. وتزداد اللعبة صعوبة كلما ازداد نمو الأفعى، و تعد بتحدٍ ممتع للاعبين من جميع المستويات."
 
-#: content/Default/apps/content.json.h:264
+#: content/Default/apps/content.json.h:273
 msgctxt "title"
 msgid "KGeography"
 msgstr "كي جيوغرافي"
 
-#: content/Default/apps/content.json.h:265
+#: content/Default/apps/content.json.h:274
 msgctxt "subtitle"
 msgid "Become a geography genius while having fun"
 msgstr "أصبح عبقريا في الجغرافيا من خلال المرح"
 
-#: content/Default/apps/content.json.h:266
+#: content/Default/apps/content.json.h:275
 msgctxt "description"
 msgid ""
 "How much do you know about world geography and political affairs? Learn the "
@@ -1806,17 +1826,17 @@ msgid ""
 "and will have had a lot of fun learning it all!"
 msgstr "كم تعرف عن عالم الجغرافيا والشؤون السياسية؟ تعلم جغرافية العالم من خلال لعبة مثيرة للاهتمام. أولا، تحقق من الخريطة وتعرف على الأسماء والعواصم، والأعلام. يحين الوقت لاختبار معلوماتك! خمن العواصم والأعلام، أو حاول وضع الحدود الوطنية على خريطة فارغة. وقبل أن تعرفها، عليك أن تغني معلوماتك عن كل ركن من أركان العالم، وسوف تحصل على الكثير من المتعة عند القيام بذلك!"
 
-#: content/Default/apps/content.json.h:267
+#: content/Default/apps/content.json.h:276
 msgctxt "title"
 msgid "KGoldrunner"
 msgstr "كي جولد رنر"
 
-#: content/Default/apps/content.json.h:268
+#: content/Default/apps/content.json.h:277
 msgctxt "subtitle"
 msgid "Look for treasure and hide from enemies"
 msgstr "البحث عن الكنز و الاختباء من الأعداء"
 
-#: content/Default/apps/content.json.h:269
+#: content/Default/apps/content.json.h:278
 msgctxt "description"
 msgid ""
 "Your enemies are right on your heels as you move through mazes collecting "
@@ -1826,17 +1846,17 @@ msgid ""
 " through any trapdoors!"
 msgstr "يلاحقك أعدائك عن قرب خلال حركتك بين المتاهات عند جمع الذهب في هذه اللعبة المثيرة للاهتمام. و من خلال ما تقدمه لك من ألغاز صعبة وهدف مثير، لابد أن تكون هذه اللعبة لعبة مفضلة عندك. ستجد فيها مئات المستويات لساعات من اللعب، و متاهات جديدة على كافة المستويات. كل ما عليك القيام به هو تجنب الفشل عند مصائد الأبواب!"
 
-#: content/Default/apps/content.json.h:270
+#: content/Default/apps/content.json.h:279
 msgctxt "title"
 msgid "KHangMan"
 msgstr "كي هانجمان"
 
-#: content/Default/apps/content.json.h:271
+#: content/Default/apps/content.json.h:280
 msgctxt "subtitle"
 msgid "One of the most fun word games on earth"
 msgstr "واحدة من أكثر ألعاب الكلمات متعة على الأرض"
 
-#: content/Default/apps/content.json.h:272
+#: content/Default/apps/content.json.h:281
 msgctxt "description"
 msgid ""
 "Practice your vocabulary the fun way! You'll learn new words with this "
@@ -1848,17 +1868,17 @@ msgid ""
 "have to start over with a new word!"
 msgstr "تدرب على المفردات الخاصة بك بطريقة ممتعة! سوف تتعلم كلمات جديدة مع هذه اللعبة التي يمكن أن يلعبها جميع أفراد الأسرة معا. كيف تلعب؟ حسنا، سيقوم الكمبيوتر باختيار كلمة وسيحاول اللاعبون محاولة تخمين ما هي تلك الكلمة بواسطة توقع حروفها واحدا تلو الآخر حتى يمكنهم تخمين الكلمة بالكامل. اذ عرف اللاعبون تخمينها بشكل صحيح، ستظهر المزيد من الكلمات. ولكن إذا لم تتمكن من ذلك، سوف تخسر ويجب أن تبدأ من جديد مع كلمة جديدة!"
 
-#: content/Default/apps/content.json.h:273
+#: content/Default/apps/content.json.h:282
 msgctxt "title"
 msgid "Kigo"
 msgstr "كييجو"
 
-#: content/Default/apps/content.json.h:274
+#: content/Default/apps/content.json.h:283
 msgctxt "subtitle"
 msgid "The ancient game of skill, updated for modern play"
 msgstr "اللعبة القديمة لعكس المهارات تم تحديثها لتصبح لعبة حديثة"
 
-#: content/Default/apps/content.json.h:275
+#: content/Default/apps/content.json.h:284
 msgctxt "description"
 msgid ""
 "Based on a two-player board game popular in Asia, this app has easy-to-learn"
@@ -1870,17 +1890,17 @@ msgid ""
 "too!"
 msgstr "تم تطوير هذا التطبيق بالإستناد على لعبة الألواح الشعبية في آسيا والتي يلعبها لاعبان، و تعتبر قواعد هذا التطبيق سهلة التعلم، ولكن يتطلب ذلك قدراً كبيراً من الاستراتيجية. انه الوسيلة المثالية لتمضية الوقت وفي الوقت نفسه تدريب عقلك. وتعد طريقة اللعب بسيطة: قم بتحريك قطعك السوداء أو البيضاء على اللوح (الشبكة) (حجم الشبكة يعتمد على مستوى الصعوبة الذي قمت باختياره)، وحاول تطويق أكبر قدر من اللوحة بشكل يفوق خصمك. إن كنت ممن يحبون الشطرنج، فلا شك أنك ستحب هذه اللعبة الاستراتيجية الرائعة!"
 
-#: content/Default/apps/content.json.h:276
+#: content/Default/apps/content.json.h:285
 msgctxt "title"
 msgid "Killbots"
 msgstr "كيلبوتس"
 
-#: content/Default/apps/content.json.h:277
+#: content/Default/apps/content.json.h:286
 msgctxt "subtitle"
 msgid "Outsmart the killer robots to win"
 msgstr "كن أكثر دهاء من الرجال الآليين القاتلة للفوز"
 
-#: content/Default/apps/content.json.h:278
+#: content/Default/apps/content.json.h:287
 msgctxt "description"
 msgid ""
 "How will you get away from the killer robots bent on destruction? Figure it "
@@ -1890,17 +1910,17 @@ msgid ""
 "tell the tale!"
 msgstr "كيف ستهرب من الرجال الآليين المبرمجين على القتل و الدمار؟ تعرف على هذا من خلال هذه اللعبة الممتعة و البسيطة. و قد ينتهي بك المطاف بعدد كبير من الرجال الآليين، و لكن بالاعتماد على ذكائك و جهاز التحكم اليدوي بإمكانك التغلب عليهم. كن أكثر دهاءً وحيلةً  من جميع الروبوتات القاتلة للفوز والعيش لتروي الحكاية!"
 
-#: content/Default/apps/content.json.h:279
+#: content/Default/apps/content.json.h:288
 msgctxt "title"
 msgid "Kolor Lines"
 msgstr "خطوط كولور"
 
-#: content/Default/apps/content.json.h:280
+#: content/Default/apps/content.json.h:289
 msgctxt "subtitle"
 msgid "Line up balls of the same color to win"
 msgstr "قم بصف الكرات من نفس اللون للفوز"
 
-#: content/Default/apps/content.json.h:281
+#: content/Default/apps/content.json.h:290
 msgctxt "description"
 msgid ""
 "This game is so fun and addicting, you’ll never want to stop playing. The "
@@ -1911,17 +1931,17 @@ msgid ""
 "possible; you lose if it fills up completely!"
 msgstr "هذه اللعبة ممتعة وقد يتعلق الفرد بها بشكل لا يرغب به في التوقف عن اللعب. الفكرة بسيطة: قم بجمع الكرات الملونة من رقعة اللعبة على شكل خطوط من خمس كرات من نفس اللون، والتي سوف تختفي عن الرقعة. إنها لعبة أكثر صعوبة مما كنت تتوقع، وذلك لأن كرات جديدة تصل بعد كل حركة. ومهمتك تكمن في تفريغ رقعة اللعبة من الكرات بأكبر قدر ممكن؛ وفي حال امتلأت الرقعة بالكرات، ستخسر اللعبة!"
 
-#: content/Default/apps/content.json.h:282
+#: content/Default/apps/content.json.h:291
 msgctxt "title"
 msgid "KMines"
 msgstr "كي ماينز"
 
-#: content/Default/apps/content.json.h:283
+#: content/Default/apps/content.json.h:292
 msgctxt "subtitle"
 msgid "Stay away from the exploding mines"
 msgstr "ابتعد عن الألغام المتفجرة"
 
-#: content/Default/apps/content.json.h:284
+#: content/Default/apps/content.json.h:293
 msgctxt "description"
 msgid ""
 "Don't take a wrong step or you'll explode! You'll need to use logic and "
@@ -1929,17 +1949,17 @@ msgid ""
 "safely across the field."
 msgstr "لا تخطو خطوة خاطئة وإلا تفجرت! ستحتاج إلى استخدام المنطق والذكاء في هذه اللعبة للالتفاف على جميع الألغام الأرضية وشق طريقك بأمان عبر الميدان."
 
-#: content/Default/apps/content.json.h:285
+#: content/Default/apps/content.json.h:294
 msgctxt "title"
 msgid "Battleships"
 msgstr "سفن الحرب"
 
-#: content/Default/apps/content.json.h:286
+#: content/Default/apps/content.json.h:295
 msgctxt "subtitle"
 msgid "Blow your opponents out of the water"
 msgstr "فجّر  خصومك من الماء"
 
-#: content/Default/apps/content.json.h:287
+#: content/Default/apps/content.json.h:296
 msgctxt "description"
 msgid ""
 "Try to guess where your enemies ships are to blow them out of the water "
@@ -1950,17 +1970,17 @@ msgid ""
 "Arrr you ready for some great naval fun?"
 msgstr "حاول تخمين موقع تواجد سفن أعدائك لتفجيرهم و اخراجهم من الماء قبل أن ينالوا منك! هذه لعبة استراتيجية ممتعة تتطلب شخصين. حيث يمكنك أن تلعب ضد صديق، أو ضد شخص آخر على شبكة الانترنت، أو ضد الكمبيوتر. سوف تتناوبون في محاولة لتخمين موقع سفن بعضكم البعض، وأول شخص يغرق  سفن جميع أعدائه يفوز. هل أنت على استعداد لبعض المرح البحري العظيم؟"
 
-#: content/Default/apps/content.json.h:288
+#: content/Default/apps/content.json.h:297
 msgctxt "title"
 msgid "KNetwalk"
 msgstr "كي نتووك"
 
-#: content/Default/apps/content.json.h:289
+#: content/Default/apps/content.json.h:298
 msgctxt "subtitle"
 msgid "Make the right cable connections and win"
 msgstr "أنجز توصيلات الكابلات الصحيحة وحقق الفوز"
 
-#: content/Default/apps/content.json.h:290
+#: content/Default/apps/content.json.h:299
 msgctxt "description"
 msgid ""
 "Who knew building computer networks could be fun? You'll need to create the "
@@ -1971,17 +1991,17 @@ msgid ""
 "enjoyable and competitive game you’ll love to play."
 msgstr "من كان يعلم أن بناء شبكات حاسوبية يمكن أن يكون أمرا ممتعاً؟ حيث تحتاج للفوز إلى إنشاء الروابط الصحيحة بأقل عدد ممكن من النقلات. لذا تجهز لتحريك الاسلاك و اكتشاف هذه اللعبة الأحجية  بسرعة! عند نجاحك، ستظهر لك قائمة النتائج الأعلى حتى تعرف من هم منافسيك! و يساعدك هذا التطبيق على فهم كيف عمل الشبكات الحاسوبية، و ما هو أهم من ذلك فهي لعبة ممتعة و تنافسية  ستعشق لعبها."
 
-#: content/Default/apps/content.json.h:291
+#: content/Default/apps/content.json.h:300
 msgctxt "title"
 msgid "Kobo Deluxe"
 msgstr "كوبو ديلوكس"
 
-#: content/Default/apps/content.json.h:292
+#: content/Default/apps/content.json.h:301
 msgctxt "subtitle"
 msgid "Destroy enemy bases in space"
 msgstr "دمر قواعد الأعداء في الفضاء"
 
-#: content/Default/apps/content.json.h:293
+#: content/Default/apps/content.json.h:302
 msgctxt "description"
 msgid ""
 "Fans of arcade-style games will love this fun shooting game. Protect "
@@ -1990,17 +2010,17 @@ msgid ""
 "to play. You'll have hours and hours of fun blowing up things in space!"
 msgstr "سيحب عشاق ألعاب الممرات هذه اللعبة الممتعة القائمة على اطلاق النار . احم نفسك من السفن وقم بتدمير سفن العدو لأنها تسعى ورائك في الفضاء! تحتوي هذه اللعبة على رسومات ممتعة والكثير من التحديات، و أكثر من 50 مستوى. سيكون لديك ساعات وساعات من المرح وتفجير الأشياء في الفضاء!"
 
-#: content/Default/apps/content.json.h:294
+#: content/Default/apps/content.json.h:303
 msgctxt "title"
 msgid "KSquares"
 msgstr "كي سكويرز"
 
-#: content/Default/apps/content.json.h:295
+#: content/Default/apps/content.json.h:304
 msgctxt "subtitle"
 msgid "Connect the dots in this challenging strategy game"
 msgstr "صل بين النقط في هذه اللعبة الاستراتيجية الصعبة"
 
-#: content/Default/apps/content.json.h:296
+#: content/Default/apps/content.json.h:305
 msgctxt "description"
 msgid ""
 "Based on a popular old game, this fun app lets you stretch your mind and "
@@ -2011,12 +2031,12 @@ msgid ""
 "entertainment. Be careful – you just might become addicted!"
 msgstr "هذا التطبيق المسلي يتيح لك توسيع تفكيرك ويتيح لك حل الأحجيات بناء على ألعاب قديمة شهيرة. الهدف هو أن تكمل مربعات في الشبكة أكثر من خصمك. بتوصيلك الخطوط بين النقاط في دورك سوف تشكل مربعات بينما تحاول التصدي لمربعات خصمك. هذه اللعبة تتطلب تفكيراً هندسياً واستراتيجياً، وسوف تمنحك المتعة لساعات طويلة. كن حذراً - فقد تصاب بالإدمان عليها!"
 
-#: content/Default/apps/content.json.h:298
+#: content/Default/apps/content.json.h:307
 msgctxt "subtitle"
 msgid "A challenging numerical puzzle game"
 msgstr "لعبة الألغاز الرقمية الصعبة"
 
-#: content/Default/apps/content.json.h:299
+#: content/Default/apps/content.json.h:308
 msgctxt "description"
 msgid ""
 "Are you better than your friend is at puzzles? Find out by playing this fun "
@@ -2028,17 +2048,17 @@ msgid ""
 "Sudoku, or are an experienced player, you'll love this app!"
 msgstr "هل أنت أفضل من أصدقائك في حل الأحجيات؟ اكتشف ذلك عن طريق اللعب بلعبة أحجية الأرقام الممتعة هذه! تستطيع أن تلعب وحدك وأن يساعدك أشخاص آخرون أو أن تتحدى أصقاءك وأفراد عائلتك لترى من سيحل الأحجية أولاً. يمتلك هذا التطبيق مزايا خاصة مثل; القدرة على إنشاء ألعاب يمكن طباعتها والقدرة على مساعدتك في حل أي أحجية سودوكو حتى تتعلم كيفية حلها لوحدك، وسواء كنت جديداً على لعبة السودوكو أم لاعباً ذو خبرة فسوف تحب هذا التطبيق!"
 
-#: content/Default/apps/content.json.h:300
+#: content/Default/apps/content.json.h:309
 msgctxt "title"
 msgid "KSnakeDuel"
 msgstr "كي سنيك ديوال"
 
-#: content/Default/apps/content.json.h:301
+#: content/Default/apps/content.json.h:310
 msgctxt "subtitle"
 msgid "Survival depends on your reflexes and wits"
 msgstr "البقاء على قيد الحياة يعتمد على ردود أفعالك وذكائك الخاص"
 
-#: content/Default/apps/content.json.h:302
+#: content/Default/apps/content.json.h:311
 msgctxt "description"
 msgid ""
 "Guide your snake to eat the apples and to avoid the other snakes, balls and "
@@ -2049,17 +2069,17 @@ msgid ""
 "fun challenge!"
 msgstr "قم بتوجيه الثعبان الخاص بك لأكل التفاح وتجنب الثعابين الأخرى، والكرات، والجدران! بعض الثعابين والكرات ستعمل على جعلك أبطأ، في حين أن آخرين سوف يعمدون إلى قتلك، لذلك من الأفضل أن تبقى بعيدا عنهم جميعا! إذا كنت تنوي أكل كل التفاح، ستحتاج إلى الخروج من المتاهة من أجل الانتقال إلى المستوى التالي. هذه اللعبة قد تبدو سهلة، ولكنها ليست كذلك، لذا عليك الاستعداد  لتحد ممتع!"
 
-#: content/Default/apps/content.json.h:303
+#: content/Default/apps/content.json.h:312
 msgctxt "title"
 msgid "Potato Guy"
 msgstr "لعبة الفتى البطاطا"
 
-#: content/Default/apps/content.json.h:304
+#: content/Default/apps/content.json.h:313
 msgctxt "subtitle"
 msgid "Give your potato a funny face"
 msgstr "أعطِ شخصية البطاطا خاصتك وجهاً مضحكاً"
 
-#: content/Default/apps/content.json.h:305
+#: content/Default/apps/content.json.h:314
 msgctxt "description"
 msgid ""
 "This is a silly game for children and their parents to play together. Based "
@@ -2069,17 +2089,17 @@ msgid ""
 "lots of laughter. Make the goofiest face you can!"
 msgstr "هذه لعبة سخيفة إذا رغب الأطفال وأولياء أمورهم لعبها معا . ووفقا إلى السيد رأس البطاطا، فإنه يسمح لك بسحب وإسقاط ملامح الوجه على البطاطا، مما يشكل وجوه مضحكة بهذه اللمسات والشوارب، وآذان القزم، وذيل الحصان الأشقر، وربطات العنق. ليس هناك هدف لهذه اللعبة باستثناء الكثير من الضحك. و تشكيل أغبى وجه ممكن!"
 
-#: content/Default/apps/content.json.h:306
+#: content/Default/apps/content.json.h:315
 msgctxt "title"
 msgid "Kubrick"
 msgstr "كيوبريك"
 
-#: content/Default/apps/content.json.h:307
+#: content/Default/apps/content.json.h:316
 msgctxt "subtitle"
 msgid "Like Rubik's Cube - create solid color sides to win"
 msgstr "مثل روبكس كيوب- أنشئ جوانب ملونة صلبة لتفوز"
 
-#: content/Default/apps/content.json.h:308
+#: content/Default/apps/content.json.h:317
 msgctxt "description"
 msgid ""
 "This puzzling game has lots of options to keep your brain working! Modeled "
@@ -2091,17 +2111,17 @@ msgid ""
 "even design your very own challenge!"
 msgstr "تتضمن هذه اللعبة المحيرة الكثير من الخيارات للحفاظ على نشاط الدماغ! و قد صممت على غرار لعبة \"مكعب روبيك\" الشعبية بنظام ثلاثي الأبعاد. و تقوم على قلب الحجارة الصغيرة في مكعب كبير في محاولة لجعل كل من الجانبين للمكعب بنفس اللون. كل الأشياء الصغيرة، والكبيرة تمنح تحديات خاصة بها. وتشمل اللعبة أيضا تطبيقات تحركات رائعة للحلول حتى تتمكن من مجاراة الخبراء، وحتى تتمكن من تصميم التحدي الخاص بك!"
 
-#: content/Default/apps/content.json.h:309
+#: content/Default/apps/content.json.h:318
 msgctxt "title"
 msgid "KWordQuiz"
 msgstr "كي وورد كويز"
 
-#: content/Default/apps/content.json.h:310
+#: content/Default/apps/content.json.h:319
 msgctxt "subtitle"
 msgid "Grow your vocabulary and test your learning"
 msgstr "حسن مفرداتك واختبر تعلمك"
 
-#: content/Default/apps/content.json.h:311
+#: content/Default/apps/content.json.h:320
 msgctxt "description"
 msgid ""
 "Learning new words is a great way to speak and write more clearly, but "
@@ -2112,17 +2132,17 @@ msgid ""
 "learning all you want."
 msgstr "يعتبر تعلم كلمات جديدة وسيلة رائعة للتحدث والكتابة بشكل أوضح، ولكن قد يكون أحيانا من الصعب القيام به. و من الوسائل التي تساعد في ذلك استخدام البطاقات التعليمية، سواء كنت تتعلم لغة أجنبية أو تحاول حفظ مفردات جديدة. يجعل هذا التطبيق عملية الحفظ سهلة وممتعة باستخدام البطاقات التعليمية التفاعلية والاختبارات التي تساعدك على اختبار معرفتك و تعلم كل ما تريد."
 
-#: content/Default/apps/content.json.h:312
+#: content/Default/apps/content.json.h:321
 msgctxt "title"
 msgid "Breakout"
 msgstr "الهروب"
 
-#: content/Default/apps/content.json.h:313
+#: content/Default/apps/content.json.h:322
 msgctxt "subtitle"
 msgid "Destroy all the bricks to win this fun game"
 msgstr "تدمر كل الحجارة للفوز في هذه اللعبة الممتعة"
 
-#: content/Default/apps/content.json.h:314
+#: content/Default/apps/content.json.h:323
 msgctxt "description"
 msgid ""
 "This classic paddle game is tons of fun! The aim is to destroy bricks with "
@@ -2132,17 +2152,17 @@ msgid ""
 " graphics and animation, intuitive controls, and plenty of levels to beat."
 msgstr "تعتبر لعبة المضرب الكلاسيكية هذه في غاية المتعة! إن الهدف هو تدمير الحجارة  بالكرة عن طريق ضربها بالمضرب الخاص بك، والذي يسمح لك الوصول إلى مستوى أعلى. إن بدايات لعبة الاختراق الأصلية هذه تعود إلى عام 1976، وقد أحب الناس هذه اللعبة  البسيطة والمدمنة منذ ذلك الحين. أحصل عليها مع رسومات كبيرة ورسوم متحركة، وضوابط سهلة الإستخدام، والكثير من المستويات من أجل الفوز."
 
-#: content/Default/apps/content.json.h:315
+#: content/Default/apps/content.json.h:324
 msgctxt "title"
 msgid "Spreadsheet"
 msgstr "جدول بيانات"
 
-#: content/Default/apps/content.json.h:316
+#: content/Default/apps/content.json.h:325
 msgctxt "subtitle"
 msgid "A spreadsheet program with many functions"
 msgstr "برنامج جداول البيانات مع العديد من الوظائف"
 
-#: content/Default/apps/content.json.h:317
+#: content/Default/apps/content.json.h:326
 msgctxt "description"
 msgid ""
 "Whatever you need to keep track of, the spreadsheet app can help you do it. "
@@ -2153,17 +2173,17 @@ msgid ""
 " job market."
 msgstr "أياً كان ما تحتاج متابعته، يمكن لتطبيق جداول البيانات هذا أن يساعدك على القيام بذلك. أن هذا التطبيق المتقدم وسهل الاستخدام يقدم خدماته للجميع: فهو تخطيط بسيط من السهل فهمه، بالإضافة إلى القدرة على القيام بعمليات حسابية معقدة. وتستخدم جداول البيانات هذه في كثير من المهن في جميع أنحاء العالم، بحيث أن الحصول على هذا التطبيق يساعدك على اكتساب مهارات قيمة لسوق العمل."
 
-#: content/Default/apps/content.json.h:318
+#: content/Default/apps/content.json.h:327
 msgctxt "title"
 msgid "Presentation"
 msgstr "العرض التقديمي"
 
-#: content/Default/apps/content.json.h:319
+#: content/Default/apps/content.json.h:328
 msgctxt "subtitle"
 msgid "Create great presentations with this easy-to-use app"
 msgstr "جهز عرضاً تقديمياً رائعاً بإستخدام هذا التطبيق السهل"
 
-#: content/Default/apps/content.json.h:320
+#: content/Default/apps/content.json.h:329
 msgctxt "description"
 msgid ""
 "Create clean, attractive, and professional presentations with this "
@@ -2174,17 +2194,17 @@ msgid ""
 "need."
 msgstr "أنشئ العروض التقديمية بشكل مرتب وجذاب وعالي الاحترافية مع هذا التطبيق للعروض التقديمية. يتميز هذا التطبيق بالقدرة على استخدام النصوص، وأدوات الرسم، والإنتقالات، وفنون ثنائية وثلاثية الأبعاد، وحتى الرسوم المتحركة لإيصال وجهة نظرك بطريقة جميلة ومقنعة. و يعتبر هذا التطبيق، والذي يعد أفضل التطبيقات،  سهل الفهم والاستخدام، مع خطوات مبسطة لإيجاد بالضبط ما تحتاجه."
 
-#: content/Default/apps/content.json.h:321
+#: content/Default/apps/content.json.h:330
 msgctxt "title"
 msgid "Writer"
 msgstr "الكاتب"
 
-#: content/Default/apps/content.json.h:322
+#: content/Default/apps/content.json.h:331
 msgctxt "subtitle"
 msgid "Free, similar to & compatible with Microsoft Word"
 msgstr "مجاني و متشابه و متوافق مع مايكروسوفت وورد"
 
-#: content/Default/apps/content.json.h:323
+#: content/Default/apps/content.json.h:332
 msgctxt "description"
 msgid ""
 "This app gives you all the features of the best word processing applications"
@@ -2196,17 +2216,17 @@ msgid ""
 "notes; either way, you’ll have simple yet powerful tools available."
 msgstr " يوفر هذا التطبيق لك جميع الميزات من أفضل تطبيقات معالجة النصوص والمتوافقة مع مايكروسوفت أوفيس. قم بإنشاء وتحرير الوثائق بسهولة، وإنشاء ملاحظات قصيرة ونصوص كتابية أطول مع الشروح والرسوم البيانية. كل شيء ممكن مع هذا التطبيق. وسوف تظهر مستنداتك بشكل مهني عال المستوى بما فيه الكفاية لتقديمه إلى أصحاب العمل، والمعلمين، أو الأشخاص المهمين الآخرين. قم باستخدام هذا التطبيق من أجل تأليف تحفتك المقبلة أو لتدوين الملاحظات أو كلاهما. سيكون لديك أدوات بسيطة لكنها فعالة."
 
-#: content/Default/apps/content.json.h:324
+#: content/Default/apps/content.json.h:333
 msgctxt "title"
 msgid "Maps"
 msgstr "خرائط"
 
-#: content/Default/apps/content.json.h:325
+#: content/Default/apps/content.json.h:334
 msgctxt "subtitle"
 msgid "Maps of the entire world"
 msgstr "خرائط العالم"
 
-#: content/Default/apps/content.json.h:326
+#: content/Default/apps/content.json.h:335
 msgctxt "description"
 msgid ""
 "Where do players from FC Barcelona or Real Madrid live? How far away are you"
@@ -2217,17 +2237,17 @@ msgid ""
 "has changed over time!"
 msgstr "أين يعيش اللاعبون من برشلونة أو ريال مدريد؟ كم تبعد عن بلد تعيش به الفيلة والأسود وتتجول بحرية؟ كم تبعد عن أقرب بركان؟ هذه هي الأسئلة التي تجيب عليها الخرائط الصحيحة. وهذا التطبيق يوفر لك الوصول إلى جميع أنواع الخرائط من جميع أنحاء العالم ومن عصور مختلفة، بحيث يمكنك أن ترى كيف تغير العالم مع مرور الوقت!"
 
-#: content/Default/apps/content.json.h:327
+#: content/Default/apps/content.json.h:336
 msgctxt "title"
 msgid "M.A.R.S."
 msgstr "لعبة مارس"
 
-#: content/Default/apps/content.json.h:328
+#: content/Default/apps/content.json.h:337
 msgctxt "subtitle"
 msgid "A shooting game in space"
 msgstr "لعبة إطلاق نار في الفضاء"
 
-#: content/Default/apps/content.json.h:329
+#: content/Default/apps/content.json.h:338
 msgctxt "description"
 msgid ""
 "In the year 3547, civilizations across the galaxy have settled their own "
@@ -2240,17 +2260,17 @@ msgid ""
 "keep playing until you succeed in returning peace to your planet!"
 msgstr "في العام 3547، أستقرت كل الحضارات عبر المجرة كل في كوكبه الخاص به. ويعيش شعبك في سلام وانسجام مع البيئة. ولكن خارج كوكبك السلمي، حرب عظيمة تدور رحاها. معروف عنك أنك مقاتل مشهور بالدفاع عن شرفه وسمعته، وسيكون مطلوب منك حماية كوكبك من الجيران الغيورين الذين يريدون تدميره! تتيح هذه اللعبة لعدد كبير من اللاعبين في المشاركة فيها، كما تتيح لك الاختيار من بين مجموعة متنوعة من الأسلحة للقتال، بل وتسمح لك تصميم سفينة الفضاء الخاصة بك. الجميل أنك سترغب في الاستمرار في اللعب حتى تنجح في إعادة السلام إلى كوكبك!"
 
-#: content/Default/apps/content.json.h:330
+#: content/Default/apps/content.json.h:339
 msgctxt "title"
 msgid "MegaGlest"
 msgstr "ميجاغليست"
 
-#: content/Default/apps/content.json.h:331
+#: content/Default/apps/content.json.h:340
 msgctxt "subtitle"
 msgid "A fantasy world with kings, queens and magic"
 msgstr "عالم خيالي مع الملوك و الملكات و السحر"
 
-#: content/Default/apps/content.json.h:332
+#: content/Default/apps/content.json.h:341
 msgctxt "description"
 msgid ""
 "Kings, castles, and dragons all unite in this awesome strategy game that "
@@ -2260,17 +2280,17 @@ msgid ""
 "you desire!"
 msgstr "يجتمع الملوك والقلاع، والتنين في هذه اللعبة الاستراتيجية الرهيبة  والتي من شأنها أن تجعلك تحكم حضارتك. إلعبها ضد أصدقائك لمعرفة من منهم مؤهل لحكم هذا العالم الخيالي الوحشي حيث يعطيك السحر فيه قوة أكبر ويمكنك من التغلب على أي جزء من عالم ترغبه!"
 
-#: content/Default/apps/content.json.h:333
+#: content/Default/apps/content.json.h:342
 msgctxt "title"
 msgid "Minetest"
 msgstr "لعبة ماين تيست"
 
-#: content/Default/apps/content.json.h:334
+#: content/Default/apps/content.json.h:343
 msgctxt "subtitle"
 msgid "Create your dream world"
 msgstr "أنشئ عالم أحلامك"
 
-#: content/Default/apps/content.json.h:335
+#: content/Default/apps/content.json.h:344
 msgctxt "description"
 msgid ""
 "What kind of a world would you build? Start with just land and water, and "
@@ -2282,17 +2302,17 @@ msgid ""
 " your city!"
 msgstr "أي نوع من العوالم تود بنائه؟ ابدء بأرضٍ ومياه فقط، ومن هناك حدد كل التفاصيل التي يمكن أن تفكر فيها! كُن مُبدعاً وابن قلعة مُدهشة، وناطحة سحاب عملاقة وقصر فسيح، ولا تنس إضافة جدران للمدينة من أجل الحماية. استكشف العالم وابن ما تريد خلال يومك، ولكن تأكد من أن تكون مستعداً لاستقبال الليل. فقد تكتشف أن عناكب وهياكل عظمية ومجموعة من الزومبي ربما تهاجم مدينتك!"
 
-#: content/Default/apps/content.json.h:336
+#: content/Default/apps/content.json.h:345
 msgctxt "title"
 msgid "Numpty Physics"
 msgstr "لعبة الرسوم نبتي فيزيكس"
 
-#: content/Default/apps/content.json.h:337
+#: content/Default/apps/content.json.h:346
 msgctxt "subtitle"
 msgid "Fun physics puzzle games"
 msgstr "ألعاب ألغاز فيزيائية (جسدية) ممتعة"
 
-#: content/Default/apps/content.json.h:338
+#: content/Default/apps/content.json.h:347
 msgctxt "description"
 msgid ""
 "Who knew the laws of physics could be so much fun? With this app, you can "
@@ -2303,17 +2323,17 @@ msgid ""
 "learning."
 msgstr "من كان يعلم  أن القوانين الفيزيائية قد تكون على هذا القدر من المتعة؟ مع هذا التطبيق، يمكنك حل الألغاز عن طريق رسم الأشياء مثل البكرات والروافع، والسلالم. وإذا كانت ابداعاتك صحيحة، عليك إنجاز مهمة هذا المستوى والانتقال إلى المستوى التالي. هذه اللعبة الصعبة سوف تعلمك أيضا بعض أسس الفيزياء، ولكن ستحصل على متعة كبيرة بحيث بالكاد تدرك انك كنت تتعلم."
 
-#: content/Default/apps/content.json.h:339
+#: content/Default/apps/content.json.h:348
 msgctxt "title"
 msgid "OpenSCAD"
 msgstr ""
 
-#: content/Default/apps/content.json.h:340
+#: content/Default/apps/content.json.h:349
 msgctxt "subtitle"
 msgid "Solid 3D CAD modeller"
 msgstr ""
 
-#: content/Default/apps/content.json.h:341
+#: content/Default/apps/content.json.h:350
 msgctxt "description"
 msgid ""
 "OpenSCAD is software for creating solid 3D CAD models. It reads in a script "
@@ -2321,17 +2341,17 @@ msgid ""
 "file. The resulting model can be sent to a 3D printer."
 msgstr ""
 
-#: content/Default/apps/content.json.h:342
+#: content/Default/apps/content.json.h:351
 msgctxt "title"
 msgid "Palapeli"
 msgstr "لعبة بالابيلي"
 
-#: content/Default/apps/content.json.h:343
+#: content/Default/apps/content.json.h:352
 msgctxt "subtitle"
 msgid "A fun jigsaw puzzle game"
 msgstr "لعبة لغز الرسومات المقطعة الممتعة"
 
-#: content/Default/apps/content.json.h:344
+#: content/Default/apps/content.json.h:353
 msgctxt "description"
 msgid ""
 "If you’re a big fan of jigsaw puzzles, you’ll love this game. Unlike other "
@@ -2341,17 +2361,17 @@ msgid ""
 "rewarding, and as true to life as can be."
 msgstr "إذا كنت من أشد المعجبين لألعاب الألغاز و الأحاجي، فإنك ستحب هذه اللعبة. وبخلاف غيرها من الألعاب الشبيهة لها، ليس من الضروري ترتيب القطع على الرقعة. وبدلا من ذلك، تمنحك لعبة بالابيلي شعورا أكثر واقعية، حيث يمكنك تحريك القطع بحرية. قم باختيار اللغز أو الأحجية الخاصة بك وأبدأ بتجميع القطع. هذه اللعبة ممتعة، ومجزية وحقيقية و قريبة للواقع بأكبر قدر ممكن."
 
-#: content/Default/apps/content.json.h:345
+#: content/Default/apps/content.json.h:354
 msgctxt "title"
 msgid "Pingus"
 msgstr "لعبة بينجس"
 
-#: content/Default/apps/content.json.h:346
+#: content/Default/apps/content.json.h:355
 msgctxt "subtitle"
 msgid "Save your penguin friends from falling into the water"
 msgstr "انقذ اصدقائك، البطريق، من السقوط في الماء"
 
-#: content/Default/apps/content.json.h:347
+#: content/Default/apps/content.json.h:356
 msgctxt "description"
 msgid ""
 "Penguins are among the cutest animals, so who wouldn’t want to play a fun "
@@ -2361,17 +2381,17 @@ msgid ""
 " them in order to avoid an untimely end."
 msgstr "تعتبر طيور البطريق من بين الحيوانات اللطيفة، من منا لا يريد أن يلعب لعبة ممتعة لحماية هذه المخلوقات المحبوبة من السقوط من فوق المنحدرات والسقوط في المياه المتجمدة؟ من المؤكد أن تصبح هذه اللعبة لعبتك المفضلة الجديدة و خصوصا أنها تحتوي على مستويات عديدة، وشخصيات رائعة. شاهد طيور البطريق الخاصة بك تستخدم الأدوات التي منحتها من أجل تجنب نهاية في غير أوانها."
 
-#: content/Default/apps/content.json.h:348
+#: content/Default/apps/content.json.h:357
 msgctxt "title"
 msgid "Video Editor"
 msgstr "محرر الفيديو"
 
-#: content/Default/apps/content.json.h:349
+#: content/Default/apps/content.json.h:358
 msgctxt "subtitle"
 msgid "Hundreds of transitions, effects, and filters to edit your videos"
 msgstr "مئات من التحولات والتأثيرات والمرشحات لتحرير فيديوهاتك"
 
-#: content/Default/apps/content.json.h:350
+#: content/Default/apps/content.json.h:359
 msgctxt "description"
 msgid ""
 "Create videos for projects, friends, family, or just for fun! Look through "
@@ -2381,17 +2401,17 @@ msgid ""
 "yourself, this video editor will help you do it!"
 msgstr "أنشئ فيديوهات لمشروعاتك أولأصدقائك وعائلتك أو فقط للمرح! تنقل بين مئات التحولات ومؤثرات الفيديو والصوت والمرشحات لمساعدتك في الحصول على ما تحتاج، أي شيء تحتاجه لسرد قصة أو لعمل هدية لصديق أو لإنشاء فيديو بشكل احترافي أو فقط للتعبير عن نفسك فمحرر الفيديو هذا سيساعدك للحصول على ما تريد!"
 
-#: content/Default/apps/content.json.h:351
+#: content/Default/apps/content.json.h:360
 msgctxt "title"
 msgid "Quadrapassel"
 msgstr "لعبة كوادروبازييل"
 
-#: content/Default/apps/content.json.h:352
+#: content/Default/apps/content.json.h:361
 msgctxt "subtitle"
 msgid "A tetris-like puzzle game"
 msgstr "لعبة الألغاز الشبيهة بلعبة التيتريس"
 
-#: content/Default/apps/content.json.h:353
+#: content/Default/apps/content.json.h:362
 msgctxt "description"
 msgid ""
 "You'll need to be quick if you want to win this game! Change the shape of "
@@ -2402,17 +2422,17 @@ msgid ""
 "challenge!"
 msgstr "إذا أردت الفوز في هذه اللعبة سوف تحتاج أن تكون سريعا! قم بتغيير شكل القطع التي تسقط من أعلى وذلك لمطابقة الألوان وجعلها تختفي. إذا لم تقم بإخفاء ما يكفي من قطع الألوان، ستجد أن الشاشة سوف تمتلئ بسرعة وعليك إعادة المحاولة. وعندما تعتقد بأنك سريع بما فيه الكفاية، فإن اللعبة ستزداد سرعتها. لذا كن على استعداد للتحدي القادم!"
 
-#: content/Default/apps/content.json.h:354
+#: content/Default/apps/content.json.h:363
 msgctxt "title"
 msgid "Music"
 msgstr "موسيقى"
 
-#: content/Default/apps/content.json.h:355
+#: content/Default/apps/content.json.h:364
 msgctxt "subtitle"
 msgid "Listen to all your music, and to the radio"
 msgstr "استمع إلى كل الموسيقى المفضلة لك، و استمع إلى المذياع"
 
-#: content/Default/apps/content.json.h:356
+#: content/Default/apps/content.json.h:365
 msgctxt "description"
 msgid ""
 "In addition to listening to your favorite music, this app lets you search "
@@ -2422,17 +2442,17 @@ msgid ""
 "in one convenient app."
 msgstr "بالإضافة إلى الاستماع إلى الموسيقى المفضلة لديك، هذا التطبيق يتيح لك البحث من خلال المكتبة، وإنشاء قوائم التشغيل واللعب ونسخ الأقراص المضغوطة، وإظهار صور الألبوم وحتى كلمات الأغاني. كما يدعم هذا التطبيق  الراديو عبر الإنترنت وتصورات الصوتية. تمتع بجميع الأغاني المفضلة لديك وتخزينها وفرزها في تطبيق واحد مناسب."
 
-#: content/Default/apps/content.json.h:357
+#: content/Default/apps/content.json.h:366
 msgctxt "title"
 msgid "Toy Train"
 msgstr "قطار لُعبة"
 
-#: content/Default/apps/content.json.h:358
+#: content/Default/apps/content.json.h:367
 msgctxt "subtitle"
 msgid "A fun train game for kids of all ages"
 msgstr "لعبة قطار ممتعة للأطفال في كل الأعمار"
 
-#: content/Default/apps/content.json.h:359
+#: content/Default/apps/content.json.h:368
 msgctxt "description"
 msgid ""
 "Sure to be an instant hit with the whole family, this is a game featuring a "
@@ -2440,17 +2460,17 @@ msgid ""
 "coaches as you go. Collect all the coaches to win the game!"
 msgstr "من المؤكد أنها لعبة عائلية رائعة، هذه لعبة تضم قاطرات بخارية والتي تستخدمها للانتقال عبر مستويات عديدة من خلال جمع العربات خلال حركتك. قم بجمع كل العربات لتحقيق الفوز في هذه اللعبة! "
 
-#: content/Default/apps/content.json.h:360
+#: content/Default/apps/content.json.h:369
 msgctxt "title"
 msgid "Scorched 3D"
 msgstr "لعبة سكورتش ثلاثية الأبعاد (الأرض المحروقة)"
 
-#: content/Default/apps/content.json.h:361
+#: content/Default/apps/content.json.h:370
 msgctxt "subtitle"
 msgid "A battle adventure multi-player game"
 msgstr "لعبة المغامرات الحربية متعددة اللاعبين"
 
-#: content/Default/apps/content.json.h:362
+#: content/Default/apps/content.json.h:371
 msgctxt "description"
 msgid ""
 "Do you love games with jets, naval vessels, and all sorts of weapons? If so,"
@@ -2462,17 +2482,17 @@ msgid ""
 "shake things up!"
 msgstr "هل تحب ألعاب الطائرات والقطع البحرية، وجميع أنواع الأسلحة؟ إذا كان الأمر كذلك، فإنك سوف تحب لعبة الأرض المحروقة ثلاثية الأبعاد هذه. توفر هذه اللعبة لك العديد من الأراضي المختلفة لتقوم بزيارتها والانخراط في المعارك. وسوف تحتاج إلى وضع استراتيجية جيدة و تكون أكثر دهاء وحيلة من خصومك والتأكد من أن ينتهي بك الأمر منتصرا. يمكنك أن تلعب وحدك، أو مع الأصدقاء، أو محاربة غيرهم من أفراد المجتمع عبر الإنترنت. تمسك جيداً بقبعتك، لأن هذه اللعبة من المؤكد أنها ستزعز الأمور!"
 
-#: content/Default/apps/content.json.h:363
+#: content/Default/apps/content.json.h:372
 msgctxt "title"
 msgid "Scratch"
 msgstr "شطب"
 
-#: content/Default/apps/content.json.h:364
+#: content/Default/apps/content.json.h:373
 msgctxt "subtitle"
 msgid "Learn basic computer programming"
 msgstr "تعلم أساسيات برمجة الكمبيوتر"
 
-#: content/Default/apps/content.json.h:365
+#: content/Default/apps/content.json.h:374
 msgctxt "description"
 msgid ""
 "Do you love computer games and applications? Why not learn how to make your "
@@ -2484,17 +2504,17 @@ msgid ""
 "will you someday make? "
 msgstr "هل تحب ألعاب وتطبيقات الكمبيوتر؟ لم لا تتعلم كيفية صُنعها بنفسك؟ يُعلمك هذا التطبيق أساسيات برمجة الكمبيوتر بطريقة تعلم ممتعة وسهلة؟ يمكنك التقاط ما تحب من الأحرف والكائنات ثم تقوم بإضافة تعليمات بما يجعلها تقوم بما تريد. ومع تقدم مستواك، سترى أنه بإمكانك تقريباً صنع أي شيء تريده أن يصبح فعالاً على الشاشة، وذلك عن طريق وضع التعليمات المناسبة له. ما هي لعبة الفيديو الرائعة، التي قد تنتجها يوماً ما؟"
 
-#: content/Default/apps/content.json.h:366
+#: content/Default/apps/content.json.h:375
 msgctxt "title"
 msgid "Photos"
 msgstr "الصور"
 
-#: content/Default/apps/content.json.h:367
+#: content/Default/apps/content.json.h:376
 msgctxt "subtitle"
 msgid "Easily edit, organize, and share photos."
 msgstr "بإمكانك بسهولة كبيرة القيام بتحرير و تنظيم و مشاركة الصور."
 
-#: content/Default/apps/content.json.h:368
+#: content/Default/apps/content.json.h:377
 msgctxt "description"
 msgid ""
 "We all love to take pictures in our everyday lives – and we especially love "
@@ -2505,17 +2525,17 @@ msgid ""
 "networks, like Facebook."
 msgstr "جميعنا يحب التقاط الصور في حياته اليومية - ونحب بالتحديد تنزيلها على حواسيبنا حتى نتمكن من تحريرها ومشاركتها عبر وسائل الإعلام الاجتماعية. يتيح لك هذا التطبيق تنزيل الصور من الكاميرا الرقمية أو من الهاتف بسهولة ويسر. وبعد ذلك يمكنك ترتيبها في ألبومات، وتحريرها لتحقيق أقصى قدر من الجمال والتأثير، وبالطبع، عرضها على الشبكات الاجتماعية، مثل الفيسبوك، المفضلة لديك."
 
-#: content/Default/apps/content.json.h:369
+#: content/Default/apps/content.json.h:378
 msgctxt "title"
 msgid "Simple Scan"
 msgstr "فحص بسيط"
 
-#: content/Default/apps/content.json.h:370
+#: content/Default/apps/content.json.h:379
 msgctxt "subtitle"
 msgid "Make a digital copy of your photos and documents"
 msgstr "قم بتحضير نسخ رقمية عن الصور والوثائق التي تمتلكها."
 
-#: content/Default/apps/content.json.h:371
+#: content/Default/apps/content.json.h:380
 msgctxt "description"
 msgid ""
 "Preserving your photos and important documents by making digital copies has "
@@ -2526,17 +2546,17 @@ msgid ""
 "sure the things you scan are clear, straight, and in any format you need!"
 msgstr "الحقاظ على صورك ووثائقك المهمة عن طريق عمل نسخ رقمية لم يكن يوما أسهل مما هو عليه الآن! ببساطة أوصل الماسح الضوئي الى جهاز حا سوبك، شغل هذا التطبيق، وابدأ بالمسح. ما أن تحول الوثيقة أو الصورة الى الصيغة الرقمية، تصبح مشاركتها بنفس سهولة ارسالها عبر البريد الالكتروني، تحميلها الى شبكة التواصل الاجتماعي المفضلة، أو وضعها على ذاكرة الناقل التسلسلي العام (يو. أس. بي.). ومن شأن هذا التطبيق أن يجعلك متأكدا من وضوح الأشياء التي تم مسحها واستقامتها وانضباطها في أي صيغة تريد!"
 
-#: content/Default/apps/content.json.h:372
+#: content/Default/apps/content.json.h:381
 msgctxt "title"
 msgid "Skype"
 msgstr "سكايب"
 
-#: content/Default/apps/content.json.h:373
+#: content/Default/apps/content.json.h:382
 msgctxt "subtitle"
 msgid "Free internet calls with cheap rates to phones"
 msgstr "مكالمات عبر الإنترنت مجانية و أجور اتصال رخيصة إلى الهواتف"
 
-#: content/Default/apps/content.json.h:374
+#: content/Default/apps/content.json.h:383
 msgctxt "description"
 msgid ""
 "Skype makes staying in touch incredibly easy and fun! If you have a webcam "
@@ -2545,17 +2565,17 @@ msgid ""
 "you can stay in touch with people anywhere in world!  **Requires Internet"
 msgstr "يجعل برنامج سكايب التواصل أمراً سهلاً وممتعاً! وإذا كان لديك كاميرا ويب وميكروفون، يمكنك بسهولة القيام بمكالمات الفيديو والمكالمات الصوتية مع أي شخص في العالم لديه أيضا برنامج سكايب. يمتاز هذا التطبيق بسهولة الاستخدام ويساعدك على التواصل مع الناس في أي مكان في العالم! ** علما أنه يتطلب وجود خدمة الإنترنت."
 
-#: content/Default/apps/content.json.h:375
+#: content/Default/apps/content.json.h:384
 msgctxt "title"
 msgid "Slingshot"
 msgstr "لعبة المقلاع"
 
-#: content/Default/apps/content.json.h:376
+#: content/Default/apps/content.json.h:385
 msgctxt "subtitle"
 msgid "A shooting strategy game set in space"
 msgstr "لعبة إطلاق نار استراتيجية مخصصة للفضاء "
 
-#: content/Default/apps/content.json.h:377
+#: content/Default/apps/content.json.h:386
 msgctxt "description"
 msgid ""
 "Gravity is your best friend in this fun shooting game set in outer space. "
@@ -2564,17 +2584,17 @@ msgid ""
 "in this fun and addictive game!"
 msgstr "تعتبر الجاذبية أفضل صديق لك في لعبة اطلاق النار الممتعة هذه و المخصصة للفضاء الخارجي. استخدم جاذبية الكواكب المختلفة لمصلحتك، واستخدم المقلاع الخاص بك والموثوق لتدمير مركبة العدو الفضائية. لا يوجد في هذه اللعبة الممتعة جولتين متشابهتين على الإطلاق، هذه اللعبة قد تسبب التعلق الشديد بها!"
 
-#: content/Default/apps/content.json.h:378
+#: content/Default/apps/content.json.h:387
 msgctxt "title"
 msgid "Freecell"
 msgstr "فري سيل (الخلية الحرة)"
 
-#: content/Default/apps/content.json.h:379
+#: content/Default/apps/content.json.h:388
 msgctxt "subtitle"
 msgid "Solitare based single player card game"
 msgstr "لعبة الورق (الشدة) للاعب واحد على نظام السوليتيير"
 
-#: content/Default/apps/content.json.h:380
+#: content/Default/apps/content.json.h:389
 msgctxt "description"
 msgid ""
 "This application lets you play a new type of solitaire that will keep you "
@@ -2584,17 +2604,17 @@ msgid ""
 "to enjoy."
 msgstr "يتيح هذا التطبيق لك لعب نوع جديد من لعبة السوليتير من شأنها أن تبقيك مستمتعاً لساعات! الفكرة العامة هي وضع أوراق اللعبة من نفس النقشة بشكل تنازلي. و لكن الأمر أكثر تعقيدا من ذلك بشكل بسيط. حيث تتحدى لعبة الورق هذه  العقل وتوفر الكثير من الترفيه لك."
 
-#: content/Default/apps/content.json.h:381
+#: content/Default/apps/content.json.h:390
 msgctxt "title"
 msgid "Solitaire"
 msgstr "سوليتير"
 
-#: content/Default/apps/content.json.h:382
+#: content/Default/apps/content.json.h:391
 msgctxt "subtitle"
 msgid "The classic single player card game"
 msgstr "لعبة الورق الكلاسيكية للاعب واحد"
 
-#: content/Default/apps/content.json.h:383
+#: content/Default/apps/content.json.h:392
 msgctxt "description"
 msgid ""
 "Solitaire is a classic card game that is fun for people of all ages. It’s "
@@ -2604,17 +2624,17 @@ msgid ""
 "entertain you, hour after hour."
 msgstr "تعتبر السوليتير لعبة ورق كلاسيكية و ممتعة للناس من جميع الأعمار. و من السهل معرفة قواعد هذه اللعبة، ولكن الأمر يتطلب بعض الوقت لإتقانها. لحسن الحظ، تحتاج إلى الوقت لتتعلم حقا كيفية اللعب، لأنك حقا سوف تستمتع كثيرا بها. هذه اللعبة المشوقة والمثرية للعقل من المؤكد انها ستمتعك، ساعة بعد ساعة."
 
-#: content/Default/apps/content.json.h:384
+#: content/Default/apps/content.json.h:393
 msgctxt "title"
 msgid "Steam"
 msgstr "البخار"
 
-#: content/Default/apps/content.json.h:385
+#: content/Default/apps/content.json.h:394
 msgctxt "subtitle"
 msgid "Browse hundreds of the most popular games online"
 msgstr "تصفح المئات من أشهر الألعاب على الإنترنت."
 
-#: content/Default/apps/content.json.h:386
+#: content/Default/apps/content.json.h:395
 msgctxt "description"
 msgid ""
 "If you like playing video games, you're going to have a great time exploring"
@@ -2625,18 +2645,18 @@ msgid ""
 " a time!"
 msgstr "إذا كنت تُحب لعب ألعاب فيديو، فستقضي وقتاً رائعاً في استكشاف كل ألعاب Linux الرائعة هذه الموجودة على بوابة Valve's Steam الإلكترونية! ستكون بحاجة لاتصال بالإنترنت لمشاهدة وشراء الألعاب من متجر Steam، فتأكد من أن الاتصال اللاسلكي Wi-Fi خاصتك على وضع التشغيل قبل فتح هذا التطبيق. استعد للعثور على أشهر الألعاب في العالم، التي ستمدك بتسليةٍ مستمرة لساعاتٍ في المرة الواحدة!"
 
-#: content/Default/apps/content.json.h:387
+#: content/Default/apps/content.json.h:396
 msgctxt "title"
 msgid "Stellarium"
 msgstr "برنامج ستيلاريوم"
 
-#: content/Default/apps/content.json.h:388
+#: content/Default/apps/content.json.h:397
 msgctxt "subtitle"
 msgid ""
 "Planetarium software that shows what you see when you look at the stars"
 msgstr "برنامج القبة الفلكية الذي يظهر ما تراه عندما تنظر إلى النجوم"
 
-#: content/Default/apps/content.json.h:389
+#: content/Default/apps/content.json.h:398
 msgctxt "description"
 msgid ""
 "Discover the night sky with this application. With a catalogue of more than "
@@ -2647,17 +2667,17 @@ msgid ""
 "coordinates and learn about the stars above you!"
 msgstr "اكتشف السماء ليلاً مع هذا التطبيق الذي يتيح  لك رؤية والتعرف على النجوم من سطح المكتب على جهازك و خصوصا مع توفر كتالوج  بأكثر من 600،000 نجم ومجموعات نجمية تم تجميعها من أكثر من عشرة ثقافات، وبتوفر العديد من المميزات. هذا التطبيق يظهر لك السماء في الليل بشكل واقعي جدا، تتطابق مع تلك التي فوقك. قم بضبط إحداثيات موقعك والتعرف على النجوم من فوقك!"
 
-#: content/Default/apps/content.json.h:390
+#: content/Default/apps/content.json.h:399
 msgctxt "title"
 msgid "Super Tux"
 msgstr "سوبر توكس"
 
-#: content/Default/apps/content.json.h:391
+#: content/Default/apps/content.json.h:400
 msgctxt "subtitle"
 msgid "Jump your way through different levels to win"
 msgstr "تجاوز مستويات عديدة للفوز"
 
-#: content/Default/apps/content.json.h:392
+#: content/Default/apps/content.json.h:401
 msgctxt "description"
 msgid ""
 "This game is similar to the original Super Mario Brothers games where you "
@@ -2666,17 +2686,17 @@ msgid ""
 " can follow along with as you play."
 msgstr "تشبه هذه اللعبة ألعاب سوبر ماريو براذرز الأصلية حيث يجب عليك الركض والقفز إلى مستويات جديدة. تمتاز هذه اللعبة بـ26 مستوى وبخصوم مختلفين لقتالهم. كما تمتاز بالموسيقى الممتعة، بالإضافة إلى أنها تروي قصة يمكنك اتباعها بالتزامن مع ما تقوم به."
 
-#: content/Default/apps/content.json.h:393
+#: content/Default/apps/content.json.h:402
 msgctxt "title"
 msgid "Tux Kart"
 msgstr "تكس كارت (بطريق السيارت)"
 
-#: content/Default/apps/content.json.h:394
+#: content/Default/apps/content.json.h:403
 msgctxt "subtitle"
 msgid "Race alone or against your friends and family"
 msgstr "تنافس في السباق مع أصدقائك أومع عائلتك"
 
-#: content/Default/apps/content.json.h:395
+#: content/Default/apps/content.json.h:404
 msgctxt "description"
 msgid ""
 "Do you love racing games? Then this is the app for you! Race down easy, "
@@ -2687,17 +2707,17 @@ msgid ""
 "is sure to entertain you and your friends for hours!"
 msgstr "هل تحب ألعاب السباقات؟ إذاً، فهذا التطبيق لك بالتحديد! سابق في المضامير المختلفة -السهلة والمتوسطة والصعبة- كما يفعل تكس، البطريق، وحاول تجاوز سرعتك في سباقات سابقة أو تجاوز سرعة أحد الأصدقاء. إذا كنت قادرا على الحصول على الأسماك الحمراء، فسوف تكسب قوى خاصة تمكنك من الفوز، ولكن تأكد من تفادي الأسماك الخضراء و إلا فعليك أن تبطئ. تعتبر هذه اللعبة ممتازة بالنسبة لكل من الصغار والكبار على حد سواء ومن المؤكد حصولك وأصدقائك على المتعة والمرح لساعات طوال!"
 
-#: content/Default/apps/content.json.h:396
+#: content/Default/apps/content.json.h:405
 msgctxt "title"
 msgid "Teeworlds"
 msgstr "تييوورردز"
 
-#: content/Default/apps/content.json.h:397
+#: content/Default/apps/content.json.h:406
 msgctxt "subtitle"
 msgid "Exciting multi-player shooting game"
 msgstr "لعبة اطلاق نار ممتعة و متعددة اللاعبين "
 
-#: content/Default/apps/content.json.h:398
+#: content/Default/apps/content.json.h:407
 msgctxt "description"
 msgid ""
 "Shoot your way to victory in death matches and more! This game has an old-"
@@ -2709,17 +2729,17 @@ msgid ""
 "and go!"
 msgstr "اخنرق طريقك للفوز في ألعاب الموت وأكثر من ذلك! تحمل هذه اللعبة طابع و شعور المدرسة القديمة، كما أنها لعبة اطلاق نار مثيرة ومتعددة اللاعبين  ومعارك ملحمية قد يصل بها عدد اللاعبين إلى 16 لاعبا في وقت واحد. إلعب \"الحصول على العلم\" أو \"فريق الموت\" حيث يجب عليك أن تبقى على قيد الحياة في الساحة الفتاكة أثناء التخلص من خصومك. تمتاز هذه اللعبة بخصائص رائعة، مثل إمكانية إنشاء الخريطة الخاصة بك! الكثير من الممتعة الدامية في انتظارك، لذلك تمسك بأسلحتك الافتراضية وانطلق!"
 
-#: content/Default/apps/content.json.h:399
+#: content/Default/apps/content.json.h:408
 msgctxt "title"
 msgid "TORCS"
 msgstr "تورس (لعبة سباق السيارات)"
 
-#: content/Default/apps/content.json.h:400
+#: content/Default/apps/content.json.h:409
 msgctxt "subtitle"
 msgid "Race cool 3D cars in this realistic game"
 msgstr "سباق السيارات الثلاثي الأبعاد في هذه اللعبة الواقعية"
 
-#: content/Default/apps/content.json.h:401
+#: content/Default/apps/content.json.h:410
 msgctxt "description"
 msgid ""
 "Rip around turns and scream past other drivers in this exciting 3D car "
@@ -2730,17 +2750,17 @@ msgid ""
 "want to play too!"
 msgstr "تجاوز المنعطفات وقم بالصراخ على السائقين الآخرين مع هذه اللعبة لسباق السيارات بنظام البعد الثلاثي. إنها واقعية  بدرجة كبيرة بحيث، أقسم لك، انك ستشتم رائحة حرق الإطارات! أما بالنسبة للمستخدمين المحترفين، مع هذه اللعبة تملكون الفرصة لتصميم سائقيكم  لكسب ميزة أكبر على خصومكم. ستحب قيادة سيارة السباق السريعة الخاصة بك، وسرعان ما ستلاحظ أن كل أصدقائك يرغبون باللعب أيضا!"
 
-#: content/Default/apps/content.json.h:402
+#: content/Default/apps/content.json.h:411
 msgctxt "title"
 msgid "Videos"
 msgstr "فيديوز"
 
-#: content/Default/apps/content.json.h:403
+#: content/Default/apps/content.json.h:412
 msgctxt "subtitle"
 msgid "Full function video and media player"
 msgstr "فيديو بخصائص كاملة و مشغل وسائط"
 
-#: content/Default/apps/content.json.h:404
+#: content/Default/apps/content.json.h:413
 msgctxt "description"
 msgid ""
 "Do you love watching movies? Do it the right way with this video application"
@@ -2750,17 +2770,17 @@ msgid ""
 "your family and friends to join you in watching all of your favorite movies!"
 msgstr "هل تحب مشاهدة الأفلام؟ حقق هذا الأمر بالطريقة الصحيحة من خلال هذا التطبيق الذي يعطيك الفرصة لمشاهدة الأفلام التي قمت بتنزيلها على نظام الشاشة الكبيرة. و ما يزيد من متعة المشاهدة الأمور الأخرى البسيطة كخاصية التحكم بالصوت و قائمة التشغيل. عند استخدامك لهذا التطبيق، ستعشق دعوة أفراد عائلتك و أصدقائك ليشاركوك مشاهدة أفلامك المفضلة"
 
-#: content/Default/apps/content.json.h:405
+#: content/Default/apps/content.json.h:414
 msgctxt "title"
 msgid "Tux Football"
 msgstr "تكس كرة القدم"
 
-#: content/Default/apps/content.json.h:406
+#: content/Default/apps/content.json.h:415
 msgctxt "subtitle"
 msgid "A fun soccer game starring Tux the penguin"
 msgstr "لعبة كرة القدم الممتعة بنجومية تكس، البطريق"
 
-#: content/Default/apps/content.json.h:407
+#: content/Default/apps/content.json.h:416
 msgctxt "description"
 msgid ""
 "Do you love soccer? Now you can play all day with your favorite penguins! "
@@ -2769,17 +2789,17 @@ msgid ""
 "professionals!"
 msgstr "هل تحب كرة القدم؟ الآن يمكنك أن تلعب كل يوم مع طيور البطريق المفضلة لديك! استعرض مهاراتك واستراتيجيتك من خلال السيطرة على اللاعبين المسيطرين على الكرة. وبعد فترة بسيطة، سوف تشعر أنك على استعداد لمواجهة اللاعبين المحترفين!"
 
-#: content/Default/apps/content.json.h:408
+#: content/Default/apps/content.json.h:417
 msgctxt "title"
 msgid "Tux Math"
 msgstr "تكس ماث (بطريق الرياضيات)"
 
-#: content/Default/apps/content.json.h:409
+#: content/Default/apps/content.json.h:418
 msgctxt "subtitle"
 msgid "Math games for kids"
 msgstr "ألعاب الرياضيات للأطفال"
 
-#: content/Default/apps/content.json.h:410
+#: content/Default/apps/content.json.h:419
 msgctxt "description"
 msgid ""
 "Learn math by playing games! Starring kids’ favorite buddy, Tux the Penguin,"
@@ -2789,17 +2809,17 @@ msgid ""
 "both worlds and will help your child learn to love math!"
 msgstr "تعلم الرياضيات من خلال لعب الألعاب! تعد لعبة تكس ذا بينجوين (تكس البطريق) أفضل صديق للأطفال. يعلم  تطبيق الرياضيات هذا الأطفال حقائق رياضية بطريقة ممتعة وتفاعلية. فأنت من جهة تريد أن يحسن أطفالك من مهاراتهم الرياضية، و هم بالمقابل يريدون لعب الألعاب، لذا فعليك تشجيعهم لعب هذه اللعبة ليحقق كل طرف مبتغاه، و بالتالي ستساعد اطفالك على حب الرياضيات."
 
-#: content/Default/apps/content.json.h:411
+#: content/Default/apps/content.json.h:420
 msgctxt "title"
 msgid "Tux Paint"
 msgstr "تكس بينت "
 
-#: content/Default/apps/content.json.h:412
+#: content/Default/apps/content.json.h:421
 msgctxt "subtitle"
 msgid "A fun drawing app for kids"
 msgstr "تطبيق رسم ممتع للأطفال"
 
-#: content/Default/apps/content.json.h:413
+#: content/Default/apps/content.json.h:422
 msgctxt "description"
 msgid ""
 "Create beautiful artwork with this fun and easy to use app! Tux the penguin "
@@ -2810,17 +2830,17 @@ msgid ""
 "then download this app and get them started on their next masterpiece!"
 msgstr "أنجز عملاً فنياً جميلاً مع هذا التطبيق الممتع وسهل الاستخدام! يساعد تطبيق \"تكس البطريق\" على إرشاد الأطفال نحو كيفية استخدام كل الأدوات المتوفرة فيه. إن الأعمار الموصى بها لاستخدام هذا التطبيق هي من 3سنوات حتى 12 سنة، ولكن أي شخص يشعر أنه من ذوي القلوب الشابة من المؤكد أنه سيحب هذا التطبيق! استخدم الطوابع وألعب مع الأشكال، أو أرسم بحرية مطلقة شيئا خاصاً. وإذا كان طفلك ممن يحبون الرسم أو يحبون إبداع أعمال فنية، قم بتحميل هذا التطبيق له و وفر له الفرصة لأبداع تحفته الفنية التالية!"
 
-#: content/Default/apps/content.json.h:414
+#: content/Default/apps/content.json.h:423
 msgctxt "title"
 msgid "Tux Puck"
 msgstr "تكس باك"
 
-#: content/Default/apps/content.json.h:415
+#: content/Default/apps/content.json.h:424
 msgctxt "subtitle"
 msgid "Exciting air hockey game for you and your friends"
 msgstr "لعبة هوكي الجوية الممتعة لك و لأصدقائك"
 
-#: content/Default/apps/content.json.h:416
+#: content/Default/apps/content.json.h:425
 msgctxt "description"
 msgid ""
 "An air hockey game in which you try to knock the puck past your opponent's "
@@ -2829,17 +2849,17 @@ msgid ""
 " or F6 to adjust your paddle speed.)"
 msgstr "لعبة هوكي الجوية التي تحاول خلالها دفع العفريت نحو دفاعات الخصم . هذه لعبة ممنازة و تناسب جميع أفراد الأسرة بأكملها! اختبر مهارتك وردود افعالك  للفوز في هذه المباراة سريعة الوتيرة!"
 
-#: content/Default/apps/content.json.h:417
+#: content/Default/apps/content.json.h:426
 msgctxt "title"
 msgid "Tux Typing"
 msgstr "تكس تايبنج (بطريق الطباعة)"
 
-#: content/Default/apps/content.json.h:418
+#: content/Default/apps/content.json.h:427
 msgctxt "subtitle"
 msgid "Learn to type by playing games"
 msgstr "تعلم الطباعة عن طريق لعب الألعاب"
 
-#: content/Default/apps/content.json.h:419
+#: content/Default/apps/content.json.h:428
 msgctxt "description"
 msgid ""
 "This fun application is a great way for kids, and even adults, to learn how "
@@ -2851,17 +2871,17 @@ msgid ""
 "encouraging them to play!"
 msgstr "هذا التطبيق هو وسيلة ممتعة وعظيمة للأطفال، وحتى الكبار لتعلم كيفية الطباعة! تعلم الأساسيات، أو حسن مهاراتك عن طريق لعب الألعاب التي تعلمك كيفية استخدام لوحة المفاتيح دون النظر إليها. يكبر الأطفال هذه الأيام وهم محاطين بأجهزة الكمبيوتر والأجهزة النقالة، وتعلم كيفية استخدام هذه التقنيات بشكل جيد سيكون له أهمية كبيرة في المستقبل. ابدأ  معهم على قاعدة متينة و أساس ممتاز وقم بتحميل هذا التطبيق وتشجيعهم على اللعب!"
 
-#: content/Default/apps/content.json.h:420
+#: content/Default/apps/content.json.h:429
 msgctxt "title"
 msgid "Warmux"
 msgstr "وورماكس"
 
-#: content/Default/apps/content.json.h:421
+#: content/Default/apps/content.json.h:430
 msgctxt "subtitle"
 msgid "Make your computer a battle of wit and war"
 msgstr "أجعل حاسوبك معركة من الحنكة و الحرب"
 
-#: content/Default/apps/content.json.h:422
+#: content/Default/apps/content.json.h:431
 msgctxt "description"
 msgid ""
 "Exterminate your opponent in a cartoon word using dynamite, grenades, "
@@ -2870,17 +2890,17 @@ msgid ""
 " member of each team attempts to destroy his opponents."
 msgstr "قم بإبادة خصمك في عالم الكرتون باستخدام الديناميت والقنابل اليدوية ومدافع البازوكا، أو حتى بمضرب البيسبول. على كل لاعب التحكم بفريقه ويجب تدمير عدوه مستعينا بأسلحته  ودهائه، وعلى الدور، كل عضو من كل فريق سيحاول تدمير خصومه."
 
-#: content/Default/apps/content.json.h:423
+#: content/Default/apps/content.json.h:432
 msgctxt "title"
 msgid "Warzone 2100"
 msgstr "وورزون 2100 (ساحة الحرب 2100)"
 
-#: content/Default/apps/content.json.h:424
+#: content/Default/apps/content.json.h:433
 msgctxt "subtitle"
 msgid "Lead your troops to rebuild the world"
 msgstr "قُد قواتك لإعادة بناء العالم"
 
-#: content/Default/apps/content.json.h:425
+#: content/Default/apps/content.json.h:434
 msgctxt "description"
 msgid ""
 "In Warzone 2100 you command forces to rebuild the world after nuclear war "
@@ -2890,17 +2910,17 @@ msgid ""
 "of strategy, tactics, and wit."
 msgstr "في لعبة وورزون 2100 يقود اللاعب القوات العسكرية لإعادة بناء العالم بعد أن دمرته الحرب النووية. بأمكانك أن تلعبها وحدك أو مع الأصدقاء. وفي كلتا الحالتين عليك الغوص في عالم آخر حيث تعيش وتتنفس فيه الاستراتيجيات العسكرية. ففي هذه اللعبة تجد التقنيات البحثية، وبناء الوحدات، وتخطيط المعارك، والتكتيكات، والذكاء و الحنكة."
 
-#: content/Default/apps/content.json.h:426
+#: content/Default/apps/content.json.h:435
 msgctxt "title"
 msgid "Wesnoth"
 msgstr "لعبة ويزنوث "
 
-#: content/Default/apps/content.json.h:427
+#: content/Default/apps/content.json.h:436
 msgctxt "subtitle"
 msgid "Fantasy turn-based strategy game"
 msgstr "لعبة استراتيجية قائمة على تبدل الخيال"
 
-#: content/Default/apps/content.json.h:428
+#: content/Default/apps/content.json.h:437
 msgctxt "description"
 msgid ""
 "Battle for control of the land, villages, and resources in this fantasy-"
@@ -2909,17 +2929,17 @@ msgid ""
 "strategy, this game is sure to reveal a great leader inside you."
 msgstr "حارب من أجل السيطرة على الأرض والقرى والموارد في هذه اللعبة الاستراتيجية الخيالية . كل لاعب يسيطر على جيش من تصميمه ويستخدمه سعياً للهيمنة. تعتبر هذه اللعبة مزيجاً مثيرً من التاريخ، والخيال، والإستراتيجية، ومن المؤكد أن تكشف عن وجود القائد العظيم بداخلك."
 
-#: content/Default/apps/content.json.h:429
+#: content/Default/apps/content.json.h:438
 msgctxt "title"
 msgid "X-Moto"
 msgstr "اكس ماتو"
 
-#: content/Default/apps/content.json.h:430
+#: content/Default/apps/content.json.h:439
 msgctxt "subtitle"
 msgid "A motorcycle racing game"
 msgstr "لعبة سباق دراجات نارية"
 
-#: content/Default/apps/content.json.h:431
+#: content/Default/apps/content.json.h:440
 msgctxt "description"
 msgid ""
 "Love motorcycles? Then you're going to love this racing game where physics "
@@ -2929,17 +2949,17 @@ msgid ""
 "time in this fast-paced, exciting test of speed!"
 msgstr "أتحب الدراجات النارية؟ إن كنت كذلك فستحب لعبة السباق هذه و التي تلعب حركات الجسد دورا مهما في الفوز! يجب عليك السيطرة على الدراجة الخاصة بك إلى أقصى حدودك الجسدية إذا كنت تريد أن يكون لك فرصة الانتهاء من الدورات الصعبة. تعرف على العلوم ومارس مهارات السباق الخاصة بك في نفس الوقت  في هذه اللعبة ذات الوتيرة السريعة، واختبر السرعة مثيرة!"
 
-#: content/Default/apps/content.json.h:432
+#: content/Default/apps/content.json.h:441
 msgctxt "title"
 msgid "KBlocks"
 msgstr "كي بلوكس"
 
-#: content/Default/apps/content.json.h:433
+#: content/Default/apps/content.json.h:442
 msgctxt "subtitle"
 msgid "Match blocks to destroy them and win"
 msgstr "طابق القطع لتدميرها و الفوز"
 
-#: content/Default/apps/content.json.h:434
+#: content/Default/apps/content.json.h:443
 msgctxt "description"
 msgid ""
 "This game is similar to Tetris, so if you love that game, you will love this"
@@ -2948,17 +2968,17 @@ msgid ""
 " lose, so pay attention and get ready for some very fast-actioned fun!"
 msgstr "تشبه هذه اللعبة لعبة تتريس، لذلك إذا كنت تحب تلك اللعبة، فإنك سوف تحب هذه اللعبة! قم بمطابقة الأشكال مع بعضها لجعلها تختفي ومنعها من ملء الشاشة. ستحتاج إلى أن تكون سريعا و إلا ستخسر، لذلك ركز و تجهز لبعض المرح السريع جدا!"
 
-#: content/Default/apps/content.json.h:435
+#: content/Default/apps/content.json.h:444
 msgctxt "title"
 msgid "KBounce"
 msgstr "كي باونس"
 
-#: content/Default/apps/content.json.h:436
+#: content/Default/apps/content.json.h:445
 msgctxt "subtitle"
 msgid "The ball-bouncing game sure to hook you"
 msgstr "لابد أن تأسرك لعبة الكرة المرتدة هذه"
 
-#: content/Default/apps/content.json.h:437
+#: content/Default/apps/content.json.h:446
 msgctxt "description"
 msgid ""
 "This is a fun game with a simple goal: you must build walls to decrease the "
@@ -2968,17 +2988,17 @@ msgid ""
 "It requires quick thinking and fast reflexes!"
 msgstr "هذه لعبة ممتعة وهدفها بسيط: يجب بناء الجدران لتقليل المنطقة التي تتحرك بها الكرة المرتدة على الشاشة. وبمجرد ملء معظم الشاشة بالجدران، ستكون قادراً على الانتقال إلى المستوى التالي. تمتاز هذه اللعبة بلمسة حل الألغاز، وسرعة الخطى وعنصر التسلية. كما أنها تتطلب التفكير السريع وردود الفعل السريعة!"
 
-#: content/Default/apps/content.json.h:438
+#: content/Default/apps/content.json.h:447
 msgctxt "title"
 msgid "KDiamond"
 msgstr "كيدايموند"
 
-#: content/Default/apps/content.json.h:439
+#: content/Default/apps/content.json.h:448
 msgctxt "subtitle"
 msgid "Create lines of three diamonds"
 msgstr "أنشئ اسطر من ثلاث ماسات"
 
-#: content/Default/apps/content.json.h:440
+#: content/Default/apps/content.json.h:449
 msgctxt "description"
 msgid ""
 "In this fast-paced game, your job is to build lines of three diamonds of the"
@@ -2989,17 +3009,17 @@ msgid ""
 "many age levels."
 msgstr "في هذه اللعبة سريعة الوتيرة، تكمن مهمتك في تشكيل أسطر من ثلاث ماسات من نفس النوع. ببساطة قم بمبادلة الماس مع الأسطر المجاورة لتشكيل خطوطك. وأفضل شيء أن تقوم بذلك بسرعة وذلك حتى تتمكن من بناء العديد من لأسطر قبل انتهاء الجولة! هذه لعبة سهلة ومسلية للغاية و يمكن أن تلعبها لوقت قصير، أو لساعات طويلة. إنها ممتعة وسريعة ورائعة لكثير من المستويات العمرية."
 
-#: content/Default/apps/content.json.h:441
+#: content/Default/apps/content.json.h:450
 msgctxt "title"
 msgid "KJumpingCube"
 msgstr "كي جمبينج كيوب"
 
-#: content/Default/apps/content.json.h:442
+#: content/Default/apps/content.json.h:451
 msgctxt "subtitle"
 msgid "Develop a good strategy to conquer all the squares"
 msgstr "قم بتطوير استراتيجية جيدة للإستيلاء على كل المربعات (المساحات)."
 
-#: content/Default/apps/content.json.h:443
+#: content/Default/apps/content.json.h:452
 msgctxt "description"
 msgid ""
 "Practice your strategic thinking with this challenging dice-based game! You "
@@ -3014,17 +3034,17 @@ msgid ""
 " toes! "
 msgstr "تدرب على التفكير الاستراتيجي الخاص بك في هذه اللعبة المليئة بالتحديات والتي تعتمد على النرد! فأنت تتحرك بالنقر على المربع الشاغر أو على أحد المربعات التي تملكها. إذا قمت بالنقر على مربع شاغر، يتغير لونه ليُظهر ملكيتك له في حينها. في كل مرةٍ تنقر فيها على أحد المربعات، تزيد قيمته بواحد. بمجرد أن يكون بالمربع نقاط أكثر من الجيران المحيطين، فإن نقاطه يتم توزيعها بين هؤلاء الجيران (تقفز النقاط في جميع الأنحاء). إذا امتلك منافسك مربع مُجاورلك، تُسيطر أنت على هذا المربع وعلى ما جميع ما به من نقاط. ستحتاج إلى تفكيرٍ عميق لكي تستطيع السيطرة على جميع المربعات، ولأن النرد يمكنه تغيير الأوضاع بسرعة كبيرة، فهذه اللعبة بكل تأكيدٍ ستبقيك مشغولاً بها وستحفز انتباهك للغاية!"
 
-#: content/Default/apps/content.json.h:444
+#: content/Default/apps/content.json.h:453
 msgctxt "title"
 msgid "KSame"
 msgstr "كي سيم"
 
-#: content/Default/apps/content.json.h:445
+#: content/Default/apps/content.json.h:454
 msgctxt "subtitle"
 msgid "Get rid of all the marbles to win"
 msgstr "تخلص من جميع القطع للفوز"
 
-#: content/Default/apps/content.json.h:446
+#: content/Default/apps/content.json.h:455
 msgctxt "description"
 msgid ""
 "Show off your pattern-finding skills in this addicting game. Match all of "
@@ -3034,17 +3054,17 @@ msgid ""
 " challenge. A really fun challenge!"
 msgstr "إستعرض مهارات التقصي الخاصة بك في هذه اللعبة التي تسبب التعلق الشديد بها. طابق كل المساحات ذات اللون الواحد لتفرغ اللوح والفوز، ولكن تذكر: كلما أفرغت المساحات بشكل أكبر وفي آن واحد، ترتفع درجاتك. لذلك فكر بشكل استراتيجي بكل التحركات الخاصة بك! وما قد يبدو سهل في البداية هو التحدي الحقيقي. تحدي حقا ممتع!"
 
-#: content/Default/apps/content.json.h:447
+#: content/Default/apps/content.json.h:456
 msgctxt "title"
 msgid "Open Arena"
 msgstr "الساحة الرياضية المفتوحة"
 
-#: content/Default/apps/content.json.h:448
+#: content/Default/apps/content.json.h:457
 msgctxt "subtitle"
 msgid "Shoot your way out of trouble in this fun game"
 msgstr "أكمل طريقك بعيدا عن المشاكل بإطلاق النار في هذه اللعبة الممتعة"
 
-#: content/Default/apps/content.json.h:449
+#: content/Default/apps/content.json.h:458
 msgctxt "description"
 msgid ""
 "If arena battles are your idea of a good time, then you’ll love this "
@@ -3054,7 +3074,7 @@ msgid ""
 "of these modes offers its own form of excitement as you battle your enemies!"
 msgstr "إذا كانت فكرتك عن قضاء الوقت الجيد هي التواجد في الساحات القتالية، فلابد أن تحب هذا التطبيق. ولكن عليك الحذر-  فهذه لعبة تحتوي على مهارات خطيرة، وإراقة الدماء. قم باستخدام أنماط مختلفة من الأسلحة في هذه المنافسات، مثل نمط \"الأستيلاء على العلم\"، أو \"مباراة الموت\"، أو \"موت فريق\"، أو \"آخر رجل واقف\"، أو \"البطولة\". كل نمط من هذه الأنماط  يوفر شكلا خاصا به من الإثارة وانت تقاتل عدوك!"
 
-#: content/Default/apps/content.json.h:159
+#: content/Default/apps/content.json.h:171
 msgctxt "description"
 msgid ""
 "Need to safely store all of your important documents, photos, songs, and "

--- a/po/eos-shell-content.pot
+++ b/po/eos-shell-content.pot
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: eos-shell-content 1.0.99\n"
 "Report-Msgid-Bugs-To: https://www.transifex.com/projects/p/eos-shell-"
 "content/\n"
-"POT-Creation-Date: 2015-02-24 12:56-0800\n"
+"POT-Creation-Date: 2015-02-24 16:21-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -546,7 +546,7 @@ msgid "Curriculum"
 msgstr ""
 
 #: content/Default/apps/content.json.h:83
-#: content/Default/apps/content.json.h:229
+#: content/Default/apps/content.json.h:241
 msgctxt "subtitle"
 msgid "From the Guatemalan Ministry of Education"
 msgstr ""
@@ -843,16 +843,34 @@ msgid ""
 msgstr ""
 
 #: content/Default/apps/content.json.h:124
+#: content/Default/apps/content.json.h:127
 msgctxt "title"
 msgid "Football"
 msgstr ""
 
 #: content/Default/apps/content.json.h:125
+#: content/Default/apps/content.json.h:137
+#: content/Default/apps/content.json.h:161
+msgctxt "subtitle"
+msgid "Deprecated version"
+msgstr ""
+
+#: content/Default/apps/content.json.h:126
+#: content/Default/apps/content.json.h:138
+#: content/Default/apps/content.json.h:162
+msgctxt "description"
+msgid ""
+"If you have internet access, there may be a newer version of this "
+"application available to download and install. In the meantime, you may "
+"continue to use this version that is already installed on your computer."
+msgstr ""
+
+#: content/Default/apps/content.json.h:128
 msgctxt "subtitle"
 msgid "Learn about your favorite team and players"
 msgstr ""
 
-#: content/Default/apps/content.json.h:126
+#: content/Default/apps/content.json.h:129
 msgctxt "description"
 msgid ""
 "Football is a major sport with fans all around the world. Are you one of "
@@ -862,17 +880,17 @@ msgid ""
 "with thousands of articles about your favorite sport!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:127
+#: content/Default/apps/content.json.h:130
 msgctxt "title"
 msgid "Social Enterprises"
 msgstr ""
 
-#: content/Default/apps/content.json.h:128
+#: content/Default/apps/content.json.h:131
 msgctxt "subtitle"
 msgid "All about non-profit organizations"
 msgstr ""
 
-#: content/Default/apps/content.json.h:129
+#: content/Default/apps/content.json.h:132
 msgctxt "description"
 msgid ""
 "Have you thought of starting your own non-profit organization, or of joining "
@@ -882,17 +900,17 @@ msgid ""
 "your impact in the world even larger!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:130
+#: content/Default/apps/content.json.h:133
 msgctxt "title"
 msgid "Social Sciences"
 msgstr ""
 
-#: content/Default/apps/content.json.h:131
+#: content/Default/apps/content.json.h:134
 msgctxt "subtitle"
 msgid "Subjects that explore the individual and society"
 msgstr ""
 
-#: content/Default/apps/content.json.h:132
+#: content/Default/apps/content.json.h:135
 msgctxt "description"
 msgid ""
 "Human beings and the relationships and societies they form are complicated. "
@@ -904,17 +922,39 @@ msgid ""
 "understanding of human behavior."
 msgstr ""
 
-#: content/Default/apps/content.json.h:133
+#: content/Default/apps/content.json.h:136
+#: content/Default/apps/content.json.h:139
+msgctxt "title"
+msgid "Textbooks"
+msgstr ""
+
+#: content/Default/apps/content.json.h:140
+msgctxt "subtitle"
+msgid "Math and science textbooks"
+msgstr ""
+
+#: content/Default/apps/content.json.h:141
+msgctxt "description"
+msgid ""
+"Find information to help you with your homework, or learn about a subject "
+"you've always wanted to know more about! You can scroll through photos, "
+"tables, and graphs to learn more about each. Not only are these textbooks "
+"very thorough and informative, but they are also easy to read and helpful. "
+"Whether you’re a student, parent, teacher, or just someone eager to learn, "
+"you'll be sure to find something interesting and useful here!"
+msgstr ""
+
+#: content/Default/apps/content.json.h:142
 msgctxt "title"
 msgid "Translate"
 msgstr ""
 
-#: content/Default/apps/content.json.h:134
+#: content/Default/apps/content.json.h:143
 msgctxt "subtitle"
 msgid "Translate text between many languages instantly"
 msgstr ""
 
-#: content/Default/apps/content.json.h:135
+#: content/Default/apps/content.json.h:144
 msgctxt "description"
 msgid ""
 "Download this app to help you understand and be understood in virtually any "
@@ -925,17 +965,17 @@ msgid ""
 "– with the world’s languages at your fingertips.  **Requires internet"
 msgstr ""
 
-#: content/Default/apps/content.json.h:136
+#: content/Default/apps/content.json.h:145
 msgctxt "title"
 msgid "Travel"
 msgstr ""
 
-#: content/Default/apps/content.json.h:137
+#: content/Default/apps/content.json.h:146
 msgctxt "subtitle"
 msgid "Travel around the world from your living room"
 msgstr ""
 
-#: content/Default/apps/content.json.h:138
+#: content/Default/apps/content.json.h:147
 msgctxt "description"
 msgid ""
 "The world is an amazing and beautiful place! Start exploring it with this "
@@ -946,17 +986,17 @@ msgid ""
 "sites in the world!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:139
+#: content/Default/apps/content.json.h:148
 msgctxt "title"
 msgid "Typing"
 msgstr ""
 
-#: content/Default/apps/content.json.h:140
+#: content/Default/apps/content.json.h:149
 msgctxt "subtitle"
 msgid "Learn to type with games and songs"
 msgstr ""
 
-#: content/Default/apps/content.json.h:141
+#: content/Default/apps/content.json.h:150
 msgctxt "description"
 msgid ""
 "How fast can you type? Whether you're already fast or just learning how to "
@@ -967,17 +1007,17 @@ msgid ""
 "now it can be a whole lot of fun too!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:142
+#: content/Default/apps/content.json.h:151
 msgctxt "title"
 msgid "Virtual School"
 msgstr ""
 
-#: content/Default/apps/content.json.h:143
+#: content/Default/apps/content.json.h:152
 msgctxt "subtitle"
 msgid "Free educational videos on almost any subject"
 msgstr ""
 
-#: content/Default/apps/content.json.h:144
+#: content/Default/apps/content.json.h:153
 msgctxt "description"
 msgid ""
 "Learning is easy and fun with video courses on subjects like math, biology, "
@@ -989,17 +1029,17 @@ msgid ""
 "this app and these videos can help you succeed in school and in life!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:145
+#: content/Default/apps/content.json.h:154
 msgctxt "title"
 msgid "Sanitation"
 msgstr ""
 
-#: content/Default/apps/content.json.h:146
+#: content/Default/apps/content.json.h:155
 msgctxt "subtitle"
 msgid "All about clean water and sanitation"
 msgstr ""
 
-#: content/Default/apps/content.json.h:147
+#: content/Default/apps/content.json.h:156
 msgctxt "description"
 msgid ""
 "Drinking clean water is essential for survival. There can often be terrible "
@@ -1008,17 +1048,17 @@ msgid ""
 "that you create a sanitary environment around you where you can thrive. "
 msgstr ""
 
-#: content/Default/apps/content.json.h:148
+#: content/Default/apps/content.json.h:157
 msgctxt "title"
 msgid "Weather"
 msgstr ""
 
-#: content/Default/apps/content.json.h:149
+#: content/Default/apps/content.json.h:158
 msgctxt "subtitle"
 msgid "Get daily local forecasts from trusted sources"
 msgstr ""
 
-#: content/Default/apps/content.json.h:150
+#: content/Default/apps/content.json.h:159
 msgctxt "description"
 msgid ""
 "“How’s the weather out there?” Answer this question easily, every day, with "
@@ -1028,17 +1068,18 @@ msgid ""
 "about the weather to take advantage of your day!  **Requires internet"
 msgstr ""
 
-#: content/Default/apps/content.json.h:151
+#: content/Default/apps/content.json.h:160
+#: content/Default/apps/content.json.h:163
 msgctxt "title"
 msgid "World Literature"
 msgstr ""
 
-#: content/Default/apps/content.json.h:152
+#: content/Default/apps/content.json.h:164
 msgctxt "subtitle"
 msgid "Read all of the world's great literature"
 msgstr ""
 
-#: content/Default/apps/content.json.h:153
+#: content/Default/apps/content.json.h:165
 msgctxt "description"
 msgid ""
 "Find some of your favorite books in this app! To begin browsing, open the "
@@ -1050,17 +1091,17 @@ msgid ""
 "entertained for hours expanding your literary knowledge."
 msgstr ""
 
-#: content/Default/apps/content.json.h:154
+#: content/Default/apps/content.json.h:166
 msgctxt "title"
 msgid "YouVideos"
 msgstr ""
 
-#: content/Default/apps/content.json.h:155
+#: content/Default/apps/content.json.h:167
 msgctxt "subtitle"
 msgid "Discover and share great videos online"
 msgstr ""
 
-#: content/Default/apps/content.json.h:156
+#: content/Default/apps/content.json.h:168
 msgctxt "description"
 msgid ""
 "This app makes finding videos on the popular video site, YouTube, and "
@@ -1071,27 +1112,27 @@ msgid ""
 "family, and the world!  ** Requires internet"
 msgstr ""
 
-#: content/Default/apps/content.json.h:157
+#: content/Default/apps/content.json.h:169
 msgctxt "title"
 msgid "Dropbox"
 msgstr ""
 
-#: content/Default/apps/content.json.h:158
+#: content/Default/apps/content.json.h:170
 msgctxt "subtitle"
 msgid "Access your files from any computer"
 msgstr ""
 
-#: content/Default/apps/content.json.h:162
+#: content/Default/apps/content.json.h:174
 msgctxt "title"
 msgid "Chat"
 msgstr ""
 
-#: content/Default/apps/content.json.h:163
+#: content/Default/apps/content.json.h:175
 msgctxt "subtitle"
 msgid "Chat with all of your friends in one place"
 msgstr ""
 
-#: content/Default/apps/content.json.h:164
+#: content/Default/apps/content.json.h:176
 msgctxt "description"
 msgid ""
 "Do you love to chat with friends? And, do you use many different programs to "
@@ -1104,17 +1145,17 @@ msgid ""
 "family easier than ever before!  **Requires internet"
 msgstr ""
 
-#: content/Default/apps/content.json.h:165
+#: content/Default/apps/content.json.h:177
 msgctxt "title"
 msgid "Documents"
 msgstr ""
 
-#: content/Default/apps/content.json.h:166
+#: content/Default/apps/content.json.h:178
 msgctxt "subtitle"
 msgid "Access all of your documents and files"
 msgstr ""
 
-#: content/Default/apps/content.json.h:167
+#: content/Default/apps/content.json.h:179
 msgctxt "description"
 msgid ""
 "Get organized with this app, which helps you find all of your documents and "
@@ -1125,17 +1166,17 @@ msgid ""
 "special photo again."
 msgstr ""
 
-#: content/Default/apps/content.json.h:168
+#: content/Default/apps/content.json.h:180
 msgctxt "title"
 msgid "E-mail"
 msgstr ""
 
-#: content/Default/apps/content.json.h:169
+#: content/Default/apps/content.json.h:181
 msgctxt "subtitle"
 msgid "Your e-mail, address book and calendar in one place"
 msgstr ""
 
-#: content/Default/apps/content.json.h:170
+#: content/Default/apps/content.json.h:182
 msgctxt "description"
 msgid ""
 "Staying in touch is an important part of modern life, and email has become "
@@ -1146,17 +1187,17 @@ msgid ""
 "**Requires internet"
 msgstr ""
 
-#: content/Default/apps/content.json.h:171
+#: content/Default/apps/content.json.h:183
 msgctxt "title"
 msgid "Tux Racer"
 msgstr ""
 
-#: content/Default/apps/content.json.h:172
+#: content/Default/apps/content.json.h:184
 msgctxt "subtitle"
 msgid "Race down icy mountains"
 msgstr ""
 
-#: content/Default/apps/content.json.h:173
+#: content/Default/apps/content.json.h:185
 msgctxt "description"
 msgid ""
 "Make it down a snow and ice-covered mountain as quickly as possible in this "
@@ -1165,17 +1206,17 @@ msgid ""
 "get your heart racing, this game is a must play for any adrenaline addict."
 msgstr ""
 
-#: content/Default/apps/content.json.h:174
+#: content/Default/apps/content.json.h:186
 msgctxt "title"
 msgid "Four in a Row"
 msgstr ""
 
-#: content/Default/apps/content.json.h:175
+#: content/Default/apps/content.json.h:187
 msgctxt "subtitle"
 msgid "A simple and addictive game for kids and adults"
 msgstr ""
 
-#: content/Default/apps/content.json.h:176
+#: content/Default/apps/content.json.h:188
 msgctxt "description"
 msgid ""
 "This classic game is great for both children and adults alike! The goal is "
@@ -1187,17 +1228,17 @@ msgid ""
 "fun game!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:177
+#: content/Default/apps/content.json.h:189
 msgctxt "title"
 msgid "FreeCiv"
 msgstr ""
 
-#: content/Default/apps/content.json.h:178
+#: content/Default/apps/content.json.h:190
 msgctxt "subtitle"
 msgid "Guide your own civilization to greatness"
 msgstr ""
 
-#: content/Default/apps/content.json.h:179
+#: content/Default/apps/content.json.h:191
 msgctxt "description"
 msgid ""
 "Create your own world with this action-packed game that lets you travel "
@@ -1209,17 +1250,17 @@ msgid ""
 "conquering the moon and beyond!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:180
+#: content/Default/apps/content.json.h:192
 msgctxt "title"
 msgid "FreeCol"
 msgstr ""
 
-#: content/Default/apps/content.json.h:181
+#: content/Default/apps/content.json.h:193
 msgctxt "subtitle"
 msgid "Create your own country and conquer the world"
 msgstr ""
 
-#: content/Default/apps/content.json.h:182
+#: content/Default/apps/content.json.h:194
 msgctxt "description"
 msgid ""
 "Have you ever wanted to start your own country? Well, now you can. Go back "
@@ -1229,17 +1270,17 @@ msgid ""
 "prosperity? You decide."
 msgstr ""
 
-#: content/Default/apps/content.json.h:183
+#: content/Default/apps/content.json.h:195
 msgctxt "title"
 msgid "FrostTorrent"
 msgstr ""
 
-#: content/Default/apps/content.json.h:184
+#: content/Default/apps/content.json.h:196
 msgctxt "subtitle"
 msgid "Download nearly anything or share your own files"
 msgstr ""
 
-#: content/Default/apps/content.json.h:185
+#: content/Default/apps/content.json.h:197
 msgctxt "description"
 msgid ""
 "Access, download and share almost any file you'd like to with this useful "
@@ -1251,17 +1292,17 @@ msgid ""
 "**Requires Internet"
 msgstr ""
 
-#: content/Default/apps/content.json.h:186
+#: content/Default/apps/content.json.h:198
 msgctxt "title"
 msgid "Frozen Bubbles"
 msgstr ""
 
-#: content/Default/apps/content.json.h:187
+#: content/Default/apps/content.json.h:199
 msgctxt "subtitle"
 msgid "Pop bubbles before they all come crashing down"
 msgstr ""
 
-#: content/Default/apps/content.json.h:188
+#: content/Default/apps/content.json.h:200
 msgctxt "description"
 msgid ""
 "Play by yourself or challenge your friends to an exciting game of frozen "
@@ -1270,17 +1311,17 @@ msgid ""
 "have a good strategy and develop a quick trigger finger in order to win!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:189
+#: content/Default/apps/content.json.h:201
 msgctxt "title"
 msgid "EduGames"
 msgstr ""
 
-#: content/Default/apps/content.json.h:190
+#: content/Default/apps/content.json.h:202
 msgctxt "subtitle"
 msgid "Puzzles, memory games, and more for kids"
 msgstr ""
 
-#: content/Default/apps/content.json.h:191
+#: content/Default/apps/content.json.h:203
 msgctxt "description"
 msgid ""
 "This app makes learning fun for young children with more than 100 games and "
@@ -1290,17 +1331,17 @@ msgid ""
 "him or her throughout life."
 msgstr ""
 
-#: content/Default/apps/content.json.h:192
+#: content/Default/apps/content.json.h:204
 msgctxt "title"
 msgid "EduGames Admin"
 msgstr ""
 
-#: content/Default/apps/content.json.h:193
+#: content/Default/apps/content.json.h:205
 msgctxt "subtitle"
 msgid "For teachers to help their students learn"
 msgstr ""
 
-#: content/Default/apps/content.json.h:194
+#: content/Default/apps/content.json.h:206
 msgctxt "description"
 msgid ""
 "Use this app to configure the EduGames app and create the exact learning "
@@ -1311,17 +1352,17 @@ msgid ""
 "fun that they'll want to spend hours doing just what you want them to!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:195
+#: content/Default/apps/content.json.h:207
 msgctxt "title"
 msgid "Gedit"
 msgstr ""
 
-#: content/Default/apps/content.json.h:196
+#: content/Default/apps/content.json.h:208
 msgctxt "subtitle"
 msgid "A simple text editor for all of your text editing needs"
 msgstr ""
 
-#: content/Default/apps/content.json.h:197
+#: content/Default/apps/content.json.h:209
 msgctxt "description"
 msgid ""
 "Use this simple app to create and edit files that require plain text inputs. "
@@ -1330,17 +1371,17 @@ msgid ""
 "should be perfect for all of your text editing needs."
 msgstr ""
 
-#: content/Default/apps/content.json.h:198
+#: content/Default/apps/content.json.h:210
 msgctxt "title"
 msgid "GIMP"
 msgstr ""
 
-#: content/Default/apps/content.json.h:199
+#: content/Default/apps/content.json.h:211
 msgctxt "subtitle"
 msgid "Advanced image editing tool similar to Photoshop"
 msgstr ""
 
-#: content/Default/apps/content.json.h:200
+#: content/Default/apps/content.json.h:212
 msgctxt "description"
 msgid ""
 "Edit your photos to create even more beautiful works of art with this "
@@ -1352,17 +1393,17 @@ msgid ""
 "images once you get the hang of this helpful editing app!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:201
+#: content/Default/apps/content.json.h:213
 msgctxt "title"
 msgid "Calculator"
 msgstr ""
 
-#: content/Default/apps/content.json.h:202
+#: content/Default/apps/content.json.h:214
 msgctxt "subtitle"
 msgid "A scientific calculator with many bonus tools"
 msgstr ""
 
-#: content/Default/apps/content.json.h:203
+#: content/Default/apps/content.json.h:215
 msgctxt "description"
 msgid ""
 "Do you ever consider how often you need to do basic or even complex math in "
@@ -1374,17 +1415,17 @@ msgid ""
 "again as long as you have this calculator app!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:204
+#: content/Default/apps/content.json.h:216
 msgctxt "title"
 msgid "Math Plotting"
 msgstr ""
 
-#: content/Default/apps/content.json.h:205
+#: content/Default/apps/content.json.h:217
 msgctxt "subtitle"
 msgid "Interactive computation and data visualization tool"
 msgstr ""
 
-#: content/Default/apps/content.json.h:206
+#: content/Default/apps/content.json.h:218
 msgctxt "description"
 msgid ""
 "This math application offers advanced mathematical computing functions that "
@@ -1395,17 +1436,17 @@ msgid ""
 "here."
 msgstr ""
 
-#: content/Default/apps/content.json.h:207
+#: content/Default/apps/content.json.h:219
 msgctxt "title"
 msgid "Mines"
 msgstr ""
 
-#: content/Default/apps/content.json.h:208
+#: content/Default/apps/content.json.h:220
 msgctxt "subtitle"
 msgid "Find and avoid all the dangerous mines to win"
 msgstr ""
 
-#: content/Default/apps/content.json.h:209
+#: content/Default/apps/content.json.h:221
 msgctxt "description"
 msgid ""
 "Figure out where the dangerous mines are in order to stay alive and win the "
@@ -1415,17 +1456,17 @@ msgid ""
 "each direction. If you figure out where all the mines are, you'll win!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:210
+#: content/Default/apps/content.json.h:222
 msgctxt "title"
 msgid "Screenshot"
 msgstr ""
 
-#: content/Default/apps/content.json.h:211
+#: content/Default/apps/content.json.h:223
 msgctxt "subtitle"
 msgid "Take a picture of your screen to save"
 msgstr ""
 
-#: content/Default/apps/content.json.h:212
+#: content/Default/apps/content.json.h:224
 msgctxt "description"
 msgid ""
 "Do you ever wish you could take a picture of your screen to save? Well now "
@@ -1434,18 +1475,18 @@ msgid ""
 "make sure to save just what you need and nothing more."
 msgstr ""
 
-#: content/Default/apps/content.json.h:213
-#: content/Default/apps/content.json.h:297
+#: content/Default/apps/content.json.h:225
+#: content/Default/apps/content.json.h:306
 msgctxt "title"
 msgid "Sudoku"
 msgstr ""
 
-#: content/Default/apps/content.json.h:214
+#: content/Default/apps/content.json.h:226
 msgctxt "subtitle"
 msgid "One of the most popular puzzle games of all time"
 msgstr ""
 
-#: content/Default/apps/content.json.h:215
+#: content/Default/apps/content.json.h:227
 msgctxt "description"
 msgid ""
 "If you’re a fan of puzzles and math games, the Sudoku app is perfect for "
@@ -1456,17 +1497,17 @@ msgid ""
 "fun solving Sudoku puzzles and exercising your mind!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:216
+#: content/Default/apps/content.json.h:228
 msgctxt "title"
 msgid "Terminal"
 msgstr ""
 
-#: content/Default/apps/content.json.h:217
+#: content/Default/apps/content.json.h:229
 msgctxt "subtitle"
 msgid "Use the command line"
 msgstr ""
 
-#: content/Default/apps/content.json.h:218
+#: content/Default/apps/content.json.h:230
 msgctxt "description"
 msgid ""
 "If you're an advanced user and want to display system information and launch "
@@ -1476,17 +1517,17 @@ msgid ""
 "in correctly and to help you easily identify any mistakes you have made."
 msgstr ""
 
-#: content/Default/apps/content.json.h:219
+#: content/Default/apps/content.json.h:231
 msgctxt "title"
 msgid "Tetravex"
 msgstr ""
 
-#: content/Default/apps/content.json.h:220
+#: content/Default/apps/content.json.h:232
 msgctxt "subtitle"
 msgid "Race the clock in a numerical puzzle game"
 msgstr ""
 
-#: content/Default/apps/content.json.h:221
+#: content/Default/apps/content.json.h:233
 msgctxt "description"
 msgid ""
 "Try to match up all of the same numbers on the blocks to win this tricky "
@@ -1495,17 +1536,17 @@ msgid ""
 "beat your or your friends' best time!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:222
+#: content/Default/apps/content.json.h:234
 msgctxt "title"
 msgid "Notes"
 msgstr ""
 
-#: content/Default/apps/content.json.h:223
+#: content/Default/apps/content.json.h:235
 msgctxt "subtitle"
 msgid "Never lose a note again"
 msgstr ""
 
-#: content/Default/apps/content.json.h:224
+#: content/Default/apps/content.json.h:236
 msgctxt "description"
 msgid ""
 "Do you find yourself writing down lots of notes on pieces of paper that "
@@ -1516,17 +1557,17 @@ msgid ""
 "notes and stay even more organized!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:225
+#: content/Default/apps/content.json.h:237
 msgctxt "title"
 msgid "Dictionary"
 msgstr ""
 
-#: content/Default/apps/content.json.h:226
+#: content/Default/apps/content.json.h:238
 msgctxt "subtitle"
 msgid "A cool dictionary with lots of bonus tools"
 msgstr ""
 
-#: content/Default/apps/content.json.h:227
+#: content/Default/apps/content.json.h:239
 msgctxt "description"
 msgid ""
 "In reading and conversation, words often come up with which you’re not "
@@ -1536,12 +1577,12 @@ msgid ""
 "you’re looking for!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:228
+#: content/Default/apps/content.json.h:240
 msgctxt "title"
 msgid "GT Curriculum"
 msgstr ""
 
-#: content/Default/apps/content.json.h:230
+#: content/Default/apps/content.json.h:242
 msgctxt "description"
 msgid ""
 "Use this app to find the basic curriculum plan and guidelines for a specific "
@@ -1553,17 +1594,17 @@ msgid ""
 "your child's life and your own."
 msgstr ""
 
-#: content/Default/apps/content.json.h:231
+#: content/Default/apps/content.json.h:243
 msgctxt "title"
 msgid "EduCollections"
 msgstr ""
 
-#: content/Default/apps/content.json.h:232
+#: content/Default/apps/content.json.h:244
 msgctxt "subtitle"
 msgid "All sorts of information to help better your life"
 msgstr ""
 
-#: content/Default/apps/content.json.h:233
+#: content/Default/apps/content.json.h:245
 msgctxt "description"
 msgid ""
 "This app is full of reliable information sent directly from the Guatemalan "
@@ -1576,17 +1617,17 @@ msgid ""
 "your age."
 msgstr ""
 
-#: content/Default/apps/content.json.h:234
+#: content/Default/apps/content.json.h:246
 msgctxt "title"
 msgid "Health Guides"
 msgstr ""
 
-#: content/Default/apps/content.json.h:235
+#: content/Default/apps/content.json.h:247
 msgctxt "subtitle"
 msgid "Health guides that could save your life"
 msgstr ""
 
-#: content/Default/apps/content.json.h:236
+#: content/Default/apps/content.json.h:248
 msgctxt "description"
 msgid ""
 "This app contains some of the most life saving documents that you'll ever "
@@ -1595,38 +1636,17 @@ msgid ""
 "learn to help your loved ones, those in your community and even yourself!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:237
-msgctxt "title"
-msgid "Textbooks"
-msgstr ""
-
-#: content/Default/apps/content.json.h:238
-msgctxt "subtitle"
-msgid "Textbooks for students, parents and teachers"
-msgstr ""
-
-#: content/Default/apps/content.json.h:239
-msgctxt "description"
-msgid ""
-"Select a grade level and prepare yourself to learn directly from your "
-"computer! This app contains textbooks, worksheets and other learning tools, "
-"to teach or supplement your learning. Whether you're a student needing extra "
-"homework help, a parent helping to develop a child's education, or someone "
-"seeking to learn more in their spare time, you'll find this app to be "
-"incredibly useful."
-msgstr ""
-
-#: content/Default/apps/content.json.h:240
+#: content/Default/apps/content.json.h:249
 msgctxt "title"
 msgid "Iagno"
 msgstr ""
 
-#: content/Default/apps/content.json.h:241
+#: content/Default/apps/content.json.h:250
 msgctxt "subtitle"
 msgid "A fun puzzle game that involves lots of thought"
 msgstr ""
 
-#: content/Default/apps/content.json.h:242
+#: content/Default/apps/content.json.h:251
 msgctxt "description"
 msgid ""
 "Turn over the pieces in front of you so that they are all the same color. "
@@ -1637,17 +1657,17 @@ msgid ""
 "strategically and see if you can figure this puzzle out!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:243
+#: content/Default/apps/content.json.h:252
 msgctxt "title"
 msgid "Inkscape"
 msgstr ""
 
-#: content/Default/apps/content.json.h:244
+#: content/Default/apps/content.json.h:253
 msgctxt "subtitle"
 msgid "An advanced graphic design tool"
 msgstr ""
 
-#: content/Default/apps/content.json.h:245
+#: content/Default/apps/content.json.h:254
 msgctxt "description"
 msgid ""
 "This app is for intermediate and advanced graphic designers who need to "
@@ -1658,17 +1678,17 @@ msgid ""
 "presentations and artwork with this great free graphics app!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:246
+#: content/Default/apps/content.json.h:255
 msgctxt "title"
 msgid "Kalzium"
 msgstr ""
 
-#: content/Default/apps/content.json.h:247
+#: content/Default/apps/content.json.h:256
 msgctxt "subtitle"
 msgid "A fun interactive periodic table of elements"
 msgstr ""
 
-#: content/Default/apps/content.json.h:248
+#: content/Default/apps/content.json.h:257
 msgctxt "description"
 msgid ""
 "The periodic table of the elements is one of the basic building blocks of "
@@ -1681,17 +1701,17 @@ msgid ""
 "simple, and informative app."
 msgstr ""
 
-#: content/Default/apps/content.json.h:249
+#: content/Default/apps/content.json.h:258
 msgctxt "title"
 msgid "Kapman"
 msgstr ""
 
-#: content/Default/apps/content.json.h:250
+#: content/Default/apps/content.json.h:259
 msgctxt "subtitle"
 msgid "The classic game of ghosts and mazes"
 msgstr ""
 
-#: content/Default/apps/content.json.h:251
+#: content/Default/apps/content.json.h:260
 msgctxt "description"
 msgid ""
 "If you love Pac-Man, then you you'll love this game too! Eat dots to gain "
@@ -1701,17 +1721,17 @@ msgid ""
 "and family, from kids to grandparents, will love the game, too!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:252
+#: content/Default/apps/content.json.h:261
 msgctxt "title"
 msgid "KAtomic"
 msgstr ""
 
-#: content/Default/apps/content.json.h:253
+#: content/Default/apps/content.json.h:262
 msgctxt "subtitle"
 msgid "A fun way to learn chemistry"
 msgstr ""
 
-#: content/Default/apps/content.json.h:254
+#: content/Default/apps/content.json.h:263
 msgctxt "description"
 msgid ""
 "If you’re struggling with concepts in chemistry, or simply looking for a way "
@@ -1723,17 +1743,17 @@ msgid ""
 "a ton!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:255
+#: content/Default/apps/content.json.h:264
 msgctxt "title"
 msgid "KBlackBox"
 msgstr ""
 
-#: content/Default/apps/content.json.h:256
+#: content/Default/apps/content.json.h:265
 msgctxt "subtitle"
 msgid "Find the pattern and uncover the hidden balls"
 msgstr ""
 
-#: content/Default/apps/content.json.h:257
+#: content/Default/apps/content.json.h:266
 msgctxt "description"
 msgid ""
 "This game takes some serious logic, but don’t be scared away – it’s also "
@@ -1743,17 +1763,17 @@ msgid ""
 "hidden ones are placed. The more you get right, the higher your score."
 msgstr ""
 
-#: content/Default/apps/content.json.h:258
+#: content/Default/apps/content.json.h:267
 msgctxt "title"
 msgid "KBruch"
 msgstr ""
 
-#: content/Default/apps/content.json.h:259
+#: content/Default/apps/content.json.h:268
 msgctxt "subtitle"
 msgid "Learn about fractions, percentages and more"
 msgstr ""
 
-#: content/Default/apps/content.json.h:260
+#: content/Default/apps/content.json.h:269
 msgctxt "description"
 msgid ""
 "One of the trickiest parts of the math we do every day is calculating "
@@ -1765,17 +1785,17 @@ msgid ""
 "benefit you in unexpected ways!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:261
+#: content/Default/apps/content.json.h:270
 msgctxt "title"
 msgid "KSnake"
 msgstr ""
 
-#: content/Default/apps/content.json.h:262
+#: content/Default/apps/content.json.h:271
 msgctxt "subtitle"
 msgid "A fun and very simple game for everyone"
 msgstr ""
 
-#: content/Default/apps/content.json.h:263
+#: content/Default/apps/content.json.h:272
 msgctxt "description"
 msgid ""
 "Similar to the popular arcade game, Snake, this classic game will help you "
@@ -1784,17 +1804,17 @@ msgid ""
 "snakes grow longer, promising a fun challenge to players of all levels."
 msgstr ""
 
-#: content/Default/apps/content.json.h:264
+#: content/Default/apps/content.json.h:273
 msgctxt "title"
 msgid "KGeography"
 msgstr ""
 
-#: content/Default/apps/content.json.h:265
+#: content/Default/apps/content.json.h:274
 msgctxt "subtitle"
 msgid "Become a geography genius while having fun"
 msgstr ""
 
-#: content/Default/apps/content.json.h:266
+#: content/Default/apps/content.json.h:275
 msgctxt "description"
 msgid ""
 "How much do you know about world geography and political affairs? Learn the "
@@ -1805,17 +1825,17 @@ msgid ""
 "and will have had a lot of fun learning it all!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:267
+#: content/Default/apps/content.json.h:276
 msgctxt "title"
 msgid "KGoldrunner"
 msgstr ""
 
-#: content/Default/apps/content.json.h:268
+#: content/Default/apps/content.json.h:277
 msgctxt "subtitle"
 msgid "Look for treasure and hide from enemies"
 msgstr ""
 
-#: content/Default/apps/content.json.h:269
+#: content/Default/apps/content.json.h:278
 msgctxt "description"
 msgid ""
 "Your enemies are right on your heels as you move through mazes collecting "
@@ -1825,17 +1845,17 @@ msgid ""
 "through any trapdoors!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:270
+#: content/Default/apps/content.json.h:279
 msgctxt "title"
 msgid "KHangMan"
 msgstr ""
 
-#: content/Default/apps/content.json.h:271
+#: content/Default/apps/content.json.h:280
 msgctxt "subtitle"
 msgid "One of the most fun word games on earth"
 msgstr ""
 
-#: content/Default/apps/content.json.h:272
+#: content/Default/apps/content.json.h:281
 msgctxt "description"
 msgid ""
 "Practice your vocabulary the fun way! You'll learn new words with this "
@@ -1847,17 +1867,17 @@ msgid ""
 "have to start over with a new word!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:273
+#: content/Default/apps/content.json.h:282
 msgctxt "title"
 msgid "Kigo"
 msgstr ""
 
-#: content/Default/apps/content.json.h:274
+#: content/Default/apps/content.json.h:283
 msgctxt "subtitle"
 msgid "The ancient game of skill, updated for modern play"
 msgstr ""
 
-#: content/Default/apps/content.json.h:275
+#: content/Default/apps/content.json.h:284
 msgctxt "description"
 msgid ""
 "Based on a two-player board game popular in Asia, this app has easy-to-learn "
@@ -1868,17 +1888,17 @@ msgid ""
 "If you like games like chess, then you'll love this great strategy game too!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:276
+#: content/Default/apps/content.json.h:285
 msgctxt "title"
 msgid "Killbots"
 msgstr ""
 
-#: content/Default/apps/content.json.h:277
+#: content/Default/apps/content.json.h:286
 msgctxt "subtitle"
 msgid "Outsmart the killer robots to win"
 msgstr ""
 
-#: content/Default/apps/content.json.h:278
+#: content/Default/apps/content.json.h:287
 msgctxt "description"
 msgid ""
 "How will you get away from the killer robots bent on destruction? Figure it "
@@ -1888,17 +1908,17 @@ msgid ""
 "tell the tale!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:279
+#: content/Default/apps/content.json.h:288
 msgctxt "title"
 msgid "Kolor Lines"
 msgstr ""
 
-#: content/Default/apps/content.json.h:280
+#: content/Default/apps/content.json.h:289
 msgctxt "subtitle"
 msgid "Line up balls of the same color to win"
 msgstr ""
 
-#: content/Default/apps/content.json.h:281
+#: content/Default/apps/content.json.h:290
 msgctxt "description"
 msgid ""
 "This game is so fun and addicting, you’ll never want to stop playing. The "
@@ -1909,17 +1929,17 @@ msgid ""
 "possible; you lose if it fills up completely!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:282
+#: content/Default/apps/content.json.h:291
 msgctxt "title"
 msgid "KMines"
 msgstr ""
 
-#: content/Default/apps/content.json.h:283
+#: content/Default/apps/content.json.h:292
 msgctxt "subtitle"
 msgid "Stay away from the exploding mines"
 msgstr ""
 
-#: content/Default/apps/content.json.h:284
+#: content/Default/apps/content.json.h:293
 msgctxt "description"
 msgid ""
 "Don't take a wrong step or you'll explode! You'll need to use logic and "
@@ -1927,17 +1947,17 @@ msgid ""
 "safely across the field."
 msgstr ""
 
-#: content/Default/apps/content.json.h:285
+#: content/Default/apps/content.json.h:294
 msgctxt "title"
 msgid "Battleships"
 msgstr ""
 
-#: content/Default/apps/content.json.h:286
+#: content/Default/apps/content.json.h:295
 msgctxt "subtitle"
 msgid "Blow your opponents out of the water"
 msgstr ""
 
-#: content/Default/apps/content.json.h:287
+#: content/Default/apps/content.json.h:296
 msgctxt "description"
 msgid ""
 "Try to guess where your enemies ships are to blow them out of the water "
@@ -1948,17 +1968,17 @@ msgid ""
 "Arrr you ready for some great naval fun?"
 msgstr ""
 
-#: content/Default/apps/content.json.h:288
+#: content/Default/apps/content.json.h:297
 msgctxt "title"
 msgid "KNetwalk"
 msgstr ""
 
-#: content/Default/apps/content.json.h:289
+#: content/Default/apps/content.json.h:298
 msgctxt "subtitle"
 msgid "Make the right cable connections and win"
 msgstr ""
 
-#: content/Default/apps/content.json.h:290
+#: content/Default/apps/content.json.h:299
 msgctxt "description"
 msgid ""
 "Who knew building computer networks could be fun? You'll need to create the "
@@ -1969,17 +1989,17 @@ msgid ""
 "enjoyable and competitive game you’ll love to play."
 msgstr ""
 
-#: content/Default/apps/content.json.h:291
+#: content/Default/apps/content.json.h:300
 msgctxt "title"
 msgid "Kobo Deluxe"
 msgstr ""
 
-#: content/Default/apps/content.json.h:292
+#: content/Default/apps/content.json.h:301
 msgctxt "subtitle"
 msgid "Destroy enemy bases in space"
 msgstr ""
 
-#: content/Default/apps/content.json.h:293
+#: content/Default/apps/content.json.h:302
 msgctxt "description"
 msgid ""
 "Fans of arcade-style games will love this fun shooting game. Protect "
@@ -1988,17 +2008,17 @@ msgid ""
 "play. You'll have hours and hours of fun blowing up things in space!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:294
+#: content/Default/apps/content.json.h:303
 msgctxt "title"
 msgid "KSquares"
 msgstr ""
 
-#: content/Default/apps/content.json.h:295
+#: content/Default/apps/content.json.h:304
 msgctxt "subtitle"
 msgid "Connect the dots in this challenging strategy game"
 msgstr ""
 
-#: content/Default/apps/content.json.h:296
+#: content/Default/apps/content.json.h:305
 msgctxt "description"
 msgid ""
 "Based on a popular old game, this fun app lets you stretch your mind and "
@@ -2009,12 +2029,12 @@ msgid ""
 "entertainment. Be careful – you just might become addicted!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:298
+#: content/Default/apps/content.json.h:307
 msgctxt "subtitle"
 msgid "A challenging numerical puzzle game"
 msgstr ""
 
-#: content/Default/apps/content.json.h:299
+#: content/Default/apps/content.json.h:308
 msgctxt "description"
 msgid ""
 "Are you better than your friend is at puzzles? Find out by playing this fun "
@@ -2026,17 +2046,17 @@ msgid ""
 "Sudoku, or are an experienced player, you'll love this app!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:300
+#: content/Default/apps/content.json.h:309
 msgctxt "title"
 msgid "KSnakeDuel"
 msgstr ""
 
-#: content/Default/apps/content.json.h:301
+#: content/Default/apps/content.json.h:310
 msgctxt "subtitle"
 msgid "Survival depends on your reflexes and wits"
 msgstr ""
 
-#: content/Default/apps/content.json.h:302
+#: content/Default/apps/content.json.h:311
 msgctxt "description"
 msgid ""
 "Guide your snake to eat the apples and to avoid the other snakes, balls and "
@@ -2047,17 +2067,17 @@ msgid ""
 "fun challenge!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:303
+#: content/Default/apps/content.json.h:312
 msgctxt "title"
 msgid "Potato Guy"
 msgstr ""
 
-#: content/Default/apps/content.json.h:304
+#: content/Default/apps/content.json.h:313
 msgctxt "subtitle"
 msgid "Give your potato a funny face"
 msgstr ""
 
-#: content/Default/apps/content.json.h:305
+#: content/Default/apps/content.json.h:314
 msgctxt "description"
 msgid ""
 "This is a silly game for children and their parents to play together. Based "
@@ -2067,17 +2087,17 @@ msgid ""
 "lots of laughter. Make the goofiest face you can!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:306
+#: content/Default/apps/content.json.h:315
 msgctxt "title"
 msgid "Kubrick"
 msgstr ""
 
-#: content/Default/apps/content.json.h:307
+#: content/Default/apps/content.json.h:316
 msgctxt "subtitle"
 msgid "Like Rubik's Cube - create solid color sides to win"
 msgstr ""
 
-#: content/Default/apps/content.json.h:308
+#: content/Default/apps/content.json.h:317
 msgctxt "description"
 msgid ""
 "This puzzling game has lots of options to keep your brain working! Modeled "
@@ -2089,17 +2109,17 @@ msgid ""
 "even design your very own challenge!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:309
+#: content/Default/apps/content.json.h:318
 msgctxt "title"
 msgid "KWordQuiz"
 msgstr ""
 
-#: content/Default/apps/content.json.h:310
+#: content/Default/apps/content.json.h:319
 msgctxt "subtitle"
 msgid "Grow your vocabulary and test your learning"
 msgstr ""
 
-#: content/Default/apps/content.json.h:311
+#: content/Default/apps/content.json.h:320
 msgctxt "description"
 msgid ""
 "Learning new words is a great way to speak and write more clearly, but "
@@ -2110,17 +2130,17 @@ msgid ""
 "learning all you want."
 msgstr ""
 
-#: content/Default/apps/content.json.h:312
+#: content/Default/apps/content.json.h:321
 msgctxt "title"
 msgid "Breakout"
 msgstr ""
 
-#: content/Default/apps/content.json.h:313
+#: content/Default/apps/content.json.h:322
 msgctxt "subtitle"
 msgid "Destroy all the bricks to win this fun game"
 msgstr ""
 
-#: content/Default/apps/content.json.h:314
+#: content/Default/apps/content.json.h:323
 msgctxt "description"
 msgid ""
 "This classic paddle game is tons of fun! The aim is to destroy bricks with "
@@ -2130,17 +2150,17 @@ msgid ""
 "graphics and animation, intuitive controls, and plenty of levels to beat."
 msgstr ""
 
-#: content/Default/apps/content.json.h:315
+#: content/Default/apps/content.json.h:324
 msgctxt "title"
 msgid "Spreadsheet"
 msgstr ""
 
-#: content/Default/apps/content.json.h:316
+#: content/Default/apps/content.json.h:325
 msgctxt "subtitle"
 msgid "A spreadsheet program with many functions"
 msgstr ""
 
-#: content/Default/apps/content.json.h:317
+#: content/Default/apps/content.json.h:326
 msgctxt "description"
 msgid ""
 "Whatever you need to keep track of, the spreadsheet app can help you do it. "
@@ -2151,17 +2171,17 @@ msgid ""
 "job market."
 msgstr ""
 
-#: content/Default/apps/content.json.h:318
+#: content/Default/apps/content.json.h:327
 msgctxt "title"
 msgid "Presentation"
 msgstr ""
 
-#: content/Default/apps/content.json.h:319
+#: content/Default/apps/content.json.h:328
 msgctxt "subtitle"
 msgid "Create great presentations with this easy-to-use app"
 msgstr ""
 
-#: content/Default/apps/content.json.h:320
+#: content/Default/apps/content.json.h:329
 msgctxt "description"
 msgid ""
 "Create clean, attractive, and professional presentations with this "
@@ -2171,17 +2191,17 @@ msgid ""
 "understand and use, with simplified steps for creating exactly what you need."
 msgstr ""
 
-#: content/Default/apps/content.json.h:321
+#: content/Default/apps/content.json.h:330
 msgctxt "title"
 msgid "Writer"
 msgstr ""
 
-#: content/Default/apps/content.json.h:322
+#: content/Default/apps/content.json.h:331
 msgctxt "subtitle"
 msgid "Free, similar to & compatible with Microsoft Word"
 msgstr ""
 
-#: content/Default/apps/content.json.h:323
+#: content/Default/apps/content.json.h:332
 msgctxt "description"
 msgid ""
 "This app gives you all the features of the best word processing applications "
@@ -2193,17 +2213,17 @@ msgid ""
 "notes; either way, you’ll have simple yet powerful tools available."
 msgstr ""
 
-#: content/Default/apps/content.json.h:324
+#: content/Default/apps/content.json.h:333
 msgctxt "title"
 msgid "Maps"
 msgstr ""
 
-#: content/Default/apps/content.json.h:325
+#: content/Default/apps/content.json.h:334
 msgctxt "subtitle"
 msgid "Maps of the entire world"
 msgstr ""
 
-#: content/Default/apps/content.json.h:326
+#: content/Default/apps/content.json.h:335
 msgctxt "description"
 msgid ""
 "Where do players from FC Barcelona or Real Madrid live? How far away are you "
@@ -2214,17 +2234,17 @@ msgid ""
 "changed over time!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:327
+#: content/Default/apps/content.json.h:336
 msgctxt "title"
 msgid "M.A.R.S."
 msgstr ""
 
-#: content/Default/apps/content.json.h:328
+#: content/Default/apps/content.json.h:337
 msgctxt "subtitle"
 msgid "A shooting game in space"
 msgstr ""
 
-#: content/Default/apps/content.json.h:329
+#: content/Default/apps/content.json.h:338
 msgctxt "description"
 msgid ""
 "In the year 3547, civilizations across the galaxy have settled their own "
@@ -2237,17 +2257,17 @@ msgid ""
 "keep playing until you succeed in returning peace to your planet!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:330
+#: content/Default/apps/content.json.h:339
 msgctxt "title"
 msgid "MegaGlest"
 msgstr ""
 
-#: content/Default/apps/content.json.h:331
+#: content/Default/apps/content.json.h:340
 msgctxt "subtitle"
 msgid "A fantasy world with kings, queens and magic"
 msgstr ""
 
-#: content/Default/apps/content.json.h:332
+#: content/Default/apps/content.json.h:341
 msgctxt "description"
 msgid ""
 "Kings, castles, and dragons all unite in this awesome strategy game that "
@@ -2257,17 +2277,17 @@ msgid ""
 "you desire!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:333
+#: content/Default/apps/content.json.h:342
 msgctxt "title"
 msgid "Minetest"
 msgstr ""
 
-#: content/Default/apps/content.json.h:334
+#: content/Default/apps/content.json.h:343
 msgctxt "subtitle"
 msgid "Create your dream world"
 msgstr ""
 
-#: content/Default/apps/content.json.h:335
+#: content/Default/apps/content.json.h:344
 msgctxt "description"
 msgid ""
 "What kind of a world would you build? Start with just land and water, and "
@@ -2279,17 +2299,17 @@ msgid ""
 "your city!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:336
+#: content/Default/apps/content.json.h:345
 msgctxt "title"
 msgid "Numpty Physics"
 msgstr ""
 
-#: content/Default/apps/content.json.h:337
+#: content/Default/apps/content.json.h:346
 msgctxt "subtitle"
 msgid "Fun physics puzzle games"
 msgstr ""
 
-#: content/Default/apps/content.json.h:338
+#: content/Default/apps/content.json.h:347
 msgctxt "description"
 msgid ""
 "Who knew the laws of physics could be so much fun? With this app, you can "
@@ -2300,17 +2320,17 @@ msgid ""
 "learning."
 msgstr ""
 
-#: content/Default/apps/content.json.h:339
+#: content/Default/apps/content.json.h:348
 msgctxt "title"
 msgid "OpenSCAD"
 msgstr ""
 
-#: content/Default/apps/content.json.h:340
+#: content/Default/apps/content.json.h:349
 msgctxt "subtitle"
 msgid "Solid 3D CAD modeller"
 msgstr ""
 
-#: content/Default/apps/content.json.h:341
+#: content/Default/apps/content.json.h:350
 msgctxt "description"
 msgid ""
 "OpenSCAD is software for creating solid 3D CAD models. It reads in a script "
@@ -2318,17 +2338,17 @@ msgid ""
 "file. The resulting model can be sent to a 3D printer."
 msgstr ""
 
-#: content/Default/apps/content.json.h:342
+#: content/Default/apps/content.json.h:351
 msgctxt "title"
 msgid "Palapeli"
 msgstr ""
 
-#: content/Default/apps/content.json.h:343
+#: content/Default/apps/content.json.h:352
 msgctxt "subtitle"
 msgid "A fun jigsaw puzzle game"
 msgstr ""
 
-#: content/Default/apps/content.json.h:344
+#: content/Default/apps/content.json.h:353
 msgctxt "description"
 msgid ""
 "If you’re a big fan of jigsaw puzzles, you’ll love this game. Unlike other "
@@ -2338,17 +2358,17 @@ msgid ""
 "rewarding, and as true to life as can be."
 msgstr ""
 
-#: content/Default/apps/content.json.h:345
+#: content/Default/apps/content.json.h:354
 msgctxt "title"
 msgid "Pingus"
 msgstr ""
 
-#: content/Default/apps/content.json.h:346
+#: content/Default/apps/content.json.h:355
 msgctxt "subtitle"
 msgid "Save your penguin friends from falling into the water"
 msgstr ""
 
-#: content/Default/apps/content.json.h:347
+#: content/Default/apps/content.json.h:356
 msgctxt "description"
 msgid ""
 "Penguins are among the cutest animals, so who wouldn’t want to play a fun "
@@ -2358,17 +2378,17 @@ msgid ""
 "them in order to avoid an untimely end."
 msgstr ""
 
-#: content/Default/apps/content.json.h:348
+#: content/Default/apps/content.json.h:357
 msgctxt "title"
 msgid "Video Editor"
 msgstr ""
 
-#: content/Default/apps/content.json.h:349
+#: content/Default/apps/content.json.h:358
 msgctxt "subtitle"
 msgid "Hundreds of transitions, effects, and filters to edit your videos"
 msgstr ""
 
-#: content/Default/apps/content.json.h:350
+#: content/Default/apps/content.json.h:359
 msgctxt "description"
 msgid ""
 "Create videos for projects, friends, family, or just for fun! Look through "
@@ -2378,17 +2398,17 @@ msgid ""
 "yourself, this video editor will help you do it!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:351
+#: content/Default/apps/content.json.h:360
 msgctxt "title"
 msgid "Quadrapassel"
 msgstr ""
 
-#: content/Default/apps/content.json.h:352
+#: content/Default/apps/content.json.h:361
 msgctxt "subtitle"
 msgid "A tetris-like puzzle game"
 msgstr ""
 
-#: content/Default/apps/content.json.h:353
+#: content/Default/apps/content.json.h:362
 msgctxt "description"
 msgid ""
 "You'll need to be quick if you want to win this game! Change the shape of "
@@ -2399,17 +2419,17 @@ msgid ""
 "challenge!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:354
+#: content/Default/apps/content.json.h:363
 msgctxt "title"
 msgid "Music"
 msgstr ""
 
-#: content/Default/apps/content.json.h:355
+#: content/Default/apps/content.json.h:364
 msgctxt "subtitle"
 msgid "Listen to all your music, and to the radio"
 msgstr ""
 
-#: content/Default/apps/content.json.h:356
+#: content/Default/apps/content.json.h:365
 msgctxt "description"
 msgid ""
 "In addition to listening to your favorite music, this app lets you search "
@@ -2419,17 +2439,17 @@ msgid ""
 "in one convenient app."
 msgstr ""
 
-#: content/Default/apps/content.json.h:357
+#: content/Default/apps/content.json.h:366
 msgctxt "title"
 msgid "Toy Train"
 msgstr ""
 
-#: content/Default/apps/content.json.h:358
+#: content/Default/apps/content.json.h:367
 msgctxt "subtitle"
 msgid "A fun train game for kids of all ages"
 msgstr ""
 
-#: content/Default/apps/content.json.h:359
+#: content/Default/apps/content.json.h:368
 msgctxt "description"
 msgid ""
 "Sure to be an instant hit with the whole family, this is a game featuring a "
@@ -2437,17 +2457,17 @@ msgid ""
 "coaches as you go. Collect all the coaches to win the game!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:360
+#: content/Default/apps/content.json.h:369
 msgctxt "title"
 msgid "Scorched 3D"
 msgstr ""
 
-#: content/Default/apps/content.json.h:361
+#: content/Default/apps/content.json.h:370
 msgctxt "subtitle"
 msgid "A battle adventure multi-player game"
 msgstr ""
 
-#: content/Default/apps/content.json.h:362
+#: content/Default/apps/content.json.h:371
 msgctxt "description"
 msgid ""
 "Do you love games with jets, naval vessels, and all sorts of weapons? If so, "
@@ -2459,17 +2479,17 @@ msgid ""
 "shake things up!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:363
+#: content/Default/apps/content.json.h:372
 msgctxt "title"
 msgid "Scratch"
 msgstr ""
 
-#: content/Default/apps/content.json.h:364
+#: content/Default/apps/content.json.h:373
 msgctxt "subtitle"
 msgid "Learn basic computer programming"
 msgstr ""
 
-#: content/Default/apps/content.json.h:365
+#: content/Default/apps/content.json.h:374
 msgctxt "description"
 msgid ""
 "Do you love computer games and applications? Why not learn how to make your "
@@ -2481,17 +2501,17 @@ msgid ""
 "will you someday make? "
 msgstr ""
 
-#: content/Default/apps/content.json.h:366
+#: content/Default/apps/content.json.h:375
 msgctxt "title"
 msgid "Photos"
 msgstr ""
 
-#: content/Default/apps/content.json.h:367
+#: content/Default/apps/content.json.h:376
 msgctxt "subtitle"
 msgid "Easily edit, organize, and share photos."
 msgstr ""
 
-#: content/Default/apps/content.json.h:368
+#: content/Default/apps/content.json.h:377
 msgctxt "description"
 msgid ""
 "We all love to take pictures in our everyday lives – and we especially love "
@@ -2502,17 +2522,17 @@ msgid ""
 "networks, like Facebook."
 msgstr ""
 
-#: content/Default/apps/content.json.h:369
+#: content/Default/apps/content.json.h:378
 msgctxt "title"
 msgid "Simple Scan"
 msgstr ""
 
-#: content/Default/apps/content.json.h:370
+#: content/Default/apps/content.json.h:379
 msgctxt "subtitle"
 msgid "Make a digital copy of your photos and documents"
 msgstr ""
 
-#: content/Default/apps/content.json.h:371
+#: content/Default/apps/content.json.h:380
 msgctxt "description"
 msgid ""
 "Preserving your photos and important documents by making digital copies has "
@@ -2523,17 +2543,17 @@ msgid ""
 "the things you scan are clear, straight, and in any format you need!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:372
+#: content/Default/apps/content.json.h:381
 msgctxt "title"
 msgid "Skype"
 msgstr ""
 
-#: content/Default/apps/content.json.h:373
+#: content/Default/apps/content.json.h:382
 msgctxt "subtitle"
 msgid "Free internet calls with cheap rates to phones"
 msgstr ""
 
-#: content/Default/apps/content.json.h:374
+#: content/Default/apps/content.json.h:383
 msgctxt "description"
 msgid ""
 "Skype makes staying in touch incredibly easy and fun! If you have a webcam "
@@ -2542,17 +2562,17 @@ msgid ""
 "you can stay in touch with people anywhere in world!  **Requires Internet"
 msgstr ""
 
-#: content/Default/apps/content.json.h:375
+#: content/Default/apps/content.json.h:384
 msgctxt "title"
 msgid "Slingshot"
 msgstr ""
 
-#: content/Default/apps/content.json.h:376
+#: content/Default/apps/content.json.h:385
 msgctxt "subtitle"
 msgid "A shooting strategy game set in space"
 msgstr ""
 
-#: content/Default/apps/content.json.h:377
+#: content/Default/apps/content.json.h:386
 msgctxt "description"
 msgid ""
 "Gravity is your best friend in this fun shooting game set in outer space. "
@@ -2561,17 +2581,17 @@ msgid ""
 "in this fun and addictive game!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:378
+#: content/Default/apps/content.json.h:387
 msgctxt "title"
 msgid "Freecell"
 msgstr ""
 
-#: content/Default/apps/content.json.h:379
+#: content/Default/apps/content.json.h:388
 msgctxt "subtitle"
 msgid "Solitare based single player card game"
 msgstr ""
 
-#: content/Default/apps/content.json.h:380
+#: content/Default/apps/content.json.h:389
 msgctxt "description"
 msgid ""
 "This application lets you play a new type of solitaire that will keep you "
@@ -2581,17 +2601,17 @@ msgid ""
 "to enjoy."
 msgstr ""
 
-#: content/Default/apps/content.json.h:381
+#: content/Default/apps/content.json.h:390
 msgctxt "title"
 msgid "Solitaire"
 msgstr ""
 
-#: content/Default/apps/content.json.h:382
+#: content/Default/apps/content.json.h:391
 msgctxt "subtitle"
 msgid "The classic single player card game"
 msgstr ""
 
-#: content/Default/apps/content.json.h:383
+#: content/Default/apps/content.json.h:392
 msgctxt "description"
 msgid ""
 "Solitaire is a classic card game that is fun for people of all ages. It’s "
@@ -2601,17 +2621,17 @@ msgid ""
 "entertain you, hour after hour."
 msgstr ""
 
-#: content/Default/apps/content.json.h:384
+#: content/Default/apps/content.json.h:393
 msgctxt "title"
 msgid "Steam"
 msgstr ""
 
-#: content/Default/apps/content.json.h:385
+#: content/Default/apps/content.json.h:394
 msgctxt "subtitle"
 msgid "Browse hundreds of the most popular games online"
 msgstr ""
 
-#: content/Default/apps/content.json.h:386
+#: content/Default/apps/content.json.h:395
 msgctxt "description"
 msgid ""
 "If you like playing video games, you're going to have a great time exploring "
@@ -2622,17 +2642,17 @@ msgid ""
 "time!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:387
+#: content/Default/apps/content.json.h:396
 msgctxt "title"
 msgid "Stellarium"
 msgstr ""
 
-#: content/Default/apps/content.json.h:388
+#: content/Default/apps/content.json.h:397
 msgctxt "subtitle"
 msgid "Planetarium software that shows what you see when you look at the stars"
 msgstr ""
 
-#: content/Default/apps/content.json.h:389
+#: content/Default/apps/content.json.h:398
 msgctxt "description"
 msgid ""
 "Discover the night sky with this application. With a catalogue of more than "
@@ -2643,17 +2663,17 @@ msgid ""
 "learn about the stars above you!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:390
+#: content/Default/apps/content.json.h:399
 msgctxt "title"
 msgid "Super Tux"
 msgstr ""
 
-#: content/Default/apps/content.json.h:391
+#: content/Default/apps/content.json.h:400
 msgctxt "subtitle"
 msgid "Jump your way through different levels to win"
 msgstr ""
 
-#: content/Default/apps/content.json.h:392
+#: content/Default/apps/content.json.h:401
 msgctxt "description"
 msgid ""
 "This game is similar to the original Super Mario Brothers games where you "
@@ -2662,17 +2682,17 @@ msgid ""
 "can follow along with as you play."
 msgstr ""
 
-#: content/Default/apps/content.json.h:393
+#: content/Default/apps/content.json.h:402
 msgctxt "title"
 msgid "Tux Kart"
 msgstr ""
 
-#: content/Default/apps/content.json.h:394
+#: content/Default/apps/content.json.h:403
 msgctxt "subtitle"
 msgid "Race alone or against your friends and family"
 msgstr ""
 
-#: content/Default/apps/content.json.h:395
+#: content/Default/apps/content.json.h:404
 msgctxt "description"
 msgid ""
 "Do you love racing games? Then this is the app for you! Race down easy, "
@@ -2683,17 +2703,17 @@ msgid ""
 "is sure to entertain you and your friends for hours!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:396
+#: content/Default/apps/content.json.h:405
 msgctxt "title"
 msgid "Teeworlds"
 msgstr ""
 
-#: content/Default/apps/content.json.h:397
+#: content/Default/apps/content.json.h:406
 msgctxt "subtitle"
 msgid "Exciting multi-player shooting game"
 msgstr ""
 
-#: content/Default/apps/content.json.h:398
+#: content/Default/apps/content.json.h:407
 msgctxt "description"
 msgid ""
 "Shoot your way to victory in death matches and more! This game has an old-"
@@ -2705,17 +2725,17 @@ msgid ""
 "and go!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:399
+#: content/Default/apps/content.json.h:408
 msgctxt "title"
 msgid "TORCS"
 msgstr ""
 
-#: content/Default/apps/content.json.h:400
+#: content/Default/apps/content.json.h:409
 msgctxt "subtitle"
 msgid "Race cool 3D cars in this realistic game"
 msgstr ""
 
-#: content/Default/apps/content.json.h:401
+#: content/Default/apps/content.json.h:410
 msgctxt "description"
 msgid ""
 "Rip around turns and scream past other drivers in this exciting 3D car "
@@ -2726,17 +2746,17 @@ msgid ""
 "want to play too!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:402
+#: content/Default/apps/content.json.h:411
 msgctxt "title"
 msgid "Videos"
 msgstr ""
 
-#: content/Default/apps/content.json.h:403
+#: content/Default/apps/content.json.h:412
 msgctxt "subtitle"
 msgid "Full function video and media player"
 msgstr ""
 
-#: content/Default/apps/content.json.h:404
+#: content/Default/apps/content.json.h:413
 msgctxt "description"
 msgid ""
 "Do you love watching movies? Do it the right way with this video application "
@@ -2746,17 +2766,17 @@ msgid ""
 "your family and friends to join you in watching all of your favorite movies!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:405
+#: content/Default/apps/content.json.h:414
 msgctxt "title"
 msgid "Tux Football"
 msgstr ""
 
-#: content/Default/apps/content.json.h:406
+#: content/Default/apps/content.json.h:415
 msgctxt "subtitle"
 msgid "A fun soccer game starring Tux the penguin"
 msgstr ""
 
-#: content/Default/apps/content.json.h:407
+#: content/Default/apps/content.json.h:416
 msgctxt "description"
 msgid ""
 "Do you love soccer? Now you can play all day with your favorite penguins! "
@@ -2765,17 +2785,17 @@ msgid ""
 "professionals!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:408
+#: content/Default/apps/content.json.h:417
 msgctxt "title"
 msgid "Tux Math"
 msgstr ""
 
-#: content/Default/apps/content.json.h:409
+#: content/Default/apps/content.json.h:418
 msgctxt "subtitle"
 msgid "Math games for kids"
 msgstr ""
 
-#: content/Default/apps/content.json.h:410
+#: content/Default/apps/content.json.h:419
 msgctxt "description"
 msgid ""
 "Learn math by playing games! Starring kids’ favorite buddy, Tux the Penguin, "
@@ -2785,17 +2805,17 @@ msgid ""
 "worlds and will help your child learn to love math!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:411
+#: content/Default/apps/content.json.h:420
 msgctxt "title"
 msgid "Tux Paint"
 msgstr ""
 
-#: content/Default/apps/content.json.h:412
+#: content/Default/apps/content.json.h:421
 msgctxt "subtitle"
 msgid "A fun drawing app for kids"
 msgstr ""
 
-#: content/Default/apps/content.json.h:413
+#: content/Default/apps/content.json.h:422
 msgctxt "description"
 msgid ""
 "Create beautiful artwork with this fun and easy to use app! Tux the penguin "
@@ -2806,17 +2826,17 @@ msgid ""
 "then download this app and get them started on their next masterpiece!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:414
+#: content/Default/apps/content.json.h:423
 msgctxt "title"
 msgid "Tux Puck"
 msgstr ""
 
-#: content/Default/apps/content.json.h:415
+#: content/Default/apps/content.json.h:424
 msgctxt "subtitle"
 msgid "Exciting air hockey game for you and your friends"
 msgstr ""
 
-#: content/Default/apps/content.json.h:416
+#: content/Default/apps/content.json.h:425
 msgctxt "description"
 msgid ""
 "An air hockey game in which you try to knock the puck past your opponent's "
@@ -2825,17 +2845,17 @@ msgid ""
 "or F6 to adjust your paddle speed.)"
 msgstr ""
 
-#: content/Default/apps/content.json.h:417
+#: content/Default/apps/content.json.h:426
 msgctxt "title"
 msgid "Tux Typing"
 msgstr ""
 
-#: content/Default/apps/content.json.h:418
+#: content/Default/apps/content.json.h:427
 msgctxt "subtitle"
 msgid "Learn to type by playing games"
 msgstr ""
 
-#: content/Default/apps/content.json.h:419
+#: content/Default/apps/content.json.h:428
 msgctxt "description"
 msgid ""
 "This fun application is a great way for kids, and even adults, to learn how "
@@ -2847,17 +2867,17 @@ msgid ""
 "encouraging them to play!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:420
+#: content/Default/apps/content.json.h:429
 msgctxt "title"
 msgid "Warmux"
 msgstr ""
 
-#: content/Default/apps/content.json.h:421
+#: content/Default/apps/content.json.h:430
 msgctxt "subtitle"
 msgid "Make your computer a battle of wit and war"
 msgstr ""
 
-#: content/Default/apps/content.json.h:422
+#: content/Default/apps/content.json.h:431
 msgctxt "description"
 msgid ""
 "Exterminate your opponent in a cartoon word using dynamite, grenades, "
@@ -2866,17 +2886,17 @@ msgid ""
 "member of each team attempts to destroy his opponents."
 msgstr ""
 
-#: content/Default/apps/content.json.h:423
+#: content/Default/apps/content.json.h:432
 msgctxt "title"
 msgid "Warzone 2100"
 msgstr ""
 
-#: content/Default/apps/content.json.h:424
+#: content/Default/apps/content.json.h:433
 msgctxt "subtitle"
 msgid "Lead your troops to rebuild the world"
 msgstr ""
 
-#: content/Default/apps/content.json.h:425
+#: content/Default/apps/content.json.h:434
 msgctxt "description"
 msgid ""
 "In Warzone 2100 you command forces to rebuild the world after nuclear war "
@@ -2886,17 +2906,17 @@ msgid ""
 "of strategy, tactics, and wit."
 msgstr ""
 
-#: content/Default/apps/content.json.h:426
+#: content/Default/apps/content.json.h:435
 msgctxt "title"
 msgid "Wesnoth"
 msgstr ""
 
-#: content/Default/apps/content.json.h:427
+#: content/Default/apps/content.json.h:436
 msgctxt "subtitle"
 msgid "Fantasy turn-based strategy game"
 msgstr ""
 
-#: content/Default/apps/content.json.h:428
+#: content/Default/apps/content.json.h:437
 msgctxt "description"
 msgid ""
 "Battle for control of the land, villages, and resources in this fantasy-"
@@ -2905,17 +2925,17 @@ msgid ""
 "strategy, this game is sure to reveal a great leader inside you."
 msgstr ""
 
-#: content/Default/apps/content.json.h:429
+#: content/Default/apps/content.json.h:438
 msgctxt "title"
 msgid "X-Moto"
 msgstr ""
 
-#: content/Default/apps/content.json.h:430
+#: content/Default/apps/content.json.h:439
 msgctxt "subtitle"
 msgid "A motorcycle racing game"
 msgstr ""
 
-#: content/Default/apps/content.json.h:431
+#: content/Default/apps/content.json.h:440
 msgctxt "description"
 msgid ""
 "Love motorcycles? Then you're going to love this racing game where physics "
@@ -2925,17 +2945,17 @@ msgid ""
 "time in this fast-paced, exciting test of speed!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:432
+#: content/Default/apps/content.json.h:441
 msgctxt "title"
 msgid "KBlocks"
 msgstr ""
 
-#: content/Default/apps/content.json.h:433
+#: content/Default/apps/content.json.h:442
 msgctxt "subtitle"
 msgid "Match blocks to destroy them and win"
 msgstr ""
 
-#: content/Default/apps/content.json.h:434
+#: content/Default/apps/content.json.h:443
 msgctxt "description"
 msgid ""
 "This game is similar to Tetris, so if you love that game, you will love this "
@@ -2944,17 +2964,17 @@ msgid ""
 "lose, so pay attention and get ready for some very fast-actioned fun!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:435
+#: content/Default/apps/content.json.h:444
 msgctxt "title"
 msgid "KBounce"
 msgstr ""
 
-#: content/Default/apps/content.json.h:436
+#: content/Default/apps/content.json.h:445
 msgctxt "subtitle"
 msgid "The ball-bouncing game sure to hook you"
 msgstr ""
 
-#: content/Default/apps/content.json.h:437
+#: content/Default/apps/content.json.h:446
 msgctxt "description"
 msgid ""
 "This is a fun game with a simple goal: you must build walls to decrease the "
@@ -2964,17 +2984,17 @@ msgid ""
 "It requires quick thinking and fast reflexes!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:438
+#: content/Default/apps/content.json.h:447
 msgctxt "title"
 msgid "KDiamond"
 msgstr ""
 
-#: content/Default/apps/content.json.h:439
+#: content/Default/apps/content.json.h:448
 msgctxt "subtitle"
 msgid "Create lines of three diamonds"
 msgstr ""
 
-#: content/Default/apps/content.json.h:440
+#: content/Default/apps/content.json.h:449
 msgctxt "description"
 msgid ""
 "In this fast-paced game, your job is to build lines of three diamonds of the "
@@ -2985,17 +3005,17 @@ msgid ""
 "age levels."
 msgstr ""
 
-#: content/Default/apps/content.json.h:441
+#: content/Default/apps/content.json.h:450
 msgctxt "title"
 msgid "KJumpingCube"
 msgstr ""
 
-#: content/Default/apps/content.json.h:442
+#: content/Default/apps/content.json.h:451
 msgctxt "subtitle"
 msgid "Develop a good strategy to conquer all the squares"
 msgstr ""
 
-#: content/Default/apps/content.json.h:443
+#: content/Default/apps/content.json.h:452
 msgctxt "description"
 msgid ""
 "Practice your strategic thinking with this challenging dice-based game! You "
@@ -3010,17 +3030,17 @@ msgid ""
 "toes! "
 msgstr ""
 
-#: content/Default/apps/content.json.h:444
+#: content/Default/apps/content.json.h:453
 msgctxt "title"
 msgid "KSame"
 msgstr ""
 
-#: content/Default/apps/content.json.h:445
+#: content/Default/apps/content.json.h:454
 msgctxt "subtitle"
 msgid "Get rid of all the marbles to win"
 msgstr ""
 
-#: content/Default/apps/content.json.h:446
+#: content/Default/apps/content.json.h:455
 msgctxt "description"
 msgid ""
 "Show off your pattern-finding skills in this addicting game. Match all of "
@@ -3030,17 +3050,17 @@ msgid ""
 "challenge. A really fun challenge!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:447
+#: content/Default/apps/content.json.h:456
 msgctxt "title"
 msgid "Open Arena"
 msgstr ""
 
-#: content/Default/apps/content.json.h:448
+#: content/Default/apps/content.json.h:457
 msgctxt "subtitle"
 msgid "Shoot your way out of trouble in this fun game"
 msgstr ""
 
-#: content/Default/apps/content.json.h:449
+#: content/Default/apps/content.json.h:458
 msgctxt "description"
 msgid ""
 "If arena battles are your idea of a good time, then you’ll love this "
@@ -3050,7 +3070,7 @@ msgid ""
 "of these modes offers its own form of excitement as you battle your enemies!"
 msgstr ""
 
-#: content/Default/apps/content.json.h:159
+#: content/Default/apps/content.json.h:171
 msgctxt "description"
 msgid ""
 "Need to safely store all of your important documents, photos, songs, and "

--- a/po/es.po
+++ b/po/es.po
@@ -15,14 +15,14 @@
 # Nora Jendoubi <jendoubi@stanford.edu>, 2013
 # Nuritzi Sanchez <ns@endlessm.com>, 2013
 # Nuritzi Sanchez <ns@endlessm.com>, 2013-2014
-# Roddy Shuler <roddy@endlessm.com>, 2013-2014
+# Roddy Shuler <roddy@endlessm.com>, 2013-2015
 # Roddy Shuler <roddy@endlessm.com>, 2013
 msgid ""
 msgstr ""
 "Project-Id-Version: eos-shell-content\n"
 "Report-Msgid-Bugs-To: https://www.transifex.com/projects/p/eos-shell-content/\n"
-"POT-Creation-Date: 2015-02-24 12:56-0800\n"
-"PO-Revision-Date: 2015-02-24 21:02+0000\n"
+"POT-Creation-Date: 2015-02-24 16:21-0800\n"
+"PO-Revision-Date: 2015-02-25 00:25+0000\n"
 "Last-Translator: Roddy Shuler <roddy@endlessm.com>\n"
 "Language-Team: Spanish (http://www.transifex.com/projects/p/eos-shell-content/language/es/)\n"
 "MIME-Version: 1.0\n"
@@ -559,7 +559,7 @@ msgid "Curriculum"
 msgstr "Currículo"
 
 #: content/Default/apps/content.json.h:83
-#: content/Default/apps/content.json.h:229
+#: content/Default/apps/content.json.h:241
 msgctxt "subtitle"
 msgid "From the Guatemalan Ministry of Education"
 msgstr "Del Ministerio de Educación de Guatemala"
@@ -857,16 +857,34 @@ msgid ""
 msgstr "La mejor manera de impresionar a un potencial empleador es tener un excelente currículum. En este programa encontrarás plantillas útiles y atractivas para ayudarte a construir tu propio currículum. Aprende exactamente qué es un currículum y lo que debería contener, obtén consejos en cada sección, y recibe recomendaciones para prepararte para entrevistas de trabajo. Este programa te puede ayudar a acercarte más al empleo de tu elección."
 
 #: content/Default/apps/content.json.h:124
+#: content/Default/apps/content.json.h:127
 msgctxt "title"
 msgid "Football"
 msgstr "Fútbol"
 
 #: content/Default/apps/content.json.h:125
+#: content/Default/apps/content.json.h:137
+#: content/Default/apps/content.json.h:161
+msgctxt "subtitle"
+msgid "Deprecated version"
+msgstr "Versión obsoleta"
+
+#: content/Default/apps/content.json.h:126
+#: content/Default/apps/content.json.h:138
+#: content/Default/apps/content.json.h:162
+msgctxt "description"
+msgid ""
+"If you have internet access, there may be a newer version of this "
+"application available to download and install. In the meantime, you may "
+"continue to use this version that is already installed on your computer."
+msgstr "Si tienes internet es posible que ya exista una nueva versión de este programa para descargar e instalar. Si no tienes internet puedes continuar usando esta versión que ya está instalada en tu computadora."
+
+#: content/Default/apps/content.json.h:128
 msgctxt "subtitle"
 msgid "Learn about your favorite team and players"
 msgstr "Aprende más de tu equipo y jugadores favoritos"
 
-#: content/Default/apps/content.json.h:126
+#: content/Default/apps/content.json.h:129
 msgctxt "description"
 msgid ""
 "Football is a major sport with fans all around the world. Are you one of "
@@ -876,17 +894,17 @@ msgid ""
 " with thousands of articles about your favorite sport!"
 msgstr "El fútbol es un deporte con aficionados en todo el mundo. ¿Eres uno de ellos? Este programa tiene todo lo que necesitas saber acerca de los mejores equipos del mundo, tus jugadores favoritos y todos los torneos en que participan. Aprende hechos acerca del juego y su historia, descubre la complejidad de las reglas, ¡y mantente al tanto con miles de artículos acerca de tu deporte favorito!"
 
-#: content/Default/apps/content.json.h:127
+#: content/Default/apps/content.json.h:130
 msgctxt "title"
 msgid "Social Enterprises"
 msgstr "Empresas sociales"
 
-#: content/Default/apps/content.json.h:128
+#: content/Default/apps/content.json.h:131
 msgctxt "subtitle"
 msgid "All about non-profit organizations"
 msgstr "Todo sobre las empresas sociales"
 
-#: content/Default/apps/content.json.h:129
+#: content/Default/apps/content.json.h:132
 msgctxt "description"
 msgid ""
 "Have you thought of starting your own non-profit organization, or of joining"
@@ -896,17 +914,17 @@ msgid ""
 "your impact in the world even larger!"
 msgstr "¿Has pensado en empezar tu propia empresa social, o de unirte a una? Las empresas sociales gozan de beneficios tributarios especiales, y se crean generalmente para hacer un impacto social. ¡Lee estas guías para entender más acerca de la estructura de empresas sociales y de cómo operarlas para que puedas comenzar a hacer que tu impacto en el mundo sea más grande!"
 
-#: content/Default/apps/content.json.h:130
+#: content/Default/apps/content.json.h:133
 msgctxt "title"
 msgid "Social Sciences"
 msgstr "Ciencias sociales"
 
-#: content/Default/apps/content.json.h:131
+#: content/Default/apps/content.json.h:134
 msgctxt "subtitle"
 msgid "Subjects that explore the individual and society"
 msgstr "Materias que exploran el individuo y la sociedad"
 
-#: content/Default/apps/content.json.h:132
+#: content/Default/apps/content.json.h:135
 msgctxt "description"
 msgid ""
 "Human beings and the relationships and societies they form are complicated. "
@@ -918,17 +936,39 @@ msgid ""
 "understanding of human behavior."
 msgstr "Los seres humanos y las relaciones y sociedades que forman son complejos. Este programa te dará a conocer muchas de las disciplinas que examinan la historia, las culturas y las interacciones de los seres humanos. Tendrás acceso a la información fundamental de la psicología, sociología, antropología, ciencia política y más. Entendiendo los fundamentos de cada disciplina te ayudará a navegar los modos en que interactuamos y nos relacionamos los unos con los otros. Saldrás con un profundo conocimiento del comportamiento de los seres humanos."
 
-#: content/Default/apps/content.json.h:133
+#: content/Default/apps/content.json.h:136
+#: content/Default/apps/content.json.h:139
+msgctxt "title"
+msgid "Textbooks"
+msgstr "Libros de texto"
+
+#: content/Default/apps/content.json.h:140
+msgctxt "subtitle"
+msgid "Math and science textbooks"
+msgstr ""
+
+#: content/Default/apps/content.json.h:141
+msgctxt "description"
+msgid ""
+"Find information to help you with your homework, or learn about a subject "
+"you've always wanted to know more about! You can scroll through photos, "
+"tables, and graphs to learn more about each. Not only are these textbooks "
+"very thorough and informative, but they are also easy to read and helpful. "
+"Whether you’re a student, parent, teacher, or just someone eager to learn, "
+"you'll be sure to find something interesting and useful here!"
+msgstr ""
+
+#: content/Default/apps/content.json.h:142
 msgctxt "title"
 msgid "Translate"
 msgstr "Traductor"
 
-#: content/Default/apps/content.json.h:134
+#: content/Default/apps/content.json.h:143
 msgctxt "subtitle"
 msgid "Translate text between many languages instantly"
 msgstr "Traduce entre varios idiomas instantáneamente"
 
-#: content/Default/apps/content.json.h:135
+#: content/Default/apps/content.json.h:144
 msgctxt "description"
 msgid ""
 "Download this app to help you understand and be understood in virtually any "
@@ -939,17 +979,17 @@ msgid ""
 " – with the world’s languages at your fingertips.  **Requires internet"
 msgstr "Con este programa puedes entender y ser entendido en casi cualquier idioma con tan solo un clic. El programa requiere una conexión al Internet, pero es bella y muy fácil de usar. Accede a más información, y hasta a nuevas amistades al poder comunicarte en cualquier idioma del mundo.   **Requiere internet"
 
-#: content/Default/apps/content.json.h:136
+#: content/Default/apps/content.json.h:145
 msgctxt "title"
 msgid "Travel"
 msgstr "¡Explora!"
 
-#: content/Default/apps/content.json.h:137
+#: content/Default/apps/content.json.h:146
 msgctxt "subtitle"
 msgid "Travel around the world from your living room"
 msgstr "Explora los lugares más populares del mundo"
 
-#: content/Default/apps/content.json.h:138
+#: content/Default/apps/content.json.h:147
 msgctxt "description"
 msgid ""
 "The world is an amazing and beautiful place! Start exploring it with this "
@@ -960,17 +1000,17 @@ msgid ""
 "sites in the world!"
 msgstr "¡El mundo es un lugar bello y extraordinario! Comienza a explorarlo con este programa que te permite ver fotos y aprender acerca de lugares y monumentos de todas partes del mundo. Contiene información acerca de los mayores atractivos en las Américas, Europa, Asia y más. ¡Conoce las maravillas naturales, explora nuevas culturas y descubre algunos de los sitios más importantes del mundo!"
 
-#: content/Default/apps/content.json.h:139
+#: content/Default/apps/content.json.h:148
 msgctxt "title"
 msgid "Typing"
 msgstr "Teclear"
 
-#: content/Default/apps/content.json.h:140
+#: content/Default/apps/content.json.h:149
 msgctxt "subtitle"
 msgid "Learn to type with games and songs"
 msgstr "Aprende a teclear con juegos y canciones"
 
-#: content/Default/apps/content.json.h:141
+#: content/Default/apps/content.json.h:150
 msgctxt "description"
 msgid ""
 "How fast can you type? Whether you're already fast or just learning how to "
@@ -981,17 +1021,17 @@ msgid ""
 "now it can be a whole lot of fun too!"
 msgstr "Teclear rápido en una computadora es una habilidad muy valiosa en casi cualquier ambiente educativo o profesional, ¿pero sabías que también puede ser muy divertido? Este programa te enseñará a usar el teclado de forma efectiva, ¡y lo mejor es que aprenderás esta habilidad tecleando la letra de tus canciones favoritas! ¿Qué podría ser más entretenido que aprender las letras de las canciones que te gustan, a la vez que aprendes una nueva y excelente habilidad?"
 
-#: content/Default/apps/content.json.h:142
+#: content/Default/apps/content.json.h:151
 msgctxt "title"
 msgid "Virtual School"
 msgstr "Escuela virtual"
 
-#: content/Default/apps/content.json.h:143
+#: content/Default/apps/content.json.h:152
 msgctxt "subtitle"
 msgid "Free educational videos on almost any subject"
 msgstr "Video cursos para ayudarte a entender materias difíciles"
 
-#: content/Default/apps/content.json.h:144
+#: content/Default/apps/content.json.h:153
 msgctxt "description"
 msgid ""
 "Learning is easy and fun with video courses on subjects like math, biology, "
@@ -1003,17 +1043,17 @@ msgid ""
 " this app and these videos can help you succeed in school and in life!"
 msgstr "¡Accede video cursos que transformarán materias difíciles en algo fácil de aprender y bastante divertido! Aprende acerca de materias como las matemáticas, la biología, la química, la física, y muchas más. Miles de profesores por todo el mundo están utilizando con éxito estos videos para ayudar a sus estudiantes a aprender mejor, ¡y ahora tienes acceso a estos videos excelentes y gratuitos! Aprende todo de una manera que finalmente hace sentido para ti, y experimenta cómo esta aplicación y estos videos pueden ayudarte a ti y a tu familia tener éxito en la escuela y en la vida!"
 
-#: content/Default/apps/content.json.h:145
+#: content/Default/apps/content.json.h:154
 msgctxt "title"
 msgid "Sanitation"
 msgstr "Saneamiento"
 
-#: content/Default/apps/content.json.h:146
+#: content/Default/apps/content.json.h:155
 msgctxt "subtitle"
 msgid "All about clean water and sanitation"
 msgstr "Sobre el agua potable y el saneamiento"
 
-#: content/Default/apps/content.json.h:147
+#: content/Default/apps/content.json.h:156
 msgctxt "description"
 msgid ""
 "Drinking clean water is essential for survival. There can often be terrible "
@@ -1022,17 +1062,17 @@ msgid ""
 "that you create a sanitary environment around you where you can thrive. "
 msgstr "Beber agua limpia es esencial para la supervivencia. A menudo hay terribles enfermedades que te pueden infectar a través de agua en mal estado, o por tener mal saneamiento a tu alrededor. Aprende cómo asegurarte de beber agua limpia, y cómo asegurarte de que se crea un ambiente limpio a tu alrededor donde se pueda prosperar."
 
-#: content/Default/apps/content.json.h:148
+#: content/Default/apps/content.json.h:157
 msgctxt "title"
 msgid "Weather"
 msgstr "El tiempo"
 
-#: content/Default/apps/content.json.h:149
+#: content/Default/apps/content.json.h:158
 msgctxt "subtitle"
 msgid "Get daily local forecasts from trusted sources"
 msgstr "Pronósticos locales de fuentes confiables"
 
-#: content/Default/apps/content.json.h:150
+#: content/Default/apps/content.json.h:159
 msgctxt "description"
 msgid ""
 "“How’s the weather out there?” Answer this question easily, every day, with "
@@ -1042,17 +1082,18 @@ msgid ""
 "about the weather to take advantage of your day!  **Requires internet"
 msgstr "¿Cómo está el tiempo? Responde a esta pregunta fácilmente, todos los días, con un solo clic. Este sencillo programa te permite ver lo que está pasando justo afuera de tu casa. ¿Hará frío? ¿Debes prepararte para la lluvia? ¿Es un día perfecto para pasarlo al aire libre? ¡Infórmate sobre todo lo que necesitas saber acerca del clima para aprovechar tu día!  **Requiere internet"
 
-#: content/Default/apps/content.json.h:151
+#: content/Default/apps/content.json.h:160
+#: content/Default/apps/content.json.h:163
 msgctxt "title"
 msgid "World Literature"
 msgstr "Literatura"
 
-#: content/Default/apps/content.json.h:152
+#: content/Default/apps/content.json.h:164
 msgctxt "subtitle"
 msgid "Read all of the world's great literature"
 msgstr "Lee toda la gran literatura del mundo"
 
-#: content/Default/apps/content.json.h:153
+#: content/Default/apps/content.json.h:165
 msgctxt "description"
 msgid ""
 "Find some of your favorite books in this app! To begin browsing, open the "
@@ -1064,17 +1105,17 @@ msgid ""
 "entertained for hours expanding your literary knowledge."
 msgstr "¡Encuentra algunos de tus libros favoritos en este programa! Para comenzar tu búsqueda, abre la carpeta, haz clic en el archivo 'Index', y selecciona el género que más te interese. Encontrarás algunos de los libros más famosos del mundo, incluyendo maravillas modernas que seguramente te interesarán. Esta biblioteca virtual tiene una colección estupenda de novelas, poemas, biografías, cuentos y otros textos. De seguro encontrarás tu libro favorito o descubrirás uno nuevo que te gustará. Te entretendrás durante horas y expandirás profundamente tu conocimiento literario."
 
-#: content/Default/apps/content.json.h:154
+#: content/Default/apps/content.json.h:166
 msgctxt "title"
 msgid "YouVideos"
 msgstr "YouVideos"
 
-#: content/Default/apps/content.json.h:155
+#: content/Default/apps/content.json.h:167
 msgctxt "subtitle"
 msgid "Discover and share great videos online"
 msgstr "Explora vídeos y comparte los tuyos en línea"
 
-#: content/Default/apps/content.json.h:156
+#: content/Default/apps/content.json.h:168
 msgctxt "description"
 msgid ""
 "This app makes finding videos on the popular video site, YouTube, and "
@@ -1085,27 +1126,27 @@ msgid ""
 "family, and the world!  ** Requires internet"
 msgstr "Buscar videos en la página web popular, YouTube, y compartirlos con familia y amigos ahora es más fácil que nunca. Ve videos de tus artistas favoritos, cursos para aprender casi cualquier cosa, chistes, animales lindos y mucho más. ¡Te divertirás por horas y podrás compartir todo lo que encuentres con tus amigos, familia y el mundo entero!  **Requiere internet"
 
-#: content/Default/apps/content.json.h:157
+#: content/Default/apps/content.json.h:169
 msgctxt "title"
 msgid "Dropbox"
 msgstr "Dropbox"
 
-#: content/Default/apps/content.json.h:158
+#: content/Default/apps/content.json.h:170
 msgctxt "subtitle"
 msgid "Access your files from any computer"
 msgstr "Accede a tus documentos desde cualquier computadora"
 
-#: content/Default/apps/content.json.h:162
+#: content/Default/apps/content.json.h:174
 msgctxt "title"
 msgid "Chat"
 msgstr "Chat"
 
-#: content/Default/apps/content.json.h:163
+#: content/Default/apps/content.json.h:175
 msgctxt "subtitle"
 msgid "Chat with all of your friends in one place"
 msgstr "Chatea con todos tus amigos en sólo un lugar"
 
-#: content/Default/apps/content.json.h:164
+#: content/Default/apps/content.json.h:176
 msgctxt "description"
 msgid ""
 "Do you love to chat with friends? And, do you use many different programs to"
@@ -1118,17 +1159,17 @@ msgid ""
 "and family easier than ever before!  **Requires internet"
 msgstr "Este programa de chat es increíble: Es compatible con todos tus sitios y programas favoritos como Facebook, Jabber, MSN, AIM, Gadu Gadu, y más. Los trae a todos juntos para que puedas chatear o hacer llamadas de voz o video en una sola aplicación. Todos tus contactos pueden estar en un solo lugar. Todo lo que necesitas hacer es configurar este programa con todas tus cuentas con la ayuda de un asistente de configuración, ¡y estarás listo para hablar con todos tus amigos y familiares! Este programa también permite el intercambio de archivos, en caso de tener imágenes, documentos o medios que quieras compartir con otros. ¡Mantenerte en contacto con todos tus amigos y familiares te será más fácil que nunca!  **Requiere internet"
 
-#: content/Default/apps/content.json.h:165
+#: content/Default/apps/content.json.h:177
 msgctxt "title"
 msgid "Documents"
 msgstr "Documentos"
 
-#: content/Default/apps/content.json.h:166
+#: content/Default/apps/content.json.h:178
 msgctxt "subtitle"
 msgid "Access all of your documents and files"
 msgstr "Accede todos los documentos y archivos"
 
-#: content/Default/apps/content.json.h:167
+#: content/Default/apps/content.json.h:179
 msgctxt "description"
 msgid ""
 "Get organized with this app, which helps you find all of your documents and "
@@ -1139,17 +1180,17 @@ msgid ""
 "special photo again."
 msgstr "Encuentra todos tus documentos y archivos en un sólo lugar - no importa hace cuándo los hayas salvado. Con este programa puedes organizarlos de una manera que te haga sentido, agregando nuevas carpetas para denominarlas de manera de que te ayudará a fácilmente reconocer qué tipos de archivos contienen. ¡Podrás almacenar todos tus archivos en un solo lugar para que jamás extravies un documento importante!"
 
-#: content/Default/apps/content.json.h:168
+#: content/Default/apps/content.json.h:180
 msgctxt "title"
 msgid "E-mail"
 msgstr "E-mail"
 
-#: content/Default/apps/content.json.h:169
+#: content/Default/apps/content.json.h:181
 msgctxt "subtitle"
 msgid "Your e-mail, address book and calendar in one place"
 msgstr "Tu e-mail, contactos y calendario todo en un lugar"
 
-#: content/Default/apps/content.json.h:170
+#: content/Default/apps/content.json.h:182
 msgctxt "description"
 msgid ""
 "Staying in touch is an important part of modern life, and email has become "
@@ -1160,17 +1201,17 @@ msgid ""
 "  **Requires internet"
 msgstr "Mantenerte en contacto es una parte importante de la vida moderna, y el correo electrónico es una de las mejores formas de hacerlo. Puedes recibir correo electrónico de amigos y familiares de cualquier lugar del mundo, tener acceso a mensajes que contengan noticias e incluso manejar asuntos importantes de trabajo todo por correo electrónico. Cuando necesites revisar tu correo electrónico rápido y fácilmente, este programa estará disponible.  **Requiere internet"
 
-#: content/Default/apps/content.json.h:171
+#: content/Default/apps/content.json.h:183
 msgctxt "title"
 msgid "Tux Racer"
 msgstr "Carreras Tux"
 
-#: content/Default/apps/content.json.h:172
+#: content/Default/apps/content.json.h:184
 msgctxt "subtitle"
 msgid "Race down icy mountains"
 msgstr "Compite en carreras en montañas heladas"
 
-#: content/Default/apps/content.json.h:173
+#: content/Default/apps/content.json.h:185
 msgctxt "description"
 msgid ""
 "Make it down a snow and ice-covered mountain as quickly as possible in this "
@@ -1179,17 +1220,17 @@ msgid ""
 "get your heart racing, this game is a must play for any adrenaline addict."
 msgstr "Este juego de carreras, con Tux el pingüino, está perfecto para niños de todas edades. La meta es bajar de una montaña cubierta de nieve lo más rápido posible mientras que evitas chocar contra los árboles y las piedras, las cuales reducirán tu velocidad. Colecta los pescados al bajar la montaña, pero evita los huesos. Este juego emocionante te dará una explosión maravillosa de adrenalina."
 
-#: content/Default/apps/content.json.h:174
+#: content/Default/apps/content.json.h:186
 msgctxt "title"
 msgid "Four in a Row"
 msgstr "Cuatro en línea"
 
-#: content/Default/apps/content.json.h:175
+#: content/Default/apps/content.json.h:187
 msgctxt "subtitle"
 msgid "A simple and addictive game for kids and adults"
 msgstr "Un juego sencillo y adictivo para niños y adultos"
 
-#: content/Default/apps/content.json.h:176
+#: content/Default/apps/content.json.h:188
 msgctxt "description"
 msgid ""
 "This classic game is great for both children and adults alike! The goal is "
@@ -1201,17 +1242,17 @@ msgid ""
 "fun game!"
 msgstr "¡Este juego clásico es divertido para niños y adultos! La meta es sencilla- tienes que crear una línea de 4 esferas tuyas antes que lo haga tu oponente. Puedes juntar tus esferas en una línea horizontal, vertical o diagonal, pero tienes que tener cuidado de lo que hace tu oponente si quieres ganar. ¡Puedes jugar contra la computadora o contra un amigo y durar horas jugando este juego tan divertido!"
 
-#: content/Default/apps/content.json.h:177
+#: content/Default/apps/content.json.h:189
 msgctxt "title"
 msgid "FreeCiv"
 msgstr "CivLibre"
 
-#: content/Default/apps/content.json.h:178
+#: content/Default/apps/content.json.h:190
 msgctxt "subtitle"
 msgid "Guide your own civilization to greatness"
 msgstr "Guía a tu propia civilización hacia la grandeza"
 
-#: content/Default/apps/content.json.h:179
+#: content/Default/apps/content.json.h:191
 msgctxt "description"
 msgid ""
 "Create your own world with this action-packed game that lets you travel "
@@ -1223,17 +1264,17 @@ msgid ""
 "conquering the moon and beyond!"
 msgstr "Crea tu propio mundo con este juego lleno de acción que te permite viajar por el tiempo y comenzar tu propia civilización. Empezarás en un mundo prehistórico, en el que tendrás que crear tu propia tribu. Después de poco tiempo, te encontrarás en la Edad Media y tendrás que sobrevivir a la plaga e inventar nueva tecnología, como la rueda. De allí, continuarás a través de los siglos hasta llegar a los tiempos modernos. ¡Necesitarás equilibrar la política mundial con tu agenda para guiar a tu pueblo hacia la conquista de la luna y de más allá!"
 
-#: content/Default/apps/content.json.h:180
+#: content/Default/apps/content.json.h:192
 msgctxt "title"
 msgid "FreeCol"
 msgstr "ColLibre"
 
-#: content/Default/apps/content.json.h:181
+#: content/Default/apps/content.json.h:193
 msgctxt "subtitle"
 msgid "Create your own country and conquer the world"
 msgstr "Crea tu propio país y deja tu huella en el mundo"
 
-#: content/Default/apps/content.json.h:182
+#: content/Default/apps/content.json.h:194
 msgctxt "description"
 msgid ""
 "Have you ever wanted to start your own country? Well, now you can. Go back "
@@ -1243,17 +1284,17 @@ msgid ""
 "prosperity? You decide."
 msgstr "¿Alguna vez has querido crear tu propio país? Bueno, ahora mismo lo puedes crear. Este juego te mete a un universo alternativo en donde las Américas aún no han sido colonizadas. Puedes crear todos los pueblos, ciudades y estados que tu quieras. Tendrás demasiado poder, ¿entonces que harás? ¿Intentarás dominar el mundo, o promoverás la paz y la prosperidad internacional? Tú decides."
 
-#: content/Default/apps/content.json.h:183
+#: content/Default/apps/content.json.h:195
 msgctxt "title"
 msgid "FrostTorrent"
 msgstr "FrostTorrent"
 
-#: content/Default/apps/content.json.h:184
+#: content/Default/apps/content.json.h:196
 msgctxt "subtitle"
 msgid "Download nearly anything or share your own files"
 msgstr "Descarga o comparte archivos a través de internet"
 
-#: content/Default/apps/content.json.h:185
+#: content/Default/apps/content.json.h:197
 msgctxt "description"
 msgid ""
 "Access, download and share almost any file you'd like to with this useful "
@@ -1265,17 +1306,17 @@ msgid ""
 "**Requires Internet"
 msgstr "¡Ahora puedes buscar y descargar todas tus canciones y videos favoritos del internet muy fácilmente! Solo conéctate a la red de BitTorrent con este programa y podrás compartir archivos con otros usuarios de esta gran comunidad. Todos los archivos en este programa son gratis, y puedes buscar por genero, tipo de archivo y varios otros criterios. ¡Seguramente encontrarás exactamente lo que quieres!  **Requiere Internet"
 
-#: content/Default/apps/content.json.h:186
+#: content/Default/apps/content.json.h:198
 msgctxt "title"
 msgid "Frozen Bubbles"
 msgstr "Burbujitas"
 
-#: content/Default/apps/content.json.h:187
+#: content/Default/apps/content.json.h:199
 msgctxt "subtitle"
 msgid "Pop bubbles before they all come crashing down"
 msgstr "El juego más adictivo que jamás jugarás"
 
-#: content/Default/apps/content.json.h:188
+#: content/Default/apps/content.json.h:200
 msgctxt "description"
 msgid ""
 "Play by yourself or challenge your friends to an exciting game of frozen "
@@ -1284,17 +1325,17 @@ msgid ""
 " have a good strategy and develop a quick trigger finger in order to win!"
 msgstr "¡Juega solo o desafía a tus amigos a un juego emocionante de burbujitas! Une las burbujas del mismo color para derribarlas y sacarlas del camino antes de que se apilen demasiado alto y te caigan encima. ¡Necesitas una estrategia buena, tanto como desarrollar un dedo rápido, para ganar!"
 
-#: content/Default/apps/content.json.h:189
+#: content/Default/apps/content.json.h:201
 msgctxt "title"
 msgid "EduGames"
 msgstr "EduJuegos"
 
-#: content/Default/apps/content.json.h:190
+#: content/Default/apps/content.json.h:202
 msgctxt "subtitle"
 msgid "Puzzles, memory games, and more for kids"
 msgstr "Actividades, rompecabezas y juegos de memoria"
 
-#: content/Default/apps/content.json.h:191
+#: content/Default/apps/content.json.h:203
 msgctxt "description"
 msgid ""
 "This app makes learning fun for young children with more than 100 games and "
@@ -1304,17 +1345,17 @@ msgid ""
 "him or her throughout life."
 msgstr "¡Este programa hace el aprendizaje divertido para los niños con más de 100 juegos y actividades! Los temas educativos incluyen lectura, geografía y matemáticas. Este programa también contiene juegos como ajedrez y Conecta Cuatro, que son excelentes para los cerebros de niños. Tu hijo o hija se divertirá desarrollando habilidades valiosas que le ayudarán por toda su vida."
 
-#: content/Default/apps/content.json.h:192
+#: content/Default/apps/content.json.h:204
 msgctxt "title"
 msgid "EduGames Admin"
 msgstr "EduJuegos admin"
 
-#: content/Default/apps/content.json.h:193
+#: content/Default/apps/content.json.h:205
 msgctxt "subtitle"
 msgid "For teachers to help their students learn"
 msgstr "Para maestros: juegos educativos para estudiantes"
 
-#: content/Default/apps/content.json.h:194
+#: content/Default/apps/content.json.h:206
 msgctxt "description"
 msgid ""
 "Use this app to configure the EduGames app and create the exact learning "
@@ -1325,17 +1366,17 @@ msgid ""
 " fun that they'll want to spend hours doing just what you want them to!"
 msgstr "Utiliza este programa para configurar EduJuegos y crear la experiencia exacta que deseas para tus estudiantes. Podrás cambiar la lista de actividades, o cambiar los controles del programa para que se mantengan enfocados sólo en los juegos que quieras. Para empezar, descarga este programa y la de EduJuegos, que se encuentra en la sección de 'Juegos' en la tienda de programas. ¡Tus estudiantes se divertirán tanto que querrán pasar horas haciendo justo lo que quieres que hagan - aprender!"
 
-#: content/Default/apps/content.json.h:195
+#: content/Default/apps/content.json.h:207
 msgctxt "title"
 msgid "Gedit"
 msgstr "Gedit"
 
-#: content/Default/apps/content.json.h:196
+#: content/Default/apps/content.json.h:208
 msgctxt "subtitle"
 msgid "A simple text editor for all of your text editing needs"
 msgstr "Un editor de texto para todas tus necesidades"
 
-#: content/Default/apps/content.json.h:197
+#: content/Default/apps/content.json.h:209
 msgctxt "description"
 msgid ""
 "Use this simple app to create and edit files that require plain text inputs."
@@ -1344,17 +1385,17 @@ msgid ""
 "should be perfect for all of your text editing needs."
 msgstr "Utiliza este programa para crear o editar archivos que requieren texto sin formato. Si eres un programador de computadoras aspirante o avanzado, este programa te será esencial. Con mucha funcionalidad y una interfaz que es fácil de usar, este editor de texto será perfecto para todas tus necesidades."
 
-#: content/Default/apps/content.json.h:198
+#: content/Default/apps/content.json.h:210
 msgctxt "title"
 msgid "GIMP"
 msgstr "GIMP"
 
-#: content/Default/apps/content.json.h:199
+#: content/Default/apps/content.json.h:211
 msgctxt "subtitle"
 msgid "Advanced image editing tool similar to Photoshop"
 msgstr "Editor de fotos avanzado y parecido a Photoshop"
 
-#: content/Default/apps/content.json.h:200
+#: content/Default/apps/content.json.h:212
 msgctxt "description"
 msgid ""
 "Edit your photos to create even more beautiful works of art with this "
@@ -1366,17 +1407,17 @@ msgid ""
 "images once you get the hang of this helpful editing app!"
 msgstr "¡Modifica tus fotos en una variedad de formas para crear obras de arte! Este programa es parecida al editor de fotos popular llamado Photoshop, que es para Windows, pero GIMP es gratis. Si eres un usuario avanzado puedes usar GIMP para hacer cosas como convertir los formatos de tus archivos o usar filtros y herramientas avanzados para retocar y modificar tus imágenes. Si eres un usuario nuevo, te puede servir como un programa básico de pintura. ¡Hay tantas posibilidades para crear imágenes bellas una vez que sepas cómo utilizar este programa!"
 
-#: content/Default/apps/content.json.h:201
+#: content/Default/apps/content.json.h:213
 msgctxt "title"
 msgid "Calculator"
 msgstr "Calculadora"
 
-#: content/Default/apps/content.json.h:202
+#: content/Default/apps/content.json.h:214
 msgctxt "subtitle"
 msgid "A scientific calculator with many bonus tools"
 msgstr "Una calculadora científica con muchas funciones"
 
-#: content/Default/apps/content.json.h:203
+#: content/Default/apps/content.json.h:215
 msgctxt "description"
 msgid ""
 "Do you ever consider how often you need to do basic or even complex math in "
@@ -1388,17 +1429,17 @@ msgid ""
 " again as long as you have this calculator app!"
 msgstr "¿Te has puesto a pensar con qué frecuencia necesitas usar matemáticas básicas o complejas en la vida diaria? Desde calcular un presupuesto o convertir medidas en una receta hasta lidiar con los impuestos, probablemente usas las ecuaciones más veces de las que imaginas. Es por eso que este programa es muy útil. Haz una aritmética simple rápidamente o deja que la calculadora haga trabajo más avanzado, dependiendo de tus necesidades. ¡Nunca volverás a tener dificultades para hacer tareas matemáticas cuando tengas este programa de calculadora abierta!"
 
-#: content/Default/apps/content.json.h:204
+#: content/Default/apps/content.json.h:216
 msgctxt "title"
 msgid "Math Plotting"
 msgstr "1,2,3 genio"
 
-#: content/Default/apps/content.json.h:205
+#: content/Default/apps/content.json.h:217
 msgctxt "subtitle"
 msgid "Interactive computation and data visualization tool"
 msgstr "Una calculadora avanzada para funciones difíciles"
 
-#: content/Default/apps/content.json.h:206
+#: content/Default/apps/content.json.h:218
 msgctxt "description"
 msgid ""
 "This math application offers advanced mathematical computing functions that "
@@ -1409,17 +1450,17 @@ msgid ""
 "here."
 msgstr "Este programa de matemáticas ofrece funciones avanzadas de computación que se pueden utilizar para mucho más que sólo cálculos básicos. Si eres un genio de las matemáticas a quien le gusta experimentar con esta disciplina, te encantará este programa. E incluso, si no lo eres, el programa funciona de maravilla como una calculadora de alto nivel. Todo lo que necesites saber sobre los misterios numéricos está aquí."
 
-#: content/Default/apps/content.json.h:207
+#: content/Default/apps/content.json.h:219
 msgctxt "title"
 msgid "Mines"
 msgstr "Minas"
 
-#: content/Default/apps/content.json.h:208
+#: content/Default/apps/content.json.h:220
 msgctxt "subtitle"
 msgid "Find and avoid all the dangerous mines to win"
 msgstr "Evita todas las minas peligrosas para ganar"
 
-#: content/Default/apps/content.json.h:209
+#: content/Default/apps/content.json.h:221
 msgctxt "description"
 msgid ""
 "Figure out where the dangerous mines are in order to stay alive and win the "
@@ -1429,17 +1470,17 @@ msgid ""
 " each direction. If you figure out where all the mines are, you'll win!"
 msgstr "¡Averigua dónde están las minas peligrosas para poder sobrevivir y ganar el juego! Cada cuadrado es mar o mina y tendrás únicamente que seleccionar los que son de mar. Si no seleccionas un cuadrado de mar, tendrás que empezar de nuevo. Cada vez que selecciones un cuadrado, descubrirás lo que es y te darás cuenta de cuántas minas hay alrededor y en cada dirección. ¡Cuando averigües donde están todas las minas, habrás ganado!"
 
-#: content/Default/apps/content.json.h:210
+#: content/Default/apps/content.json.h:222
 msgctxt "title"
 msgid "Screenshot"
 msgstr "Fotopantalla"
 
-#: content/Default/apps/content.json.h:211
+#: content/Default/apps/content.json.h:223
 msgctxt "subtitle"
 msgid "Take a picture of your screen to save"
 msgstr "Toma una foto de tu pantalla y guárdala"
 
-#: content/Default/apps/content.json.h:212
+#: content/Default/apps/content.json.h:224
 msgctxt "description"
 msgid ""
 "Do you ever wish you could take a picture of your screen to save? Well now "
@@ -1448,18 +1489,18 @@ msgid ""
 "make sure to save just what you need and nothing more."
 msgstr "¿Has querido alguna vez tomarle una foto a tu pantalla para poderla guardar? Ahora puedes, con este programa de captura de pantalla que es muy fácil de usar. Puedes escoger entre tomarle una foto a tu pantalla entera, o a solo una de las ventanas abiertas. Así puedes asegurarte que solo estas guardando lo que necesitas y nada más."
 
-#: content/Default/apps/content.json.h:213
-#: content/Default/apps/content.json.h:297
+#: content/Default/apps/content.json.h:225
+#: content/Default/apps/content.json.h:306
 msgctxt "title"
 msgid "Sudoku"
 msgstr "Sudoku"
 
-#: content/Default/apps/content.json.h:214
+#: content/Default/apps/content.json.h:226
 msgctxt "subtitle"
 msgid "One of the most popular puzzle games of all time"
 msgstr "Una rompecabezas popular en todo el mundo"
 
-#: content/Default/apps/content.json.h:215
+#: content/Default/apps/content.json.h:227
 msgctxt "description"
 msgid ""
 "If you’re a fan of puzzles and math games, the Sudoku app is perfect for "
@@ -1470,17 +1511,17 @@ msgid ""
 "fun solving Sudoku puzzles and exercising your mind!"
 msgstr "Si eres un fanático de los rompecabezas y los juegos de matemáticas, el programa de Sudoku te entretendrá por horas. Éstos son enigmas divertidos donde hay que organizar los números del 1 al 9 en una cuadrícula de modo que no haya ningún duplicado en cualquiera de las filas o columnas de la cuadrícula más grande. Puede parecer complicado al principio, pero con este programa, podrás aprender a jugar y te acostumbrarás en poco tiempo. ¡Muy pronto te divertirás resolviendo rompecabezas Sudoku y ejercitando tu mente!"
 
-#: content/Default/apps/content.json.h:216
+#: content/Default/apps/content.json.h:228
 msgctxt "title"
 msgid "Terminal"
 msgstr "Terminal"
 
-#: content/Default/apps/content.json.h:217
+#: content/Default/apps/content.json.h:229
 msgctxt "subtitle"
 msgid "Use the command line"
 msgstr "Utiliza la línea de comandos"
 
-#: content/Default/apps/content.json.h:218
+#: content/Default/apps/content.json.h:230
 msgctxt "description"
 msgid ""
 "If you're an advanced user and want to display system information and launch"
@@ -1490,17 +1531,17 @@ msgid ""
 "in correctly and to help you easily identify any mistakes you have made."
 msgstr "Si eres un usuario de computadoras avanzado y deseas acceder a la información del sistema y ejecutar programas sin usar el ratón, ahora puedes hacer precisamente eso con este programa básico del terminal. Con esta terminal moderna puedes ver todos los comandos que escribes en diferentes colores para asegurarte de que estás escribiendo todo correctamente y para ayudarte a identificar fácilmente cualquier error que hayas cometido."
 
-#: content/Default/apps/content.json.h:219
+#: content/Default/apps/content.json.h:231
 msgctxt "title"
 msgid "Tetravex"
 msgstr "Tetravex"
 
-#: content/Default/apps/content.json.h:220
+#: content/Default/apps/content.json.h:232
 msgctxt "subtitle"
 msgid "Race the clock in a numerical puzzle game"
 msgstr "Divertido rompecabezas numérico"
 
-#: content/Default/apps/content.json.h:221
+#: content/Default/apps/content.json.h:233
 msgctxt "description"
 msgid ""
 "Try to match up all of the same numbers on the blocks to win this tricky "
@@ -1509,17 +1550,17 @@ msgid ""
 "beat your or your friends' best time!"
 msgstr "Intenta combinar todos los números en los bloques para poder ganar. Tendrás que pensar rápidamente en estrategias para poder terminar el rompecabezas. El tiempo estará medido, así que tendrás que apresurarte cada vez para poder ganar la carrera contra el reloj, vencer tus amigos y sacar más puntos que la última vez que jugaste."
 
-#: content/Default/apps/content.json.h:222
+#: content/Default/apps/content.json.h:234
 msgctxt "title"
 msgid "Notes"
 msgstr "Notas"
 
-#: content/Default/apps/content.json.h:223
+#: content/Default/apps/content.json.h:235
 msgctxt "subtitle"
 msgid "Never lose a note again"
 msgstr "Jamás volverás a perder una nota"
 
-#: content/Default/apps/content.json.h:224
+#: content/Default/apps/content.json.h:236
 msgctxt "description"
 msgid ""
 "Do you find yourself writing down lots of notes on pieces of paper that "
@@ -1530,17 +1571,17 @@ msgid ""
 "notes and stay even more organized!"
 msgstr "¿Te encuentras escribiendo un montón de notas en pedazos de papel que luego se pierden o se rompen? O bien, ¿hay tantas notas en tu escritorio que te estás quedando sin espacio? No importa qué tipo de notas necesites tomar, este programa te puede ayudar a mantener todo en un solo lugar. Este programa también tiene la capacidad de enlazar tus notas juntas para que puedas acceder notas relacionadas rápidamente. ¡Así que te harás mucho más organizado de lo que ya eres!"
 
-#: content/Default/apps/content.json.h:225
+#: content/Default/apps/content.json.h:237
 msgctxt "title"
 msgid "Dictionary"
 msgstr "Diccionario"
 
-#: content/Default/apps/content.json.h:226
+#: content/Default/apps/content.json.h:238
 msgctxt "subtitle"
 msgid "A cool dictionary with lots of bonus tools"
 msgstr "Un diccionario con varias funciones addicionales"
 
-#: content/Default/apps/content.json.h:227
+#: content/Default/apps/content.json.h:239
 msgctxt "description"
 msgid ""
 "In reading and conversation, words often come up with which you’re not "
@@ -1550,12 +1591,12 @@ msgid ""
 "word you’re looking for!"
 msgstr "En la lectura y en la conversación, a veces encuentras palabras desconocidas. Es una buen idea tener un diccionario cerca para que puedas aprender nuevo vocabulario y entender lo que lees y escuchas. Este programa es fácil de usar y navegar, por lo que nunca vas a tener problemas para encontrar justo la palabra que estás buscando."
 
-#: content/Default/apps/content.json.h:228
+#: content/Default/apps/content.json.h:240
 msgctxt "title"
 msgid "GT Curriculum"
 msgstr "Currículo"
 
-#: content/Default/apps/content.json.h:230
+#: content/Default/apps/content.json.h:242
 msgctxt "description"
 msgid ""
 "Use this app to find the basic curriculum plan and guidelines for a specific"
@@ -1567,17 +1608,17 @@ msgid ""
 "difference both your child's life and your own."
 msgstr "El Ministerio de Educación de Guatemala ha hecho disponible este recurso valioso para que puedas encontrar el currículo básico de cualquier grado, así como hojas de trabajo que pueden ayudar a tus niños a aprender temas difíciles. Lee los manuales para aprender cómo se estructura la educación primaria y secundaria. Aprende cómo ayudar a los niños a crecer de forma saludable. Instrúyete acerca de una variedad de otros temas importantes que pueden hacer una gran diferencia en la vida de tus hijos y en la tuya."
 
-#: content/Default/apps/content.json.h:231
+#: content/Default/apps/content.json.h:243
 msgctxt "title"
 msgid "EduCollections"
 msgstr "EduColecciones"
 
-#: content/Default/apps/content.json.h:232
+#: content/Default/apps/content.json.h:244
 msgctxt "subtitle"
 msgid "All sorts of information to help better your life"
 msgstr "Todo tipo de información a tu dispocisión con un clic"
 
-#: content/Default/apps/content.json.h:233
+#: content/Default/apps/content.json.h:245
 msgctxt "description"
 msgid ""
 "This app is full of reliable information sent directly from the Guatemalan "
@@ -1590,17 +1631,17 @@ msgid ""
 "your age."
 msgstr "Este programa está lleno de información recolectada por el gobierno de Guatemala para ayudarte a vivir una vida más sana y próspera. Encontrarás información sobre el cultivo de diferentes tipos de plantas, consejos para las madres antes y después del embarazo, herramientas útiles para la preparación de un plan de estudio, hojas de trabajo para los estudiantes, textos que enseñan la lengua maya y mucha más información. Esta fuente de conocimiento está disponible para cuando la necesites."
 
-#: content/Default/apps/content.json.h:234
+#: content/Default/apps/content.json.h:246
 msgctxt "title"
 msgid "Health Guides"
 msgstr "Guías de salud"
 
-#: content/Default/apps/content.json.h:235
+#: content/Default/apps/content.json.h:247
 msgctxt "subtitle"
 msgid "Health guides that could save your life"
 msgstr "Guías de salud que podrían salvar tu vida"
 
-#: content/Default/apps/content.json.h:236
+#: content/Default/apps/content.json.h:248
 msgctxt "description"
 msgid ""
 "This app contains some of the most life saving documents that you'll ever "
@@ -1609,38 +1650,17 @@ msgid ""
 " learn to help your loved ones, those in your community and even yourself!"
 msgstr "Encuentra información que podría salvar tu vida algún día, la de tus seres queridos o la de alguien en tu comunidad. Para empezar, abre la carpeta llamada 'Materiales de Salud' para aprender cómo llevar a cabo auto exámenes y procedimientos menores. Te sorprenderás de todo lo que se puede aprender con sólo leer algunos artículos sobre salud."
 
-#: content/Default/apps/content.json.h:237
-msgctxt "title"
-msgid "Textbooks"
-msgstr "Libros de texto"
-
-#: content/Default/apps/content.json.h:238
-msgctxt "subtitle"
-msgid "Textbooks for students, parents and teachers"
-msgstr "Libros de texto para estudiantes y maestros"
-
-#: content/Default/apps/content.json.h:239
-msgctxt "description"
-msgid ""
-"Select a grade level and prepare yourself to learn directly from your "
-"computer! This app contains textbooks, worksheets and other learning tools, "
-"to teach or supplement your learning. Whether you're a student needing extra"
-" homework help, a parent helping to develop a child's education, or someone "
-"seeking to learn more in their spare time, you'll find this app to be "
-"incredibly useful."
-msgstr "¡Selecciona un nivel de grado y prepárate para aprender directamente desde tu computadora! Este programa contiene libros de texto, hojas de cálculo y otras herramientas de aprendizaje para ayudarte a dominar la materia que estudias. Tanto si eres un estudiante que necesita ayuda adicional para tu tarea, un padre que quiere ayudar a su niño, o alguien que desea aprender más en su tiempo libre, encontrarás que este programa te será increíblemente útil."
-
-#: content/Default/apps/content.json.h:240
+#: content/Default/apps/content.json.h:249
 msgctxt "title"
 msgid "Iagno"
 msgstr "Iagno"
 
-#: content/Default/apps/content.json.h:241
+#: content/Default/apps/content.json.h:250
 msgctxt "subtitle"
 msgid "A fun puzzle game that involves lots of thought"
 msgstr "Entretenidos rompecabezas que te harán pensar"
 
-#: content/Default/apps/content.json.h:242
+#: content/Default/apps/content.json.h:251
 msgctxt "description"
 msgid ""
 "Turn over the pieces in front of you so that they are all the same color. "
@@ -1651,17 +1671,17 @@ msgid ""
 "strategically and see if you can figure this puzzle out!"
 msgstr "Voltea cada ficha en frente de ti para que todas sean del mismo color para ganar esta rompecabezas. ¿Sencillo? ¡Para nada! Puedes cambiar las fichas a tu color si puedes poner una de tus fichas en un lugar donde se forma un línea horizontal, vertical o diagonal con fichas todas del mismo color. Necesitas voltear cada ficha con mucho cuidado para lograr cambiar todas a ser de tu color. ¡Juega y crea estrategias para poder resolver este rompecabezas!"
 
-#: content/Default/apps/content.json.h:243
+#: content/Default/apps/content.json.h:252
 msgctxt "title"
 msgid "Inkscape"
 msgstr "Inkscape"
 
-#: content/Default/apps/content.json.h:244
+#: content/Default/apps/content.json.h:253
 msgctxt "subtitle"
 msgid "An advanced graphic design tool"
 msgstr "Un editor de gráficos para diseñadores avanzados"
 
-#: content/Default/apps/content.json.h:245
+#: content/Default/apps/content.json.h:254
 msgctxt "description"
 msgid ""
 "This app is for intermediate and advanced graphic designers who need to "
@@ -1672,17 +1692,17 @@ msgid ""
 "presentations and artwork with this great free graphics app!"
 msgstr "Este programa es para diseñadores gráficos intermedios y avanzados que necesitan crear y editar gráficos e imágenes. Este programa te brinda funciones avanzadas y es comparable a Adobe InDesign. Por ejemplo, te permite crear imágenes en SVG (gráficos vectoriales escalables), que permiten que los gráficos conserven su alta calidad, no importa qué tamaño sean. ¡Crea bellos anuncios, folletos, presentaciones y obras de arte con este programa gratuito y excelente!"
 
-#: content/Default/apps/content.json.h:246
+#: content/Default/apps/content.json.h:255
 msgctxt "title"
 msgid "Kalzium"
 msgstr "Química"
 
-#: content/Default/apps/content.json.h:247
+#: content/Default/apps/content.json.h:256
 msgctxt "subtitle"
 msgid "A fun interactive periodic table of elements"
 msgstr "Una tabla periódica interactiva y divertida"
 
-#: content/Default/apps/content.json.h:248
+#: content/Default/apps/content.json.h:257
 msgctxt "description"
 msgid ""
 "The periodic table of the elements is one of the basic building blocks of "
@@ -1695,17 +1715,17 @@ msgid ""
 "simple, and informative app."
 msgstr "La tabla periódica de los elementos es una de las bases fundamentales del conocimiento científico, y este programa te ayudará a memorizarla más fácil que nunca. Selecciona elementos en la tabla para aprender información básica sobre ellos incluyendo sus puntos de fusión, masa y más. Información más compleja como la visualización de las líneas espectrales de elementos, hace que este programa sea indispensable para descubrimiento científico. No vas a creer cuanto se puede aprender con este programa hermoso, simple e informativo."
 
-#: content/Default/apps/content.json.h:249
+#: content/Default/apps/content.json.h:258
 msgctxt "title"
 msgid "Kapman"
 msgstr "PacMan II"
 
-#: content/Default/apps/content.json.h:250
+#: content/Default/apps/content.json.h:259
 msgctxt "subtitle"
 msgid "The classic game of ghosts and mazes"
 msgstr "El juego clásico de fantasmas y laberintos"
 
-#: content/Default/apps/content.json.h:251
+#: content/Default/apps/content.json.h:260
 msgctxt "description"
 msgid ""
 "If you love Pac-Man, then you you'll love this game too! Eat dots to gain "
@@ -1715,17 +1735,17 @@ msgid ""
 "and family, from kids to grandparents, will love the game, too!"
 msgstr "¡Si te gusta Pac-Man también te gustará este juego! Cómete los puntos para ganar puntos pero no dejes que los fantasmas te atrapen o perderás. Conforme ganas habilidad y pases de niveles, la velocidad del juego aumentará, dándote un desafío cada vez más y más emocionante. ¡No querrás dejar de jugar y tus amigos y familia desde los niños hasta los abuelos no querrán dejar de jugarlo también!"
 
-#: content/Default/apps/content.json.h:252
+#: content/Default/apps/content.json.h:261
 msgctxt "title"
 msgid "KAtomic"
 msgstr "Átomos"
 
-#: content/Default/apps/content.json.h:253
+#: content/Default/apps/content.json.h:262
 msgctxt "subtitle"
 msgid "A fun way to learn chemistry"
 msgstr "Una manera divertida de aprender química"
 
-#: content/Default/apps/content.json.h:254
+#: content/Default/apps/content.json.h:263
 msgctxt "description"
 msgid ""
 "If you’re struggling with concepts in chemistry, or simply looking for a way"
@@ -1737,17 +1757,17 @@ msgid ""
 " a ton!"
 msgstr "Si descubres que te cuesta aprender los conceptos de química, o simplemente si estás en busca de una manera de fortalecer tu entendimiento, ¡has encontrado el programa perfecto para ayudarte! En este desafiante juego tendrás que crear moléculas de los átomos que se te dan. Verás ejemplos de moléculas en tu pantalla y tendrás que mover tus átomos para formarlas. Este juego requiere de estrategia y pensamiento rápido, ¡y te enseñará más de lo que imaginabas posible!"
 
-#: content/Default/apps/content.json.h:255
+#: content/Default/apps/content.json.h:264
 msgctxt "title"
 msgid "KBlackBox"
 msgstr "CajaNegra"
 
-#: content/Default/apps/content.json.h:256
+#: content/Default/apps/content.json.h:265
 msgctxt "subtitle"
 msgid "Find the pattern and uncover the hidden balls"
 msgstr "Encuentra a las esferas ocultas"
 
-#: content/Default/apps/content.json.h:257
+#: content/Default/apps/content.json.h:266
 msgctxt "description"
 msgid ""
 "This game takes some serious logic, but don’t be scared away – it’s also "
@@ -1757,17 +1777,17 @@ msgid ""
 "hidden ones are placed. The more you get right, the higher your score."
 msgstr "¡Este juego requiere que uses tu lógica para descubrir en dónde están escondidas las esferas! Las bolas están escondidas debajo de unas cajas negras y tendrás que adivinar en cuáles están. Tendrás un rayo láser para revelar dónde se encuentran las esferas, ¡así que presta atención y empieza a adivinar! ¡Si adivinas correctamente adquirás puntos y ganarás!"
 
-#: content/Default/apps/content.json.h:258
+#: content/Default/apps/content.json.h:267
 msgctxt "title"
 msgid "KBruch"
 msgstr "Fracciones"
 
-#: content/Default/apps/content.json.h:259
+#: content/Default/apps/content.json.h:268
 msgctxt "subtitle"
 msgid "Learn about fractions, percentages and more"
 msgstr "Aprende sobre fracciones, porcentajes y más"
 
-#: content/Default/apps/content.json.h:260
+#: content/Default/apps/content.json.h:269
 msgctxt "description"
 msgid ""
 "One of the trickiest parts of the math we do every day is calculating "
@@ -1779,17 +1799,17 @@ msgid ""
 "benefit you in unexpected ways!"
 msgstr "Usamos mucho las fracciones y porcentajes en nuestra vida cotidiana, como por ejemplo para calcular cuánto costará algo después de algún descuento; entonces es importante dominar la habilidad de hacer estos cálculos fácilmente. Este programa te ayudará a hacer precisamente eso. Encontrarás varios juegos y ejercicios para mejorar tus habilidades matemáticas incluyendo temas como la aritmética, comparación, conversión y factorización. Aprende todo acerca de fracciones y porcentajes y practica cuando quieras. ¡Si practicas y dominas las matemáticas, verás como tus nuevas habilidades te beneficiarán de maneras inesperadas!"
 
-#: content/Default/apps/content.json.h:261
+#: content/Default/apps/content.json.h:270
 msgctxt "title"
 msgid "KSnake"
 msgstr "Serpientes"
 
-#: content/Default/apps/content.json.h:262
+#: content/Default/apps/content.json.h:271
 msgctxt "subtitle"
 msgid "A fun and very simple game for everyone"
 msgstr "Un juego divertido y sencillo para todas las edades"
 
-#: content/Default/apps/content.json.h:263
+#: content/Default/apps/content.json.h:272
 msgctxt "description"
 msgid ""
 "Similar to the popular arcade game, Snake, this classic game will help you "
@@ -1798,17 +1818,17 @@ msgid ""
 "snakes grow longer, promising a fun challenge to players of all levels."
 msgstr "En este juego tienes que guiar una serpiente hacia su comida. Al comer, la serpiente crece y el juego se hará más difícil, ya que si la serpiente choca contra otra serpiente o contra la pared, el juego se acaba. ¡Este juego es sencillo, pero muy divertido! Este juego entretendrá a personas de todas edades."
 
-#: content/Default/apps/content.json.h:264
+#: content/Default/apps/content.json.h:273
 msgctxt "title"
 msgid "KGeography"
 msgstr "GeoMapas"
 
-#: content/Default/apps/content.json.h:265
+#: content/Default/apps/content.json.h:274
 msgctxt "subtitle"
 msgid "Become a geography genius while having fun"
 msgstr "Conviértete en un genio de la geografía"
 
-#: content/Default/apps/content.json.h:266
+#: content/Default/apps/content.json.h:275
 msgctxt "description"
 msgid ""
 "How much do you know about world geography and political affairs? Learn the "
@@ -1819,17 +1839,17 @@ msgid ""
 "and will have had a lot of fun learning it all!"
 msgstr "¿Cuánto sabes acerca del mundo y de los asuntos políticos? ¡Este juego te ayudará a convertirte en un genio de la geografía! Primero, consulta el mapa y aprende acerca de los nombres, capitales y banderas de cada país. ¡Después, pon a prueba tus conocimientos! Adivina capitales y banderas, o trata de colocar las fronteras nacionales en un mapa vacío. ¡Antes de que lo sepas, conocerás todos los rincones del mundo!"
 
-#: content/Default/apps/content.json.h:267
+#: content/Default/apps/content.json.h:276
 msgctxt "title"
 msgid "KGoldrunner"
 msgstr "Minas de oro"
 
-#: content/Default/apps/content.json.h:268
+#: content/Default/apps/content.json.h:277
 msgctxt "subtitle"
 msgid "Look for treasure and hide from enemies"
 msgstr "Busca el tesoro y escóndete de tus enemigos"
 
-#: content/Default/apps/content.json.h:269
+#: content/Default/apps/content.json.h:278
 msgctxt "description"
 msgid ""
 "Your enemies are right on your heels as you move through mazes collecting "
@@ -1839,17 +1859,17 @@ msgid ""
 " through any trapdoors!"
 msgstr "Tus enemigos te están persiguiendo mientras buscas y recoges oro por los laberintos en este juego. Con rompecabezas desafiantes y un objetivo emocionante, este juego se convertirá en uno de tus juegos favoritos. ¡Encontrarás muchos niveles y tendrás diversión por horas, con nuevos laberintos en cada nivel!"
 
-#: content/Default/apps/content.json.h:270
+#: content/Default/apps/content.json.h:279
 msgctxt "title"
 msgid "KHangMan"
 msgstr "Ahorcado"
 
-#: content/Default/apps/content.json.h:271
+#: content/Default/apps/content.json.h:280
 msgctxt "subtitle"
 msgid "One of the most fun word games on earth"
 msgstr "Juego de vocabulario hecho para niños de 6+ años"
 
-#: content/Default/apps/content.json.h:272
+#: content/Default/apps/content.json.h:281
 msgctxt "description"
 msgid ""
 "Practice your vocabulary the fun way! You'll learn new words with this "
@@ -1861,17 +1881,17 @@ msgid ""
 "have to start over with a new word!"
 msgstr "¡Practica y aumenta tu vocabulario de modo divertido! Toda la familia podrá jugar contigo. ¿Cómo se juega? Bueno, primero la computadora escogerá una palabra y tendrás que adivinarla. Para hacer esto, empieza por adivinar letra por letra, y así podrás ver cuáles letras faltan y tendrás mejor idea de la palabra misteriosa. ¿Qué tan rápido puedes adivinar las palabras? Si fallas 10 veces, perderás y necesitarás tratar de nuevo. ¡Mejora tu vocabulario mientras que te diviertes por horas! Este juego está hecho para niños de 6+ años, ¡pero gente de todas edades querrán jugar!"
 
-#: content/Default/apps/content.json.h:273
+#: content/Default/apps/content.json.h:282
 msgctxt "title"
 msgid "Kigo"
 msgstr "Go"
 
-#: content/Default/apps/content.json.h:274
+#: content/Default/apps/content.json.h:283
 msgctxt "subtitle"
 msgid "The ancient game of skill, updated for modern play"
 msgstr "Un juego vigorizante"
 
-#: content/Default/apps/content.json.h:275
+#: content/Default/apps/content.json.h:284
 msgctxt "description"
 msgid ""
 "Based on a two-player board game popular in Asia, this app has easy-to-learn"
@@ -1883,17 +1903,17 @@ msgid ""
 "too!"
 msgstr "¿Te gusta la estrategia? ¡Encuentra a un adversario formidable y prepárate para horas de entretenimiento! Basado en un juego que es muy popular en Asia, este juego tiene reglas que son bastante fáciles de aprender pero jugarlo requiere de gran estrategia. Es la manera perfecta de pasar el tiempo ejercitando tu mente. El objetivo es simple: mueve las piezas blancas o negras en la cuadrícula (el tamaño de la cuadrícula depende del nivel de dificultad que elijas), y trata de rodear a la tabla con todas tus piezas, o con más de las de tu adversario. Si te gustan los juegos de estrategia como el ajedrez, ¡entonces te encantará este juego también!"
 
-#: content/Default/apps/content.json.h:276
+#: content/Default/apps/content.json.h:285
 msgctxt "title"
 msgid "Killbots"
 msgstr "Killbots"
 
-#: content/Default/apps/content.json.h:277
+#: content/Default/apps/content.json.h:286
 msgctxt "subtitle"
 msgid "Outsmart the killer robots to win"
 msgstr "Escápate de los robots asesinos que te persiguen"
 
-#: content/Default/apps/content.json.h:278
+#: content/Default/apps/content.json.h:287
 msgctxt "description"
 msgid ""
 "How will you get away from the killer robots bent on destruction? Figure it "
@@ -1903,17 +1923,17 @@ msgid ""
 "tell the tale!"
 msgstr "En este simple juego tienes que escaparte de los robots. Ellos son asesinos que tienen un sólo objetivo: destruirte. Afortunadamente, el creador de los robots se enfocó en crear muchos en vez de crearlos de buena calidad. ¡Tu inteligencia superior y un aparato de tele-transporte te ayudarán a combatir a esos robots y ganar!"
 
-#: content/Default/apps/content.json.h:279
+#: content/Default/apps/content.json.h:288
 msgctxt "title"
 msgid "Kolor Lines"
 msgstr "Kolor líneas"
 
-#: content/Default/apps/content.json.h:280
+#: content/Default/apps/content.json.h:289
 msgctxt "subtitle"
 msgid "Line up balls of the same color to win"
 msgstr "Alinea los círculos del mismo color para ganar"
 
-#: content/Default/apps/content.json.h:281
+#: content/Default/apps/content.json.h:290
 msgctxt "description"
 msgid ""
 "This game is so fun and addicting, you’ll never want to stop playing. The "
@@ -1924,17 +1944,17 @@ msgid ""
 "possible; you lose if it fills up completely!"
 msgstr "¡Este juego es tan divertido y adictivo que nunca querrás dejar de jugar! El concepto es simple: junta las esferas en líneas de cinco del mismo color para eliminarlos del tablero y ganar. Es más difícil de lo que esperas porque nuevas esferas te caen después de cada movimiento. ¡No dejes que se te llene el tablero de esferas, o perderás!"
 
-#: content/Default/apps/content.json.h:282
+#: content/Default/apps/content.json.h:291
 msgctxt "title"
 msgid "KMines"
 msgstr "KMinas"
 
-#: content/Default/apps/content.json.h:283
+#: content/Default/apps/content.json.h:292
 msgctxt "subtitle"
 msgid "Stay away from the exploding mines"
 msgstr "Manténte alejado minas peligrosas"
 
-#: content/Default/apps/content.json.h:284
+#: content/Default/apps/content.json.h:293
 msgctxt "description"
 msgid ""
 "Don't take a wrong step or you'll explode! You'll need to use logic and "
@@ -1942,17 +1962,17 @@ msgid ""
 "safely across the field."
 msgstr "¡No des un paso equivocado o explotarás! Haz buen uso de tu inteligencia y la lógica para encontrar un camino seguro alrededor de todas las minas que están escondidas en el campo."
 
-#: content/Default/apps/content.json.h:285
+#: content/Default/apps/content.json.h:294
 msgctxt "title"
 msgid "Battleships"
 msgstr "Batalla naval"
 
-#: content/Default/apps/content.json.h:286
+#: content/Default/apps/content.json.h:295
 msgctxt "subtitle"
 msgid "Blow your opponents out of the water"
 msgstr "Elimina a tus adversarios con tu barco de guerra"
 
-#: content/Default/apps/content.json.h:287
+#: content/Default/apps/content.json.h:296
 msgctxt "description"
 msgid ""
 "Try to guess where your enemies ships are to blow them out of the water "
@@ -1963,17 +1983,17 @@ msgid ""
 "Arrr you ready for some great naval fun?"
 msgstr "¡Trata de adivinar en dónde están los barcos de tu adversario para eliminarlos antes de que te ataquen! Este es un divertido juego de estrategia que requiere de dos jugadores. Puedes jugar contra un amigo, contra otra persona en internet o contra la computadora. Tomarán turnos tratando de adivinar dónde están los barcos y el primer jugador en hundir todos los barcos de su enemigo gana el juego. ¿Estas listo para empezar la batalla?"
 
-#: content/Default/apps/content.json.h:288
+#: content/Default/apps/content.json.h:297
 msgctxt "title"
 msgid "KNetwalk"
 msgstr "Cables"
 
-#: content/Default/apps/content.json.h:289
+#: content/Default/apps/content.json.h:298
 msgctxt "subtitle"
 msgid "Make the right cable connections and win"
 msgstr "Haz las conexiones correctas para ganar"
 
-#: content/Default/apps/content.json.h:290
+#: content/Default/apps/content.json.h:299
 msgctxt "description"
 msgid ""
 "Who knew building computer networks could be fun? You'll need to create the "
@@ -1984,17 +2004,17 @@ msgid ""
 "enjoyable and competitive game you’ll love to play."
 msgstr "¿Quién sabía que crear redes informáticas sería tan divertido? Tendrás que crear las conexiones adecuadas en el menor número de turnos posible para ganar, ¡así que prepárate para mover los hilos y solucionar el rompecabezas rápidamente! Una vez que has tenido éxito, encontrarás una lista de puntuación para encontrar competidores. Esta aplicación te ayudará a entender cómo funcionan las redes de computadoras, pero más importante aún, es un juego divertido y competitivo que te encantará jugar."
 
-#: content/Default/apps/content.json.h:291
+#: content/Default/apps/content.json.h:300
 msgctxt "title"
 msgid "Kobo Deluxe"
 msgstr "Kobo deluxe"
 
-#: content/Default/apps/content.json.h:292
+#: content/Default/apps/content.json.h:301
 msgctxt "subtitle"
 msgid "Destroy enemy bases in space"
 msgstr "Destruye las bases enemigas en el espacio"
 
-#: content/Default/apps/content.json.h:293
+#: content/Default/apps/content.json.h:302
 msgctxt "description"
 msgid ""
 "Fans of arcade-style games will love this fun shooting game. Protect "
@@ -2003,17 +2023,17 @@ msgid ""
 "to play. You'll have hours and hours of fun blowing up things in space!"
 msgstr "Si te gustan las máquinas de sala de videojuegos, ¡te encantará este juego emocionante! Tendrás que navegar por lugares llenos de enemigos y protegerte de los que te persiguen. Estarás en el espacio - un ambiente completamente extraño. Si eres exitoso y logras navegar por los 50 niveles, ¡serás el campeón y ganarás el juego!"
 
-#: content/Default/apps/content.json.h:294
+#: content/Default/apps/content.json.h:303
 msgctxt "title"
 msgid "KSquares"
 msgstr "Totito chino"
 
-#: content/Default/apps/content.json.h:295
+#: content/Default/apps/content.json.h:304
 msgctxt "subtitle"
 msgid "Connect the dots in this challenging strategy game"
 msgstr "Juego de puntos y cuadrados"
 
-#: content/Default/apps/content.json.h:296
+#: content/Default/apps/content.json.h:305
 msgctxt "description"
 msgid ""
 "Based on a popular old game, this fun app lets you stretch your mind and "
@@ -2024,12 +2044,12 @@ msgid ""
 "entertainment. Be careful – you just might become addicted!"
 msgstr "Basado en un juego popular, este programa interactivo te ayudará a ejercitar tu mente al resolver rompecabezas difíciles. El objetivo es completar más cuadrados en la pantalla que tu oponente. Tomando turnos dibujando líneas entre puntos, se irán formando cuadrados y tendrás que bloquear los que intenta formar tu oponente. Este juego requiere pensamiento geométrico y una buena estrategia, y seguro te entretendrá por horas. ¡Ten cuidado, pronto serás un fanático de este juego!"
 
-#: content/Default/apps/content.json.h:298
+#: content/Default/apps/content.json.h:307
 msgctxt "subtitle"
 msgid "A challenging numerical puzzle game"
 msgstr "Rompecabezas desafiantes"
 
-#: content/Default/apps/content.json.h:299
+#: content/Default/apps/content.json.h:308
 msgctxt "description"
 msgid ""
 "Are you better than your friend is at puzzles? Find out by playing this fun "
@@ -2041,17 +2061,17 @@ msgid ""
 "Sudoku, or are an experienced player, you'll love this app!"
 msgstr "¿Eres mejor que tu amigo a los rompecabezas? Desafía a tu amigo a este juego de números rompecabezas y alístate para horas de diversión! Puedes jugar solo, con personas que te ayuden, o puedes desafiar a tus amigos y familiares para ver quién puede resolver el rompecabezas primero. Como extra, este programa te deja crear juegos que se pueden imprimir, y te dan la capacidad de ayudar a resolver cualquier rompecabezas Sudoku para que puedas aprender a resolverlo por tu propia cuenta. Aunque seas completamente nuevo a Sodoku, o eres un jugador experimentado, ¡te encantará este programa!"
 
-#: content/Default/apps/content.json.h:300
+#: content/Default/apps/content.json.h:309
 msgctxt "title"
 msgid "KSnakeDuel"
 msgstr "DueloSSS"
 
-#: content/Default/apps/content.json.h:301
+#: content/Default/apps/content.json.h:310
 msgctxt "subtitle"
 msgid "Survival depends on your reflexes and wits"
 msgstr "La supervivencia depende de tus reflejos e ingenio"
 
-#: content/Default/apps/content.json.h:302
+#: content/Default/apps/content.json.h:311
 msgctxt "description"
 msgid ""
 "Guide your snake to eat the apples and to avoid the other snakes, balls and "
@@ -2062,17 +2082,17 @@ msgid ""
 "fun challenge!"
 msgstr "¡Guía a tu serpiente a comer las manzanas y a evitar las otras serpientes, a las esferas y a las paredes! Algunas de las serpientes y esferas sólo te harán más lento, mientras que otras te matarán, ¡así que lo mejor es mantenerte alejado de todos! Si te las arreglas para comer todas las manzanas, tendrás que salir del laberinto para poder pasar al siguiente nivel. Este juego puede parecer fácil pero no lo es, ¡así que prepárate para un reto divertido!"
 
-#: content/Default/apps/content.json.h:303
+#: content/Default/apps/content.json.h:312
 msgctxt "title"
 msgid "Potato Guy"
 msgstr "Cara de papa"
 
-#: content/Default/apps/content.json.h:304
+#: content/Default/apps/content.json.h:313
 msgctxt "subtitle"
 msgid "Give your potato a funny face"
 msgstr "Dale una cara graciosa a tu patata"
 
-#: content/Default/apps/content.json.h:305
+#: content/Default/apps/content.json.h:314
 msgctxt "description"
 msgid ""
 "This is a silly game for children and their parents to play together. Based "
@@ -2082,17 +2102,17 @@ msgid ""
 "lots of laughter. Make the goofiest face you can!"
 msgstr "¡Este es un juego divertido para jugar con tus niños! Está basado en el juguete Sr. Cara de Papa, que te permite crear expresiones graciosas. Para formar una nueva cara, arrastra y suelta a los rasgos faciales en tu papa. Puedes ponerle bigotes, orejas de elfo, coletas rubias o un corbatín. ¡No hay objetivo en este juego, excepto darte un montón de risas!"
 
-#: content/Default/apps/content.json.h:306
+#: content/Default/apps/content.json.h:315
 msgctxt "title"
 msgid "Kubrick"
 msgstr "CuboRubik"
 
-#: content/Default/apps/content.json.h:307
+#: content/Default/apps/content.json.h:316
 msgctxt "subtitle"
 msgid "Like Rubik's Cube - create solid color sides to win"
 msgstr "Juego basado en el Cubo de Rubik"
 
-#: content/Default/apps/content.json.h:308
+#: content/Default/apps/content.json.h:317
 msgctxt "description"
 msgid ""
 "This puzzling game has lots of options to keep your brain working! Modeled "
@@ -2104,17 +2124,17 @@ msgid ""
 "even design your very own challenge!"
 msgstr "¡Este juego popular basado en el Cubo de Rubik viene con un montón de opciones extras para mantenerte entretenido por horas! El desafío es alinear los ladrillos del cubo para hacer lados del mismo color. Cuando domines el cubo regular, podrás tratar la otras figuras. Este programa incluye demostraciones de soluciones y movimientos hechos por los expertos, así que podrás seguirlos y tratar los movimientos para poder resolver el rompecabeza más rápidamente. ¡Otra cosa genial es que podrás incluso diseñar tu propio desafío!"
 
-#: content/Default/apps/content.json.h:309
+#: content/Default/apps/content.json.h:318
 msgctxt "title"
 msgid "KWordQuiz"
 msgstr "Vocabulario"
 
-#: content/Default/apps/content.json.h:310
+#: content/Default/apps/content.json.h:319
 msgctxt "subtitle"
 msgid "Grow your vocabulary and test your learning"
 msgstr "Aprende usando tarjetas virtuales"
 
-#: content/Default/apps/content.json.h:311
+#: content/Default/apps/content.json.h:320
 msgctxt "description"
 msgid ""
 "Learning new words is a great way to speak and write more clearly, but "
@@ -2125,17 +2145,17 @@ msgid ""
 "learning all you want."
 msgstr "Crea fichas virtuales de ayuda con este programa para poder aprender y memorizar nuevas palabras y datos. Podrás crear cuestionarios interactivos que te ayudarán a probar tus conocimientos para poder enfocarte en las áreas en donde necesites más práctica. Este programa será muy útil para los estudiantes y es muy fácil de usar."
 
-#: content/Default/apps/content.json.h:312
+#: content/Default/apps/content.json.h:321
 msgctxt "title"
 msgid "Breakout"
 msgstr "Breakout"
 
-#: content/Default/apps/content.json.h:313
+#: content/Default/apps/content.json.h:322
 msgctxt "subtitle"
 msgid "Destroy all the bricks to win this fun game"
 msgstr "Destruye los ladrillos para ganar en este juego adictivo"
 
-#: content/Default/apps/content.json.h:314
+#: content/Default/apps/content.json.h:323
 msgctxt "description"
 msgid ""
 "This classic paddle game is tons of fun! The aim is to destroy bricks with "
@@ -2145,17 +2165,17 @@ msgid ""
 " graphics and animation, intuitive controls, and plenty of levels to beat."
 msgstr "¡Este juego de raqueta clásico es demasiado divertido! El objetivo es destruir bloques con la pelota al golpearla con tu raqueta, lo que te permite subir de nivel. El juego original Breakout se publicó en 1976, y a la gente le ha encantado este juego sencillo pero adictivo desde entonces. Consigue tu dosis de rompe-ladrillos con excelentes gráficos y animaciones, controles intuitivos y muchos niveles que superar."
 
-#: content/Default/apps/content.json.h:315
+#: content/Default/apps/content.json.h:324
 msgctxt "title"
 msgid "Spreadsheet"
 msgstr "Hoja de cálculo"
 
-#: content/Default/apps/content.json.h:316
+#: content/Default/apps/content.json.h:325
 msgctxt "subtitle"
 msgid "A spreadsheet program with many functions"
 msgstr "Funciones avanzadas para calcular lo que necesites"
 
-#: content/Default/apps/content.json.h:317
+#: content/Default/apps/content.json.h:326
 msgctxt "description"
 msgid ""
 "Whatever you need to keep track of, the spreadsheet app can help you do it. "
@@ -2166,17 +2186,17 @@ msgid ""
 " job market."
 msgstr "Esta hoja de cálculo avanzada tiene algo para todos: un diseño simple que es fácil de entender y la posibilidad de hacer cálculos complejos. Las hojas de cálculo se utilizan en muchas profesiones en todo el mundo, así que aprender a utilizar este programa podría ayudarte a obtener valiosas habilidades para algún trabajo futuro."
 
-#: content/Default/apps/content.json.h:318
+#: content/Default/apps/content.json.h:327
 msgctxt "title"
 msgid "Presentation"
 msgstr "Presentaciones"
 
-#: content/Default/apps/content.json.h:319
+#: content/Default/apps/content.json.h:328
 msgctxt "subtitle"
 msgid "Create great presentations with this easy-to-use app"
 msgstr "Crea presentaciones espectaculares"
 
-#: content/Default/apps/content.json.h:320
+#: content/Default/apps/content.json.h:329
 msgctxt "description"
 msgid ""
 "Create clean, attractive, and professional presentations with this "
@@ -2187,17 +2207,17 @@ msgid ""
 "need."
 msgstr "Crea presentaciones limpias, atractivas y profesionales con este programa de presentación. Este programa cuenta con la posibilidad de utilizar texto, herramientas de dibujo, transiciones, arte en 2-D y 3-D e incluso animaciones, para expresarte como quieras. Y lo mejor es que este programa es fácil de entender, con pasos simplificados para crear exactamente lo que necesitas."
 
-#: content/Default/apps/content.json.h:321
+#: content/Default/apps/content.json.h:330
 msgctxt "title"
 msgid "Writer"
 msgstr "Escritor"
 
-#: content/Default/apps/content.json.h:322
+#: content/Default/apps/content.json.h:331
 msgctxt "subtitle"
 msgid "Free, similar to & compatible with Microsoft Word"
 msgstr "Parecido a y compatible con Microsoft Word, pero gratis"
 
-#: content/Default/apps/content.json.h:323
+#: content/Default/apps/content.json.h:332
 msgctxt "description"
 msgid ""
 "This app gives you all the features of the best word processing applications"
@@ -2209,17 +2229,17 @@ msgid ""
 "notes; either way, you’ll have simple yet powerful tools available."
 msgstr "Este programa te ofrece todas las funciones de los mejores programas de procesador de textos y es compatible con Microsoft Office. Crea y edita documentos con facilidad, crea notas cortas o ensayos largos con anotaciones y diagramas. Todo es posible. Tus documentos quedarán tan profesionales como para presentar a los empleadores, maestros u otras personas importantes. Utiliza este programa para escribir tu próxima obra maestra o para tomar notas excelentes. Tendrás herramienta sencilla y poderosa disponible para lo que necesites realizar."
 
-#: content/Default/apps/content.json.h:324
+#: content/Default/apps/content.json.h:333
 msgctxt "title"
 msgid "Maps"
 msgstr "Mapas"
 
-#: content/Default/apps/content.json.h:325
+#: content/Default/apps/content.json.h:334
 msgctxt "subtitle"
 msgid "Maps of the entire world"
 msgstr "Mapas de todo el mundo"
 
-#: content/Default/apps/content.json.h:326
+#: content/Default/apps/content.json.h:335
 msgctxt "description"
 msgid ""
 "Where do players from FC Barcelona or Real Madrid live? How far away are you"
@@ -2230,17 +2250,17 @@ msgid ""
 "has changed over time!"
 msgstr "¿De dónde son los jugadores de FC Barcelona o el Real Madrid? ¿Qué tan lejos estás de un país donde elefantes y leones viven en estado salvaje? ¿Qué tan cerca se encuentra el volcán más cercano? El mapa adecuado te puede ayudar a encontrar respuestas a todas estas preguntas, y más. Este programa te dará acceso a mapas de todo el mundo y a mapas de diferentes edades, ¡así que podrás hasta ver cómo ha cambiado el mundo con el tiempo!"
 
-#: content/Default/apps/content.json.h:327
+#: content/Default/apps/content.json.h:336
 msgctxt "title"
 msgid "M.A.R.S."
 msgstr "M.A.R.S."
 
-#: content/Default/apps/content.json.h:328
+#: content/Default/apps/content.json.h:337
 msgctxt "subtitle"
 msgid "A shooting game in space"
 msgstr "Un juego de batalla en el espacio"
 
-#: content/Default/apps/content.json.h:329
+#: content/Default/apps/content.json.h:338
 msgctxt "description"
 msgid ""
 "In the year 3547, civilizations across the galaxy have settled their own "
@@ -2253,17 +2273,17 @@ msgid ""
 "keep playing until you succeed in returning peace to your planet!"
 msgstr "Es el año 3547 y cada una de las civilizaciones en tu galaxia han colonizado a un planeta. La gente de tu planeta está viviendo en paz y en harmonía, ¡pero existe una gran guerra entre los otros planetas! Tienes que proteger a tu planeta de tus vecinos y del peligro que están causando. ¡Este juego es muy emocionante y ofrece la opción de multijugador, de seleccionar entre muchas armas impresionantes y de personalizar tu propio barco!"
 
-#: content/Default/apps/content.json.h:330
+#: content/Default/apps/content.json.h:339
 msgctxt "title"
 msgid "MegaGlest"
 msgstr "MegaGlest"
 
-#: content/Default/apps/content.json.h:331
+#: content/Default/apps/content.json.h:340
 msgctxt "subtitle"
 msgid "A fantasy world with kings, queens and magic"
 msgstr "Un mundo de fantasía con reyes, reinas y magia"
 
-#: content/Default/apps/content.json.h:332
+#: content/Default/apps/content.json.h:341
 msgctxt "description"
 msgid ""
 "Kings, castles, and dragons all unite in this awesome strategy game that "
@@ -2273,17 +2293,17 @@ msgid ""
 "you desire!"
 msgstr "Encontrarás a reyes, castillos y dragones en este juego emocionante de fantasía. Juega contra tus amigos para ver quién tiene lo que se necesita para gobernar este mundo de fantasía salvaje donde la magia te hace aún más poderoso. ¡Podrás conquistar cualquier parte del terreno que desees con las tácticas correctas y tu valentía!"
 
-#: content/Default/apps/content.json.h:333
+#: content/Default/apps/content.json.h:342
 msgctxt "title"
 msgid "Minetest"
 msgstr "Minetest"
 
-#: content/Default/apps/content.json.h:334
+#: content/Default/apps/content.json.h:343
 msgctxt "subtitle"
 msgid "Create your dream world"
 msgstr "Crea el mundo de tus sueños"
 
-#: content/Default/apps/content.json.h:335
+#: content/Default/apps/content.json.h:344
 msgctxt "description"
 msgid ""
 "What kind of a world would you build? Start with just land and water, and "
@@ -2295,17 +2315,17 @@ msgid ""
 " your city!"
 msgstr "Crea un mundo entero, agregándole cada detalle que puedas imaginar. Se creativo y construye un castillo increíble, un rascacielos gigante o una mansión masiva. Explora y crea todo durante el día, pero asegúrate de estar preparado para la noche, ¡porque hay arañas, esqueletos y zombies intentarán atacar tus ciudades!"
 
-#: content/Default/apps/content.json.h:336
+#: content/Default/apps/content.json.h:345
 msgctxt "title"
 msgid "Numpty Physics"
 msgstr "Física numpty"
 
-#: content/Default/apps/content.json.h:337
+#: content/Default/apps/content.json.h:346
 msgctxt "subtitle"
 msgid "Fun physics puzzle games"
 msgstr "Rompecabezas que utilizan tu conocimiento de la física"
 
-#: content/Default/apps/content.json.h:338
+#: content/Default/apps/content.json.h:347
 msgctxt "description"
 msgid ""
 "Who knew the laws of physics could be so much fun? With this app, you can "
@@ -2316,17 +2336,17 @@ msgid ""
 "learning."
 msgstr "¿Quién diría que las leyes de la física podrían ser tan divertidas? Con este programa, puedes resolver rompecabezas dibujando objetos como poleas, palancas y rampas. Si tus creaciones salen bien, cumplirás con la tarea de ese nivel y pasarás al nivel siguiente. Este juego te enseñará algo de física básica, pero te divertirás tanto que apenas notarás que estás aprendiendo."
 
-#: content/Default/apps/content.json.h:339
+#: content/Default/apps/content.json.h:348
 msgctxt "title"
 msgid "OpenSCAD"
 msgstr ""
 
-#: content/Default/apps/content.json.h:340
+#: content/Default/apps/content.json.h:349
 msgctxt "subtitle"
 msgid "Solid 3D CAD modeller"
 msgstr ""
 
-#: content/Default/apps/content.json.h:341
+#: content/Default/apps/content.json.h:350
 msgctxt "description"
 msgid ""
 "OpenSCAD is software for creating solid 3D CAD models. It reads in a script "
@@ -2334,17 +2354,17 @@ msgid ""
 "file. The resulting model can be sent to a 3D printer."
 msgstr ""
 
-#: content/Default/apps/content.json.h:342
+#: content/Default/apps/content.json.h:351
 msgctxt "title"
 msgid "Palapeli"
 msgstr "Rompecabezas"
 
-#: content/Default/apps/content.json.h:343
+#: content/Default/apps/content.json.h:352
 msgctxt "subtitle"
 msgid "A fun jigsaw puzzle game"
 msgstr "Rompecabezas clásicos y muy divertidos"
 
-#: content/Default/apps/content.json.h:344
+#: content/Default/apps/content.json.h:353
 msgctxt "description"
 msgid ""
 "If you’re a big fan of jigsaw puzzles, you’ll love this game. Unlike other "
@@ -2354,17 +2374,17 @@ msgid ""
 "rewarding, and as true to life as can be."
 msgstr "Si eres un gran fan de las rompecabezas, ¡te encantará este juego! Este programa te da la sensación de estar jugando en la vida real ya que puedes mover las piezas con completa libertad. Elige la imagen que quieres al inicio y alístate para juntar las piezas y ponerlas todas en donde corresponden. ¡Este juego es divertido, gratificante y perfecto para niños y adultos de todas edades!"
 
-#: content/Default/apps/content.json.h:345
+#: content/Default/apps/content.json.h:354
 msgctxt "title"
 msgid "Pingus"
 msgstr "Pingus"
 
-#: content/Default/apps/content.json.h:346
+#: content/Default/apps/content.json.h:355
 msgctxt "subtitle"
 msgid "Save your penguin friends from falling into the water"
 msgstr "Salva a tus amigos pingüinos de el agua helado"
 
-#: content/Default/apps/content.json.h:347
+#: content/Default/apps/content.json.h:356
 msgctxt "description"
 msgid ""
 "Penguins are among the cutest animals, so who wouldn’t want to play a fun "
@@ -2374,17 +2394,17 @@ msgid ""
 " them in order to avoid an untimely end."
 msgstr "Los pingüinos están entre los animales más lindos, así que ¿quién no quisiera jugar un juego divertido que protege a estas criaturas para que no se caigan a las aguas heladas? Con una gran cantidad de niveles y personajes adorables, este juego seguramente se convertirá en tu nuevo juego favorito. Observa a tus pingüinos utilizar las herramientas que les das para evitar un final prematuro."
 
-#: content/Default/apps/content.json.h:348
+#: content/Default/apps/content.json.h:357
 msgctxt "title"
 msgid "Video Editor"
 msgstr "Editor de videos"
 
-#: content/Default/apps/content.json.h:349
+#: content/Default/apps/content.json.h:358
 msgctxt "subtitle"
 msgid "Hundreds of transitions, effects, and filters to edit your videos"
 msgstr "Efectos, filtros y transiciones para editar tus videos"
 
-#: content/Default/apps/content.json.h:350
+#: content/Default/apps/content.json.h:359
 msgctxt "description"
 msgid ""
 "Create videos for projects, friends, family, or just for fun! Look through "
@@ -2394,17 +2414,17 @@ msgid ""
 "yourself, this video editor will help you do it!"
 msgstr "¡Crea videos para proyectos, amigos, familia o para divertirte mientras haciéndolos! Explora entre muchas opciones para elegir transiciones, efectos de video y audio y filtros para completar tus proyectos. Si quieres contar una historia, crear un video para regalárselo a un amigo, hacer un proyecto profesional o simplemente quieres expresarte, este programa te ayudará a hacerlo!"
 
-#: content/Default/apps/content.json.h:351
+#: content/Default/apps/content.json.h:360
 msgctxt "title"
 msgid "Quadrapassel"
 msgstr "Quadrapassel"
 
-#: content/Default/apps/content.json.h:352
+#: content/Default/apps/content.json.h:361
 msgctxt "subtitle"
 msgid "A tetris-like puzzle game"
 msgstr "Un juego similar a Tetris que aumenta en dificultad al avanzar"
 
-#: content/Default/apps/content.json.h:353
+#: content/Default/apps/content.json.h:362
 msgctxt "description"
 msgid ""
 "You'll need to be quick if you want to win this game! Change the shape of "
@@ -2415,17 +2435,17 @@ msgid ""
 "challenge!"
 msgstr "¡Necesitarás ser muy rápido si quieres ganarle a este juego! Cambia la figura de las fichas que caen para que se puedan juntar, combinar y desaparecer. Si no combinas suficientes bloques para que se desaparezcan, tu pantalla se llenará y tendrás que intentarlo de nuevo. ¡En cuanto pienses que estas actuando lo suficiente rápido, el juego se acelerará y será un nuevo desafío!"
 
-#: content/Default/apps/content.json.h:354
+#: content/Default/apps/content.json.h:363
 msgctxt "title"
 msgid "Music"
 msgstr "Música"
 
-#: content/Default/apps/content.json.h:355
+#: content/Default/apps/content.json.h:364
 msgctxt "subtitle"
 msgid "Listen to all your music, and to the radio"
 msgstr "Organiza tu música digital y escucha la radio por Internet"
 
-#: content/Default/apps/content.json.h:356
+#: content/Default/apps/content.json.h:365
 msgctxt "description"
 msgid ""
 "In addition to listening to your favorite music, this app lets you search "
@@ -2435,17 +2455,17 @@ msgid ""
 "in one convenient app."
 msgstr "Además de dejarte escuchar tu música favorita, este programa te permite buscar en tu biblioteca, crear listas de reproducción, y reproducir y grabar CDs. Muestra la carátula del álbum e incluso las letras de todas tus canciones favoritas. Este programa también soporta transferencia continua de radio por Internet y visualizaciones de audio. Disfruta de tus canciones favoritas que estarán almacenadas y clasificadas en este programa."
 
-#: content/Default/apps/content.json.h:357
+#: content/Default/apps/content.json.h:366
 msgctxt "title"
 msgid "Toy Train"
 msgstr "Trencito"
 
-#: content/Default/apps/content.json.h:358
+#: content/Default/apps/content.json.h:367
 msgctxt "subtitle"
 msgid "A fun train game for kids of all ages"
 msgstr "Para los niños a quienes les encantan los trenes"
 
-#: content/Default/apps/content.json.h:359
+#: content/Default/apps/content.json.h:368
 msgctxt "description"
 msgid ""
 "Sure to be an instant hit with the whole family, this is a game featuring a "
@@ -2453,17 +2473,17 @@ msgid ""
 "coaches as you go. Collect all the coaches to win the game!"
 msgstr "En este juego tienes que conducir un tren hecho de madera para avanzar por los diferentes niveles y para poder ganar. ¡Si a tus niños les gustan los trenes, les encantará ser el conductor de su propio tren!"
 
-#: content/Default/apps/content.json.h:360
+#: content/Default/apps/content.json.h:369
 msgctxt "title"
 msgid "Scorched 3D"
 msgstr "Quemadura3D"
 
-#: content/Default/apps/content.json.h:361
+#: content/Default/apps/content.json.h:370
 msgctxt "subtitle"
 msgid "A battle adventure multi-player game"
 msgstr "Un juego de artillería que puedes jugar con otros"
 
-#: content/Default/apps/content.json.h:362
+#: content/Default/apps/content.json.h:371
 msgctxt "description"
 msgid ""
 "Do you love games with jets, naval vessels, and all sorts of weapons? If so,"
@@ -2475,17 +2495,17 @@ msgid ""
 "shake things up!"
 msgstr "¿Te gustan los juegos de aviones, de guerra, y todo tipo de armas? Si es así, entonces te encantará este juego que tiene con muchos países que puedes visitar y proteger o invadir. Tendrás que tener una estrategia buena y ser astuto para que tus enemigos no ganen y para asegurarte de que terminarás victorioso. Puedes jugar solo, con amigos, o puedes jugar contra otros miembros de la comunidad en línea."
 
-#: content/Default/apps/content.json.h:363
+#: content/Default/apps/content.json.h:372
 msgctxt "title"
 msgid "Scratch"
 msgstr "Scratch"
 
-#: content/Default/apps/content.json.h:364
+#: content/Default/apps/content.json.h:373
 msgctxt "subtitle"
 msgid "Learn basic computer programming"
 msgstr "Aprende programación de computadoras a nivel básico"
 
-#: content/Default/apps/content.json.h:365
+#: content/Default/apps/content.json.h:374
 msgctxt "description"
 msgid ""
 "Do you love computer games and applications? Why not learn how to make your "
@@ -2497,17 +2517,17 @@ msgid ""
 "will you someday make? "
 msgstr "¿Te encantan los videojuegos y los programas de la computadora? ¿Por qué no aprender como hacer tu propio juego? Este programa te enseñará lo básico en programación de una manera fácil y entretenida. Puedes seleccionar los personajes y los objetos que te gusten y darles instrucciones para que hagan lo que tu quieras. Como vas avanzando, podrás ver que puedes hacer casi cualquier cosa que quieras con solo poniendo las instrucciones adecuadas. ¿Qué videojuego harás algún día?"
 
-#: content/Default/apps/content.json.h:366
+#: content/Default/apps/content.json.h:375
 msgctxt "title"
 msgid "Photos"
 msgstr "Fotos"
 
-#: content/Default/apps/content.json.h:367
+#: content/Default/apps/content.json.h:376
 msgctxt "subtitle"
 msgid "Easily edit, organize, and share photos."
 msgstr "Importa, edita, organiza y comparte tus fotografías"
 
-#: content/Default/apps/content.json.h:368
+#: content/Default/apps/content.json.h:377
 msgctxt "description"
 msgid ""
 "We all love to take pictures in our everyday lives – and we especially love "
@@ -2518,17 +2538,17 @@ msgid ""
 "networks, like Facebook."
 msgstr "A todos nos gusta tomar fotos de nuestra vida cotidiana - y sobre todo nos encanta descargarlas en nuestras computadoras para poderlas modificar y compartir a través de los medios sociales. Este programa te permite importar fotos desde una cámara digital o un teléfono sin problemas. Luego, puedes organizarlas en álbumes, modificarlas para hacerlas más bellas, darles los efectos que quieras, y por supuesto, mostrarlas en tus redes sociales favoritas, como Facebook."
 
-#: content/Default/apps/content.json.h:369
+#: content/Default/apps/content.json.h:378
 msgctxt "title"
 msgid "Simple Scan"
 msgstr "Escáner"
 
-#: content/Default/apps/content.json.h:370
+#: content/Default/apps/content.json.h:379
 msgctxt "subtitle"
 msgid "Make a digital copy of your photos and documents"
 msgstr "Haz copias digitales de tus fotos y documentos"
 
-#: content/Default/apps/content.json.h:371
+#: content/Default/apps/content.json.h:380
 msgctxt "description"
 msgid ""
 "Preserving your photos and important documents by making digital copies has "
@@ -2539,17 +2559,17 @@ msgid ""
 "sure the things you scan are clear, straight, and in any format you need!"
 msgstr "¡Ahora preservar tus fotos y documentos importantes es más fácil que nunca! Solo conecta el escáner a tu computadora, abre este programa y comienza a escanear. Una vez que un documento o una foto este digitalizado, compartirlos es igual de fácil. Puedes enviarlos por correo electrónico, cargarlos en tu red social favorita o ponerlos en una memoria USB. Este programa te permitirá asegurarte de que todo lo que escanees sea claro, recto y en el formato que necesitas."
 
-#: content/Default/apps/content.json.h:372
+#: content/Default/apps/content.json.h:381
 msgctxt "title"
 msgid "Skype"
 msgstr "Skype"
 
-#: content/Default/apps/content.json.h:373
+#: content/Default/apps/content.json.h:382
 msgctxt "subtitle"
 msgid "Free internet calls with cheap rates to phones"
 msgstr "Haz llamadas gratuitas por internet"
 
-#: content/Default/apps/content.json.h:374
+#: content/Default/apps/content.json.h:383
 msgctxt "description"
 msgid ""
 "Skype makes staying in touch incredibly easy and fun! If you have a webcam "
@@ -2558,17 +2578,17 @@ msgid ""
 "you can stay in touch with people anywhere in world!  **Requires Internet"
 msgstr "¡Skype te ayuda a mantenerte en contacto con quien quieras! Si tienes una cámara web y un micrófono, puedes hacer llamadas de video o de voz a cualquier persona en el mundo que tenga Skype, por gratis. Ahora podrás mantenerte en contacto con todos tus seres queridos, o hasta hacer nuevos amigos en otros lugares, con solo el uso de la Internet, Skype, y un micrófono!  **Requiere Internet."
 
-#: content/Default/apps/content.json.h:375
+#: content/Default/apps/content.json.h:384
 msgctxt "title"
 msgid "Slingshot"
 msgstr "Slingshot"
 
-#: content/Default/apps/content.json.h:376
+#: content/Default/apps/content.json.h:385
 msgctxt "subtitle"
 msgid "A shooting strategy game set in space"
 msgstr "Un juego de tiro y estrategia en el espacio"
 
-#: content/Default/apps/content.json.h:377
+#: content/Default/apps/content.json.h:386
 msgctxt "description"
 msgid ""
 "Gravity is your best friend in this fun shooting game set in outer space. "
@@ -2577,17 +2597,17 @@ msgid ""
 "in this fun and addictive game!"
 msgstr "¡La gravedad es tu mejor amigo en este juego divertido en el espacio exterior! Utiliza a la gravedad de diferentes planetas para tu ventaja, y usa a tu resortera confiable para destruir a las naves de tus enemigos. ¡No hay dos rondas iguales en este juego divertido y adictivo!"
 
-#: content/Default/apps/content.json.h:378
+#: content/Default/apps/content.json.h:387
 msgctxt "title"
 msgid "Freecell"
 msgstr "Freecell"
 
-#: content/Default/apps/content.json.h:379
+#: content/Default/apps/content.json.h:388
 msgctxt "subtitle"
 msgid "Solitare based single player card game"
 msgstr "Una variación del juego de cartas clásico"
 
-#: content/Default/apps/content.json.h:380
+#: content/Default/apps/content.json.h:389
 msgctxt "description"
 msgid ""
 "This application lets you play a new type of solitaire that will keep you "
@@ -2597,17 +2617,17 @@ msgid ""
 "to enjoy."
 msgstr "¡Este programa te permite jugar un nuevo tipo de Solitario que te mantendrá ocupado durante horas! La idea general es poner cartas del mismo palo en orden numérico, pero es un poco más complicado que eso. Este juego de cartas te desafía la mente mientras te divierte."
 
-#: content/Default/apps/content.json.h:381
+#: content/Default/apps/content.json.h:390
 msgctxt "title"
 msgid "Solitaire"
 msgstr "Solitaire"
 
-#: content/Default/apps/content.json.h:382
+#: content/Default/apps/content.json.h:391
 msgctxt "subtitle"
 msgid "The classic single player card game"
 msgstr "El juego de cartas clásico que todos aman"
 
-#: content/Default/apps/content.json.h:383
+#: content/Default/apps/content.json.h:392
 msgctxt "description"
 msgid ""
 "Solitaire is a classic card game that is fun for people of all ages. It’s "
@@ -2617,17 +2637,17 @@ msgid ""
 "entertain you, hour after hour."
 msgstr "Solitaire es un juego clásico de cartas para todas las edades. Las reglas son fáciles, pero se necesita tiempo para dominar el juego. ¡Querrás dedicar tiempo para realmente aprender cómo jugar, porque te estarás divirtiendo mucho! Este juego fascinante te dará mucho entretenimiento, hora tras hora."
 
-#: content/Default/apps/content.json.h:384
+#: content/Default/apps/content.json.h:393
 msgctxt "title"
 msgid "Steam"
 msgstr "Steam"
 
-#: content/Default/apps/content.json.h:385
+#: content/Default/apps/content.json.h:394
 msgctxt "subtitle"
 msgid "Browse hundreds of the most popular games online"
 msgstr "Encuentra y explorar los juegos más populares en línea"
 
-#: content/Default/apps/content.json.h:386
+#: content/Default/apps/content.json.h:395
 msgctxt "description"
 msgid ""
 "If you like playing video games, you're going to have a great time exploring"
@@ -2638,18 +2658,18 @@ msgid ""
 " a time!"
 msgstr "¡Si te gusta jugar videojuegos, te vas a divertir explorando todos los juegos en la tienda Steam! Necesitarás una conexión al internet para ver y comprar juegos en la tienda así que asegúrate de que tu conexión esté activada antes de abrir este programa. ¡Prepárate para encontrar los juegos más populares del mundo que seguramente te entretendrán por horas!"
 
-#: content/Default/apps/content.json.h:387
+#: content/Default/apps/content.json.h:396
 msgctxt "title"
 msgid "Stellarium"
 msgstr "Stellarium"
 
-#: content/Default/apps/content.json.h:388
+#: content/Default/apps/content.json.h:397
 msgctxt "subtitle"
 msgid ""
 "Planetarium software that shows what you see when you look at the stars"
 msgstr "Conoce a tu cielo con este programa que te mostrará las estrellas y constelaciones"
 
-#: content/Default/apps/content.json.h:389
+#: content/Default/apps/content.json.h:398
 msgctxt "description"
 msgid ""
 "Discover the night sky with this application. With a catalogue of more than "
@@ -2660,17 +2680,17 @@ msgid ""
 "coordinates and learn about the stars above you!"
 msgstr "Descubre el cielo nocturno con este programa. Tiene un catálogo de más de 600,000 estrellas, constelaciones de más de una docena de culturas y muchas más funciones. ¡Este programa te permitirá ver y conocer a las estrellas directamente desde tu computadora! Te mostrará un cielo nocturno tan realístico, que coincidirá con el cielo que puedas ver arriba, allí a tu afuera. ¡Establece tus coordenadas de ubicación y conoce las estrellas que tienes arriba!"
 
-#: content/Default/apps/content.json.h:390
+#: content/Default/apps/content.json.h:399
 msgctxt "title"
 msgid "Super Tux"
 msgstr "Super Tux"
 
-#: content/Default/apps/content.json.h:391
+#: content/Default/apps/content.json.h:400
 msgctxt "subtitle"
 msgid "Jump your way through different levels to win"
 msgstr "Salta los obstáculos para ganar"
 
-#: content/Default/apps/content.json.h:392
+#: content/Default/apps/content.json.h:401
 msgctxt "description"
 msgid ""
 "This game is similar to the original Super Mario Brothers games where you "
@@ -2679,17 +2699,17 @@ msgid ""
 " can follow along with as you play."
 msgstr "Este juego es parecido a los juegos originales de Super Mario Brothers donde tienes que correr y saltar para llegar a nuevos niveles. El juego viene con 26 niveles con diferentes oponentes que tendrás que vencer y muchas sorpresas. Además, tiene una divertida historia para seguir durante el juego, ¡así que querrás seguir jugando hasta que llegues al final!"
 
-#: content/Default/apps/content.json.h:393
+#: content/Default/apps/content.json.h:402
 msgctxt "title"
 msgid "Tux Kart"
 msgstr "Tux Kart"
 
-#: content/Default/apps/content.json.h:394
+#: content/Default/apps/content.json.h:403
 msgctxt "subtitle"
 msgid "Race alone or against your friends and family"
 msgstr "Juega solo o contra tus amigos o familia"
 
-#: content/Default/apps/content.json.h:395
+#: content/Default/apps/content.json.h:404
 msgctxt "description"
 msgid ""
 "Do you love racing games? Then this is the app for you! Race down easy, "
@@ -2700,17 +2720,17 @@ msgid ""
 "is sure to entertain you and your friends for hours!"
 msgstr "¿Te encantan las carreras? ¡Entonces te encantará este juego que contiene varias pistas de diferentes niveles de dificultad! Podrás poner a prueba tu habilidad para manejar, sólo o compitiendo con tus amigos. Alcanza a los peces rojos para obtener poderes temporales que te ayudarán a ganar la carrera, y evita a los peces verdes que son obstáculos. ¡Este juego será muy divertido y entretenido para ti y todos tus amigos!"
 
-#: content/Default/apps/content.json.h:396
+#: content/Default/apps/content.json.h:405
 msgctxt "title"
 msgid "Teeworlds"
 msgstr "Teeworlds"
 
-#: content/Default/apps/content.json.h:397
+#: content/Default/apps/content.json.h:406
 msgctxt "subtitle"
 msgid "Exciting multi-player shooting game"
 msgstr "Un juego multijugador de guerra y batallas"
 
-#: content/Default/apps/content.json.h:398
+#: content/Default/apps/content.json.h:407
 msgctxt "description"
 msgid ""
 "Shoot your way to victory in death matches and more! This game has an old-"
@@ -2722,17 +2742,17 @@ msgid ""
 "and go!"
 msgstr "¡Dispara y elimina a tus enemigos para ganar en este juego intenso de multijugador! Tiene un aspecto de un juego retro y clásico - pero no dejes que esto te engañe. Además de ser muy entretenido y divertido, puedes jugar con hasta 16 participantes para aumentar la emoción. Puedes escoger entre varios juegos para competir contra tus oponentes. Intenta sobrevivir y vencer a cada uno de tus oponentes en las diferentes pistas. En este juego hasta podrás crear tus propias pistas y campos. ¡Mucho entretenimiento te espera con este programa!"
 
-#: content/Default/apps/content.json.h:399
+#: content/Default/apps/content.json.h:408
 msgctxt "title"
 msgid "TORCS"
 msgstr "TORCS"
 
-#: content/Default/apps/content.json.h:400
+#: content/Default/apps/content.json.h:409
 msgctxt "subtitle"
 msgid "Race cool 3D cars in this realistic game"
 msgstr "Juego de carreras en 3D"
 
-#: content/Default/apps/content.json.h:401
+#: content/Default/apps/content.json.h:410
 msgctxt "description"
 msgid ""
 "Rip around turns and scream past other drivers in this exciting 3D car "
@@ -2743,17 +2763,17 @@ msgid ""
 "want to play too!"
 msgstr "En este juego emocionante puedes competir en carreras contra varios oponentes que son simulados por la computadora. ¡Tomarás vueltas a alta velocidad y te será tan realista que pensarás que verdaderamente hueles la goma quemada! Los usuarios avanzados tienen la oportunidad de crear sus propios autos personalizados para obtener una mejor ventaja. ¡Te va a encantar este juego y verás que todos tus amigos querrán jugar también!"
 
-#: content/Default/apps/content.json.h:402
+#: content/Default/apps/content.json.h:411
 msgctxt "title"
 msgid "Videos"
 msgstr "Videos"
 
-#: content/Default/apps/content.json.h:403
+#: content/Default/apps/content.json.h:412
 msgctxt "subtitle"
 msgid "Full function video and media player"
 msgstr "Todo lo que necesitas para ver tus videos y multimedia"
 
-#: content/Default/apps/content.json.h:404
+#: content/Default/apps/content.json.h:413
 msgctxt "description"
 msgid ""
 "Do you love watching movies? Do it the right way with this video application"
@@ -2763,17 +2783,17 @@ msgid ""
 "your family and friends to join you in watching all of your favorite movies!"
 msgstr "¿Te gusta ver películas? Usa este programa para verlas en pantalla completa. Podrás descargar tus películas favoritas desde internet y verlas en tu computadora. Este programa es simple y tiene todos las funciones básicas que necesitarás para que tu experiencia al ver tus videos sea fácil y divertida. ¡Con este programa querrás invitar a toda tu familia y a tus amigos a una noche de cine en tu computadora!"
 
-#: content/Default/apps/content.json.h:405
+#: content/Default/apps/content.json.h:414
 msgctxt "title"
 msgid "Tux Football"
 msgstr "Tux fútbol"
 
-#: content/Default/apps/content.json.h:406
+#: content/Default/apps/content.json.h:415
 msgctxt "subtitle"
 msgid "A fun soccer game starring Tux the penguin"
 msgstr "Juega fútbol con Tux el pingüino"
 
-#: content/Default/apps/content.json.h:407
+#: content/Default/apps/content.json.h:416
 msgctxt "description"
 msgid ""
 "Do you love soccer? Now you can play all day with your favorite penguins! "
@@ -2782,17 +2802,17 @@ msgid ""
 "professionals!"
 msgstr "¿Te gusta el fútbol? ¡Ahora podrás jugar todo el día con tus pingüinos favoritos! Demuestra tus habilidades y estrategia, porque siempre controlarás a los jugadores con la pelota. ¡Podrás desarrollar tus habilidades, y muy pronto te sentirás como si puedes desafiar hasta a los profesionales!"
 
-#: content/Default/apps/content.json.h:408
+#: content/Default/apps/content.json.h:417
 msgctxt "title"
 msgid "Tux Math"
 msgstr "123 Tux"
 
-#: content/Default/apps/content.json.h:409
+#: content/Default/apps/content.json.h:418
 msgctxt "subtitle"
 msgid "Math games for kids"
 msgstr "Juegos para que los niños aprendan matemáticas"
 
-#: content/Default/apps/content.json.h:410
+#: content/Default/apps/content.json.h:419
 msgctxt "description"
 msgid ""
 "Learn math by playing games! Starring kids’ favorite buddy, Tux the Penguin,"
@@ -2802,17 +2822,17 @@ msgid ""
 "both worlds and will help your child learn to love math!"
 msgstr "¡Aprende matemáticas jugando! Con el amigo favorito de los niños, Tux el Pingüino, este divertido programa de juegos numéricos guiará a los niños a través de ejercicios matemáticos en una manera divertida y participativa. Tú quieres que tus hijos mejoren sus habilidades numéricas y ellos quieren jugar. ¡Animarlos a jugar en este programa reúne lo mejor de ambos y los ayudará a amar las matemáticas!"
 
-#: content/Default/apps/content.json.h:411
+#: content/Default/apps/content.json.h:420
 msgctxt "title"
 msgid "Tux Paint"
 msgstr "Pinta Tux"
 
-#: content/Default/apps/content.json.h:412
+#: content/Default/apps/content.json.h:421
 msgctxt "subtitle"
 msgid "A fun drawing app for kids"
 msgstr "Un programa sencillo y divertido para que niños dibujen"
 
-#: content/Default/apps/content.json.h:413
+#: content/Default/apps/content.json.h:422
 msgctxt "description"
 msgid ""
 "Create beautiful artwork with this fun and easy to use app! Tux the penguin "
@@ -2823,17 +2843,17 @@ msgid ""
 "then download this app and get them started on their next masterpiece!"
 msgstr "¡Crea tus propias obras de arte con este programa que es divertido y fácil de usar! Tux el pingüino te ayudará a usar las herramientas del programa, así que hasta niños pequeños podrán usarla. Edades recomendadas para el uso de este programa son de 3 a 12 años, ¡pero también le encantará a cualquier persona que es joven de corazón! Utiliza sellos, juega con las formas, o dibuja a mano alzada para crear algo especial. Si a tu hijo o hija le gusta dibujar y crear obras de arte, ¡descarga este programa y ayúdales a comenzar su próxima obra maestra!"
 
-#: content/Default/apps/content.json.h:414
+#: content/Default/apps/content.json.h:423
 msgctxt "title"
 msgid "Tux Puck"
 msgstr "Tux puck"
 
-#: content/Default/apps/content.json.h:415
+#: content/Default/apps/content.json.h:424
 msgctxt "subtitle"
 msgid "Exciting air hockey game for you and your friends"
 msgstr "Juega a hockey de mesa con tus amigos"
 
-#: content/Default/apps/content.json.h:416
+#: content/Default/apps/content.json.h:425
 msgctxt "description"
 msgid ""
 "An air hockey game in which you try to knock the puck past your opponent's "
@@ -2842,17 +2862,17 @@ msgid ""
 " or F6 to adjust your paddle speed.)"
 msgstr "En este juego de hockey, necesitas golpear el disco tras la defensa de tu oponente. ¡Es un juego que le encantará a toda la familia! ¡Pon a prueba tu habilidad y tus reflejos para ganar este partido de ritmo rápido! (Presiona los botones F5 y F6 para ajustar la velocidad de tu pala mientras que estés jugando)"
 
-#: content/Default/apps/content.json.h:417
+#: content/Default/apps/content.json.h:426
 msgctxt "title"
 msgid "Tux Typing"
 msgstr "Teclea Tux"
 
-#: content/Default/apps/content.json.h:418
+#: content/Default/apps/content.json.h:427
 msgctxt "subtitle"
 msgid "Learn to type by playing games"
 msgstr "Ahora niños se divertirán aprendiendo a teclear"
 
-#: content/Default/apps/content.json.h:419
+#: content/Default/apps/content.json.h:428
 msgctxt "description"
 msgid ""
 "This fun application is a great way for kids, and even adults, to learn how "
@@ -2864,17 +2884,17 @@ msgid ""
 "encouraging them to play!"
 msgstr "Esta aplicación divertida les ayuda a niños aprender a escribir a máquina, e incluso puede ayudar hasta adultos hacer lo mismo. Aprende los conceptos básicos, o mejora tus habilidades, por medio de juegos que te enseñan a usar un teclado sin siquiera mirarlo. Los niños de hoy están creciendo rodeados de computadoras y otros electrónicos, y aprender a utilizar estas tecnologías correctamente será aún más importante en el futuro. ¡Comienza por darles los fundamentos al descargar este programa y animándolos a jugar!"
 
-#: content/Default/apps/content.json.h:420
+#: content/Default/apps/content.json.h:429
 msgctxt "title"
 msgid "Warmux"
 msgstr "Warmux"
 
-#: content/Default/apps/content.json.h:421
+#: content/Default/apps/content.json.h:430
 msgctxt "subtitle"
 msgid "Make your computer a battle of wit and war"
 msgstr "Un juego de guerra virtual"
 
-#: content/Default/apps/content.json.h:422
+#: content/Default/apps/content.json.h:431
 msgctxt "description"
 msgid ""
 "Exterminate your opponent in a cartoon word using dynamite, grenades, "
@@ -2883,17 +2903,17 @@ msgid ""
 " member of each team attempts to destroy his opponents."
 msgstr "¡Elimina a tu oponente con dinamita, granadas, bazucas, o incluso un bate de béisbol! Cada jugador controla su propio equipo y debe destruir a sus adversarios usando su arsenal e ingenio. ¡Necesitarás actuar cautelosa y rápidamente!"
 
-#: content/Default/apps/content.json.h:423
+#: content/Default/apps/content.json.h:432
 msgctxt "title"
 msgid "Warzone 2100"
 msgstr "Warzone 2100"
 
-#: content/Default/apps/content.json.h:424
+#: content/Default/apps/content.json.h:433
 msgctxt "subtitle"
 msgid "Lead your troops to rebuild the world"
 msgstr "Dirige a tus tropas para reconstruir el mundo"
 
-#: content/Default/apps/content.json.h:425
+#: content/Default/apps/content.json.h:434
 msgctxt "description"
 msgid ""
 "In Warzone 2100 you command forces to rebuild the world after nuclear war "
@@ -2903,17 +2923,17 @@ msgid ""
 "of strategy, tactics, and wit."
 msgstr "En este juego emocionante tu eres la persona en cargo de un proyecto de reconstruir el mundo. La humanidad se ha destruido con misiles nucleares y se necesita tu ayuda para poder salvar el mundo. Tendrás que entrenar tus tropas, y batallar contra maleantes para lograr tu objetiva. Puedes jugar sólo, o con otros jugadores, ¡así que alístate para un juego de mucha acción!"
 
-#: content/Default/apps/content.json.h:426
+#: content/Default/apps/content.json.h:435
 msgctxt "title"
 msgid "Wesnoth"
 msgstr "Wesnoth"
 
-#: content/Default/apps/content.json.h:427
+#: content/Default/apps/content.json.h:436
 msgctxt "subtitle"
 msgid "Fantasy turn-based strategy game"
 msgstr "Juego de estrategia basado en la fantasía"
 
-#: content/Default/apps/content.json.h:428
+#: content/Default/apps/content.json.h:437
 msgctxt "description"
 msgid ""
 "Battle for control of the land, villages, and resources in this fantasy-"
@@ -2922,17 +2942,17 @@ msgid ""
 "strategy, this game is sure to reveal a great leader inside you."
 msgstr "Batalla usando diferentes armas para ganar el control de aldeas. Cada arma tiene sus ventajas y desventajas dependiendo en el tipo de terreno en que suceden los ataques. Al usar cada arma vas acumulando puntos de experiencia, los cuales te ayudan a mejorar los ataques. Avanza de nivel a nivel por medio de diferentes escenarios que ocurren en la campaña de la batalla."
 
-#: content/Default/apps/content.json.h:429
+#: content/Default/apps/content.json.h:438
 msgctxt "title"
 msgid "X-Moto"
 msgstr "X-moto"
 
-#: content/Default/apps/content.json.h:430
+#: content/Default/apps/content.json.h:439
 msgctxt "subtitle"
 msgid "A motorcycle racing game"
 msgstr "Juego de motocross en dos dimensiones"
 
-#: content/Default/apps/content.json.h:431
+#: content/Default/apps/content.json.h:440
 msgctxt "description"
 msgid ""
 "Love motorcycles? Then you're going to love this racing game where physics "
@@ -2942,17 +2962,17 @@ msgid ""
 "time in this fast-paced, exciting test of speed!"
 msgstr "¿Te gustan las motocicletas? Entonces te encantará este juego de carreras donde la física juega un papel importante para que ganes! Controla tu motocicleta y si lo haces correctamente, tendrás la oportunidad de terminar hasta pistas difíciles. ¡Aprende acerca de la ciencia y practica tus habilidades para maniobrar al mismo tiempo en esta emocionante prueba de velocidad!"
 
-#: content/Default/apps/content.json.h:432
+#: content/Default/apps/content.json.h:441
 msgctxt "title"
 msgid "KBlocks"
 msgstr "TetriBloques"
 
-#: content/Default/apps/content.json.h:433
+#: content/Default/apps/content.json.h:442
 msgctxt "subtitle"
 msgid "Match blocks to destroy them and win"
 msgstr "Combina bloques de manera que se desaparezcan"
 
-#: content/Default/apps/content.json.h:434
+#: content/Default/apps/content.json.h:443
 msgctxt "description"
 msgid ""
 "This game is similar to Tetris, so if you love that game, you will love this"
@@ -2961,17 +2981,17 @@ msgid ""
 " lose, so pay attention and get ready for some very fast-actioned fun!"
 msgstr "¡Este juego es parecido al Tetris, así que si te gusta ese juego, te encantará este! Trata de alinear los bloques de moda de hacerlos desaparecer y evitar que se llene la pantalla. Tendrás que ser muy rápido o perderás, ¡así que presta atención y prepárate para diversión que tendrá emocionado por horas!"
 
-#: content/Default/apps/content.json.h:435
+#: content/Default/apps/content.json.h:444
 msgctxt "title"
 msgid "KBounce"
 msgstr "Rebote"
 
-#: content/Default/apps/content.json.h:436
+#: content/Default/apps/content.json.h:445
 msgctxt "subtitle"
 msgid "The ball-bouncing game sure to hook you"
 msgstr "Juego de paredes y rebotes"
 
-#: content/Default/apps/content.json.h:437
+#: content/Default/apps/content.json.h:446
 msgctxt "description"
 msgid ""
 "This is a fun game with a simple goal: you must build walls to decrease the "
@@ -2981,17 +3001,17 @@ msgid ""
 "It requires quick thinking and fast reflexes!"
 msgstr "En este programa, el jugador necesita construir paredes rápidamente para contener a las pelotas que rebotan. Podrás construir muros para reducir el área en la que una pelota pueda rebotar en la pantalla y una vez que construyas paredes en la mayor parte de la pantalla, pasarás al siguiente nivel. Suena fácil, ¿no? ¡Nunca lo es! Este juego tiene un elemento de rompecabezas, requiere un pensamiento rápido ¡y reflejos aún más rápidos!"
 
-#: content/Default/apps/content.json.h:438
+#: content/Default/apps/content.json.h:447
 msgctxt "title"
 msgid "KDiamond"
 msgstr "Diamantes"
 
-#: content/Default/apps/content.json.h:439
+#: content/Default/apps/content.json.h:448
 msgctxt "subtitle"
 msgid "Create lines of three diamonds"
 msgstr "Crea líneas de tres diamantes"
 
-#: content/Default/apps/content.json.h:440
+#: content/Default/apps/content.json.h:449
 msgctxt "description"
 msgid ""
 "In this fast-paced game, your job is to build lines of three diamonds of the"
@@ -3002,17 +3022,17 @@ msgid ""
 "many age levels."
 msgstr "¡Este juego es verdaderamente de ritmo rápido! Debes crear líneas de tres diamantes de la misma clase en cuestión de segundos. Sólamente puedes cambiar los diamantes con sus vecinos para formar tus líneas, ¡y tendrás que formar tantas líneas como puedas antes de que se te acabe el tiempo! Este es un juego fácil y muy entretenido que podrás jugar sólo por un poco de tiempo, o por horas en extremo. ¡Es divertido, rápido y genial para personas de todas edades!"
 
-#: content/Default/apps/content.json.h:441
+#: content/Default/apps/content.json.h:450
 msgctxt "title"
 msgid "KJumpingCube"
 msgstr "CuboSaltador"
 
-#: content/Default/apps/content.json.h:442
+#: content/Default/apps/content.json.h:451
 msgctxt "subtitle"
 msgid "Develop a good strategy to conquer all the squares"
 msgstr "Conquista todas las plazas"
 
-#: content/Default/apps/content.json.h:443
+#: content/Default/apps/content.json.h:452
 msgctxt "description"
 msgid ""
 "Practice your strategic thinking with this challenging dice-based game! You "
@@ -3027,17 +3047,17 @@ msgid ""
 " toes! "
 msgstr "¡Practica tu pensamiento estratégico con este juego desafiante basado en los dados! Te puedes mover con hacer clic en un cuadrado vacante o en uno que ya tienes. Si haces clic en un cuadrado vacío, su color cambia para mostrar que ahora es tuyo. Cada vez que haces clic en un cuadrado, su valor aumenta por uno. Una vez que un cuadrado tiene más puntos que los que lo rodean, sus puntos son distribuidos entre ellos (los puntos saltan). Si un cuadrado vecino es propiedad de tu oponente, tomas el control de ese cuadrado y de todos sus puntos. Tendrás que pensar cuidadosamente para controlar todos los cuadrados, y porque los dados se pueden cambiar de manos muy rápidamente, este juego seguramente te mantendrá atento e interesado!"
 
-#: content/Default/apps/content.json.h:444
+#: content/Default/apps/content.json.h:453
 msgctxt "title"
 msgid "KSame"
 msgstr "Iguales"
 
-#: content/Default/apps/content.json.h:445
+#: content/Default/apps/content.json.h:454
 msgctxt "subtitle"
 msgid "Get rid of all the marbles to win"
 msgstr "Deshazte de todos los cincos para ganar"
 
-#: content/Default/apps/content.json.h:446
+#: content/Default/apps/content.json.h:455
 msgctxt "description"
 msgid ""
 "Show off your pattern-finding skills in this addicting game. Match all of "
@@ -3047,17 +3067,17 @@ msgid ""
 " challenge. A really fun challenge!"
 msgstr "Demuestra tus habilidades al identificar patrones y pensar rápidamente utilizando este juego adictivo. Identifica todas las esferas del mismo color que se tocan para quitarlas y despejar el tablero, pero recuerda: si identificas y quitas más esferas a la vez, ganarás más puntos. ¡Así que piensa estratégicamente todos tus movimientos! Lo que puede parecer fácil al principio es un verdadero desafío. ¡Un reto muy divertido!"
 
-#: content/Default/apps/content.json.h:447
+#: content/Default/apps/content.json.h:456
 msgctxt "title"
 msgid "Open Arena"
 msgstr "Arena abierta"
 
-#: content/Default/apps/content.json.h:448
+#: content/Default/apps/content.json.h:457
 msgctxt "subtitle"
 msgid "Shoot your way out of trouble in this fun game"
 msgstr "Un juego de acción donde se batalla hasta la muerte"
 
-#: content/Default/apps/content.json.h:449
+#: content/Default/apps/content.json.h:458
 msgctxt "description"
 msgid ""
 "If arena battles are your idea of a good time, then you’ll love this "
@@ -3067,7 +3087,7 @@ msgid ""
 "of these modes offers its own form of excitement as you battle your enemies!"
 msgstr "Si los campos de batalla son tu idea de diversión, entonces te encantará este programa. Ten en cuenta - esto es un juego de habilidad en serio y tiene derramamiento de sangre grave. Utiliza diferentes estilos de armas en concursos como Capturar la Bandera, Torneo de Muerte, Torneo de Muerte en Equipo, Último Hombre y Torneo Abierto. ¡Cada uno de estos modos ofrece su propia forma de diversión mientras te enfrentas a tus enemigos!"
 
-#: content/Default/apps/content.json.h:159
+#: content/Default/apps/content.json.h:171
 msgctxt "description"
 msgid ""
 "Need to safely store all of your important documents, photos, songs, and "

--- a/po/fr.po
+++ b/po/fr.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: eos-shell-content\n"
 "Report-Msgid-Bugs-To: https://www.transifex.com/projects/p/eos-shell-content/\n"
-"POT-Creation-Date: 2015-02-24 12:56-0800\n"
-"PO-Revision-Date: 2015-02-24 21:02+0000\n"
+"POT-Creation-Date: 2015-02-24 16:21-0800\n"
+"PO-Revision-Date: 2015-02-25 00:22+0000\n"
 "Last-Translator: Roddy Shuler <roddy@endlessm.com>\n"
 "Language-Team: French (http://www.transifex.com/projects/p/eos-shell-content/language/fr/)\n"
 "MIME-Version: 1.0\n"
@@ -546,7 +546,7 @@ msgid "Curriculum"
 msgstr "Curriculum"
 
 #: content/Default/apps/content.json.h:83
-#: content/Default/apps/content.json.h:229
+#: content/Default/apps/content.json.h:241
 msgctxt "subtitle"
 msgid "From the Guatemalan Ministry of Education"
 msgstr "Du Ministère de l’Éducation guatémaltèque"
@@ -844,16 +844,34 @@ msgid ""
 msgstr "La meilleure façon de faire une bonne impression à un employeur potentiel est d’avoir un CV excellent, et cette application est là pour vous aider à cela. Avec des modèles pratiques et attractifs, vous aurez des quantités de styles à utiliser pour concevoir votre superbe CV. Apprenez exactement ce qu’est un CV et ce qu’il doit contenir, obtenez des conseils sur chaque section, et recevez même des orientations sur la façon de vous préparer aux entretiens d’embauche. Cette application peut vous aider à vous rapprocher du job dont vous rêvez."
 
 #: content/Default/apps/content.json.h:124
+#: content/Default/apps/content.json.h:127
 msgctxt "title"
 msgid "Football"
 msgstr "Football"
 
 #: content/Default/apps/content.json.h:125
+#: content/Default/apps/content.json.h:137
+#: content/Default/apps/content.json.h:161
+msgctxt "subtitle"
+msgid "Deprecated version"
+msgstr ""
+
+#: content/Default/apps/content.json.h:126
+#: content/Default/apps/content.json.h:138
+#: content/Default/apps/content.json.h:162
+msgctxt "description"
+msgid ""
+"If you have internet access, there may be a newer version of this "
+"application available to download and install. In the meantime, you may "
+"continue to use this version that is already installed on your computer."
+msgstr ""
+
+#: content/Default/apps/content.json.h:128
 msgctxt "subtitle"
 msgid "Learn about your favorite team and players"
 msgstr "Apprenez-en davantage sur votre équipe et vos joueurs favoris"
 
-#: content/Default/apps/content.json.h:126
+#: content/Default/apps/content.json.h:129
 msgctxt "description"
 msgid ""
 "Football is a major sport with fans all around the world. Are you one of "
@@ -863,17 +881,17 @@ msgid ""
 " with thousands of articles about your favorite sport!"
 msgstr "Le football est un sport important, qui possède des fans partout dans le monde. Êtes-vous l’un d’entre eux ? Alors c’est l’application pour vous. Elle comporte tout ce que vous avez besoin de savoir sur les principales équipes mondiales, les joueurs, et les compétitions. Apprenez des éléments à propos du jeu et de son histoire, découvrez-en plus sur les règles, et restez à jour avec des milliers d’articles sur votre sport préféré !"
 
-#: content/Default/apps/content.json.h:127
+#: content/Default/apps/content.json.h:130
 msgctxt "title"
 msgid "Social Enterprises"
 msgstr "Entreprises sociales"
 
-#: content/Default/apps/content.json.h:128
+#: content/Default/apps/content.json.h:131
 msgctxt "subtitle"
 msgid "All about non-profit organizations"
 msgstr "Tout à propos des organisations à but non lucratif"
 
-#: content/Default/apps/content.json.h:129
+#: content/Default/apps/content.json.h:132
 msgctxt "description"
 msgid ""
 "Have you thought of starting your own non-profit organization, or of joining"
@@ -883,17 +901,17 @@ msgid ""
 "your impact in the world even larger!"
 msgstr "Avez-vous songé à démarrer votre propre organisation à but non lucratif, ou à en rejoindre une ? Les organisations à but non lucratif bénéficient d'avantages fiscaux spéciaux et sont en général créées pour avoir un réel impact social. Lisez ces guides pour mieux comprendre leur structure et comment les gérer afin de pouvoir commencer à amplifier votre impact dans le monde !"
 
-#: content/Default/apps/content.json.h:130
+#: content/Default/apps/content.json.h:133
 msgctxt "title"
 msgid "Social Sciences"
 msgstr "Sciences Humaines"
 
-#: content/Default/apps/content.json.h:131
+#: content/Default/apps/content.json.h:134
 msgctxt "subtitle"
 msgid "Subjects that explore the individual and society"
 msgstr "Sujets explorant l'individu et la société"
 
-#: content/Default/apps/content.json.h:132
+#: content/Default/apps/content.json.h:135
 msgctxt "description"
 msgid ""
 "Human beings and the relationships and societies they form are complicated. "
@@ -905,17 +923,39 @@ msgid ""
 "understanding of human behavior."
 msgstr "Les êtres humains sont compliqués, ainsi que les relations et les sociétés qu’ils forment. Cette application va vous apporter une introduction à de nombreuses disciplines qui examinent l’histoire, les cultures et les interactions humaines. Vous aurez accès aux bases de la psychologie, de la sociologie, de l’anthropologie, des sciences politiques, et bien plus encore. Comprendre les fondamentaux de telles disciplines vous aidera à appréhender les façons que nous avons d’interagir et d’établir des relations les uns avec les autres. Vous en sortirez avec une compréhension riche du comportement humain."
 
-#: content/Default/apps/content.json.h:133
+#: content/Default/apps/content.json.h:136
+#: content/Default/apps/content.json.h:139
+msgctxt "title"
+msgid "Textbooks"
+msgstr "Manuels"
+
+#: content/Default/apps/content.json.h:140
+msgctxt "subtitle"
+msgid "Math and science textbooks"
+msgstr ""
+
+#: content/Default/apps/content.json.h:141
+msgctxt "description"
+msgid ""
+"Find information to help you with your homework, or learn about a subject "
+"you've always wanted to know more about! You can scroll through photos, "
+"tables, and graphs to learn more about each. Not only are these textbooks "
+"very thorough and informative, but they are also easy to read and helpful. "
+"Whether you’re a student, parent, teacher, or just someone eager to learn, "
+"you'll be sure to find something interesting and useful here!"
+msgstr ""
+
+#: content/Default/apps/content.json.h:142
 msgctxt "title"
 msgid "Translate"
 msgstr "Traduire"
 
-#: content/Default/apps/content.json.h:134
+#: content/Default/apps/content.json.h:143
 msgctxt "subtitle"
 msgid "Translate text between many languages instantly"
 msgstr "Traduisez instantanément des textes entre de nombreuses langues"
 
-#: content/Default/apps/content.json.h:135
+#: content/Default/apps/content.json.h:144
 msgctxt "description"
 msgid ""
 "Download this app to help you understand and be understood in virtually any "
@@ -926,17 +966,17 @@ msgid ""
 " – with the world’s languages at your fingertips.  **Requires internet"
 msgstr "Téléchargez cette application pour vous aider à comprendre et être compris dans théoriquement toutes les langues. Cette application nécessite une connexion à internet, et est très simple à utiliser. Vous pouvez effectuer des traductions avec un simple clic sur le bouton ! Apprenez une nouvelle langue plus facilement en étudiant les traductions de ce que vous écrivez, ou utilisez l’application pour vous aider à établir de nouvelles relations à l’international — et même de nouveaux amis — avec les langues du monde entier à portée de doigt. **Nécessite une connexion internet"
 
-#: content/Default/apps/content.json.h:136
+#: content/Default/apps/content.json.h:145
 msgctxt "title"
 msgid "Travel"
 msgstr "Voyage"
 
-#: content/Default/apps/content.json.h:137
+#: content/Default/apps/content.json.h:146
 msgctxt "subtitle"
 msgid "Travel around the world from your living room"
 msgstr "Voyagez à travers le monde à partir de votre salon"
 
-#: content/Default/apps/content.json.h:138
+#: content/Default/apps/content.json.h:147
 msgctxt "description"
 msgid ""
 "The world is an amazing and beautiful place! Start exploring it with this "
@@ -947,17 +987,17 @@ msgid ""
 "sites in the world!"
 msgstr "Le monde est un lieu fascinant et magnifique ! Commencez son exploration avec cette chouette application que vous permet de voir des images et d’apprendre des faits à propos des zones du monde entier. Elle propose des informations sur des sites majeurs dans des lieux tels que l’Amérique, l’Europe, l’Asie, et au-delà. Apprenez de nombreuses choses sur les merveilles naturelles, explorez de nouvelles cultures, et découvrez certains des sites sacrés les plus importants du monde !"
 
-#: content/Default/apps/content.json.h:139
+#: content/Default/apps/content.json.h:148
 msgctxt "title"
 msgid "Typing"
 msgstr "Taper au clavier"
 
-#: content/Default/apps/content.json.h:140
+#: content/Default/apps/content.json.h:149
 msgctxt "subtitle"
 msgid "Learn to type with games and songs"
 msgstr "Apprenez à taper avec des jeux et des chansons"
 
-#: content/Default/apps/content.json.h:141
+#: content/Default/apps/content.json.h:150
 msgctxt "description"
 msgid ""
 "How fast can you type? Whether you're already fast or just learning how to "
@@ -968,17 +1008,17 @@ msgid ""
 "now it can be a whole lot of fun too!"
 msgstr "À quelle vitesse pouvez-vous taper ? Que vous soyez déjà rapide ou juste en train d’apprendre à vous servir d’un clavier, cette application peut vous aider à améliorer vos aptitudes de frappe ! Apprenez à taper de vous-même, ou défiez les vitesses de frappe de vos amis, tout en apprenant à taper les paroles de vos chansons préférées. Il est certain que taper est une compétence précieuse dans pratiquement tous les environnements éducatifs ou professionnels, mais maintenant ce peut être aussi beaucoup d’amusement !"
 
-#: content/Default/apps/content.json.h:142
+#: content/Default/apps/content.json.h:151
 msgctxt "title"
 msgid "Virtual School"
 msgstr "École Virtuelle"
 
-#: content/Default/apps/content.json.h:143
+#: content/Default/apps/content.json.h:152
 msgctxt "subtitle"
 msgid "Free educational videos on almost any subject"
 msgstr "Vidéos éducatives gratuites sur presque tous les sujets"
 
-#: content/Default/apps/content.json.h:144
+#: content/Default/apps/content.json.h:153
 msgctxt "description"
 msgid ""
 "Learning is easy and fun with video courses on subjects like math, biology, "
@@ -990,17 +1030,17 @@ msgid ""
 " this app and these videos can help you succeed in school and in life!"
 msgstr "Apprendre est facile et amusant avec ces cours en vidéo sur des sujets tels que les maths, la biologie, la chimie, la physique, et bien plus encore ! Des étudiants du monde entier utilisent ces vidéos avec succès pour affronter des sujets difficiles d’une façon plaisante et amusante. Que vous ayez besoin d’aide supplémentaire pour vos devoirs ou que vous envisagiez d’apprendre de nouvelles choses en autonomie, vous trouverez ce que vous cherchez ici. Apprenez des sujets difficiles d’une façon qui fait sens pour vous, et constatez combien cette application et ses vidéos peuvent vous aider à réussir à l’école et dans la vie !"
 
-#: content/Default/apps/content.json.h:145
+#: content/Default/apps/content.json.h:154
 msgctxt "title"
 msgid "Sanitation"
 msgstr "Installations sanitaires"
 
-#: content/Default/apps/content.json.h:146
+#: content/Default/apps/content.json.h:155
 msgctxt "subtitle"
 msgid "All about clean water and sanitation"
 msgstr "Tout à propos de l'eau propre et des installations sanitaires"
 
-#: content/Default/apps/content.json.h:147
+#: content/Default/apps/content.json.h:156
 msgctxt "description"
 msgid ""
 "Drinking clean water is essential for survival. There can often be terrible "
@@ -1009,17 +1049,17 @@ msgid ""
 "that you create a sanitary environment around you where you can thrive. "
 msgstr "Boire de l'eau propre est essentiel à la survie. Il peut souvent y avoir de terribles maladies pouvant vous infecter avec de l'eau contaminée, ou en ayant de mauvaises installations sanitaires autour de vous. Apprenez à vous assurer de boire de l'eau propre, et à garantir la création d'un environnement sain autour de vous où vous pourrez bien vous porter."
 
-#: content/Default/apps/content.json.h:148
+#: content/Default/apps/content.json.h:157
 msgctxt "title"
 msgid "Weather"
 msgstr "Météo"
 
-#: content/Default/apps/content.json.h:149
+#: content/Default/apps/content.json.h:158
 msgctxt "subtitle"
 msgid "Get daily local forecasts from trusted sources"
 msgstr "Obtenez des prévisions météo locales quotidiennes de sources fiables"
 
-#: content/Default/apps/content.json.h:150
+#: content/Default/apps/content.json.h:159
 msgctxt "description"
 msgid ""
 "“How’s the weather out there?” Answer this question easily, every day, with "
@@ -1029,17 +1069,18 @@ msgid ""
 "about the weather to take advantage of your day!  **Requires internet"
 msgstr "« Quel temps fait-il dehors ? » Répondez à cette question facilement, chaque jour, juste en tapant sur un bouton. Cette application météo vous permet de savoir ce qu’il se passe juste derrière votre porte. Fera-t-il froid ? Devez-vous prendre votre parapluie ? Est-ce un jour parfait à passer en extérieur ? Apprenez tout ce que vous devez savoir sur la météo pour tirer au maximum profit de votre journée ! **Nécessite une connexion internet"
 
-#: content/Default/apps/content.json.h:151
+#: content/Default/apps/content.json.h:160
+#: content/Default/apps/content.json.h:163
 msgctxt "title"
 msgid "World Literature"
 msgstr "Littérature du monde"
 
-#: content/Default/apps/content.json.h:152
+#: content/Default/apps/content.json.h:164
 msgctxt "subtitle"
 msgid "Read all of the world's great literature"
 msgstr "Lisez tout de la meilleure littérature mondiale"
 
-#: content/Default/apps/content.json.h:153
+#: content/Default/apps/content.json.h:165
 msgctxt "description"
 msgid ""
 "Find some of your favorite books in this app! To begin browsing, open the "
@@ -1051,17 +1092,17 @@ msgid ""
 "entertained for hours expanding your literary knowledge."
 msgstr "Trouvez certains de vos livres favoris dans cette application ! Pour commencer à parcourir, ouvrez les dossiers, cliquez sur le fichier « Index », et sélectionnez le genre qui vous intéresse le plus. Vous trouverez certains des ouvrages les plus connus, dont des merveilles contemporaines qui piqueront probablement votre curiosité. Cette bibliothèque virtuelle possède une incroyable collection de nouvelles, poèmes, biographies, histoires, et d’autres textes. Que vous trouviez votre livre préféré ou que vous en découvriez un nouveau, vous pourrez vous divertir des heures durant en étendant vos connaissances littéraires."
 
-#: content/Default/apps/content.json.h:154
+#: content/Default/apps/content.json.h:166
 msgctxt "title"
 msgid "YouVideos"
 msgstr "YouVideos"
 
-#: content/Default/apps/content.json.h:155
+#: content/Default/apps/content.json.h:167
 msgctxt "subtitle"
 msgid "Discover and share great videos online"
 msgstr "Découvrez et partagez de super vidéos en ligne"
 
-#: content/Default/apps/content.json.h:156
+#: content/Default/apps/content.json.h:168
 msgctxt "description"
 msgid ""
 "This app makes finding videos on the popular video site, YouTube, and "
@@ -1072,27 +1113,27 @@ msgid ""
 "family, and the world!  ** Requires internet"
 msgstr "Cette application rend plus facile la recherche de vidéos sur le populaire site de vidéos, Youtube. Le partage de celles que vous réalisez est également facilité, et tout cela d’une façon nouvelle et élégante ! Visionnez des vidéos de vos artistes musicaux préférés, des tutoriels qui vous enseignent comment faire à peu près tout, des vidéos drôles ou attendrissantes, et bien plus. Vous aurez accès à des heures d’amusement, et serez en mesure de partager toutes les choses cools que vous trouvez ou faites avec vos amis, votre famille, et le monde ! **Nécessite une connexion internet"
 
-#: content/Default/apps/content.json.h:157
+#: content/Default/apps/content.json.h:169
 msgctxt "title"
 msgid "Dropbox"
 msgstr "Dropbox"
 
-#: content/Default/apps/content.json.h:158
+#: content/Default/apps/content.json.h:170
 msgctxt "subtitle"
 msgid "Access your files from any computer"
 msgstr "Accédez à vos fichiers depuis n'importe quel ordinateur"
 
-#: content/Default/apps/content.json.h:162
+#: content/Default/apps/content.json.h:174
 msgctxt "title"
 msgid "Chat"
 msgstr "Conversations"
 
-#: content/Default/apps/content.json.h:163
+#: content/Default/apps/content.json.h:175
 msgctxt "subtitle"
 msgid "Chat with all of your friends in one place"
 msgstr "Dialoguez avec tous vos amis dans un seul endroit"
 
-#: content/Default/apps/content.json.h:164
+#: content/Default/apps/content.json.h:176
 msgctxt "description"
 msgid ""
 "Do you love to chat with friends? And, do you use many different programs to"
@@ -1105,17 +1146,17 @@ msgid ""
 "and family easier than ever before!  **Requires internet"
 msgstr "Aimez-vous converser avec vos amis ? Et utilisez-vous différents programmes pour parler avec tous vos amis ? Désormais, vous pouvez combiner tous ces différents logiciels en un seul pour que vous n’ayez plus à jongler entre les programmes ! Discutez avec vos amis de Facebook, Jabber, MSN, AIM, Gadu Gadu, et plus — tout cela réuni en un seul endroit. Cette application supporte les messages, la voix, et les chats vidéos, vous serez donc en mesure de faire tout ce que vous voulez. Tout ce dont vous avez besoin est de configurer cette application avec vos autres comptes, et vous serez prêt à rester en contact avec vos amis et votre famille plus facilement que jamais auparavant ! **Nécessite une connexion internet"
 
-#: content/Default/apps/content.json.h:165
+#: content/Default/apps/content.json.h:177
 msgctxt "title"
 msgid "Documents"
 msgstr "Documents"
 
-#: content/Default/apps/content.json.h:166
+#: content/Default/apps/content.json.h:178
 msgctxt "subtitle"
 msgid "Access all of your documents and files"
 msgstr "Accédez à tous vos documents et fichiers"
 
-#: content/Default/apps/content.json.h:167
+#: content/Default/apps/content.json.h:179
 msgctxt "description"
 msgid ""
 "Get organized with this app, which helps you find all of your documents and "
@@ -1126,17 +1167,17 @@ msgid ""
 "special photo again."
 msgstr "Soyez organisé avec cette application qui vous aidera à retrouver tous vos documents et fichiers, quelle que soit la durée depuis laquelle vous les avez enregistrés. Organisez les éléments d’une façon qui fait sens pour vous, en ajoutant et en renommant les dossiers d’une façon qui vous aidera à garder un œil sur vos images, vidéos, et documents. Avec cette application, vous pouvez tout stocker à un seul endroit et vous ne perdrez plus jamais ce fichier important ou cette photo si spéciale."
 
-#: content/Default/apps/content.json.h:168
+#: content/Default/apps/content.json.h:180
 msgctxt "title"
 msgid "E-mail"
 msgstr "Email"
 
-#: content/Default/apps/content.json.h:169
+#: content/Default/apps/content.json.h:181
 msgctxt "subtitle"
 msgid "Your e-mail, address book and calendar in one place"
 msgstr "Vos emails, carnet d'adresses et calendrier dans un seul endroit"
 
-#: content/Default/apps/content.json.h:170
+#: content/Default/apps/content.json.h:182
 msgctxt "description"
 msgid ""
 "Staying in touch is an important part of modern life, and email has become "
@@ -1147,17 +1188,17 @@ msgid ""
 "  **Requires internet"
 msgstr "Rester en contact est une part primordiale de la vie moderne, et l’email est devenu l’une des meilleures façons de le faire. Vous pouvez recevoir des emails de connaissances lointaines, ou de votre famille et de vos amis proches, accéder à des messages contenant des blagues du jour, du vocabulaire ou des informations d’actualité, et même gérer des questions importantes — tout cela par email. Si vous avez besoin de vérifier vos emails rapidement et facilement, cette application est là pour vous. **Nécessite une connexion internet"
 
-#: content/Default/apps/content.json.h:171
+#: content/Default/apps/content.json.h:183
 msgctxt "title"
 msgid "Tux Racer"
 msgstr "Tux Racer"
 
-#: content/Default/apps/content.json.h:172
+#: content/Default/apps/content.json.h:184
 msgctxt "subtitle"
 msgid "Race down icy mountains"
 msgstr "Dévalez des montagnes glacées"
 
-#: content/Default/apps/content.json.h:173
+#: content/Default/apps/content.json.h:185
 msgctxt "description"
 msgid ""
 "Make it down a snow and ice-covered mountain as quickly as possible in this "
@@ -1166,17 +1207,17 @@ msgid ""
 "get your heart racing, this game is a must play for any adrenaline addict."
 msgstr "Dévalez une montagne neigeuse et couverte de glace aussi vite que possible dans cet excellent jeu de course ! Mais ce ne sera pas facile ! Vous devrez éviter les arbres, les rochers, et même les os de poissons qui vous tombent dessus et vous ralentissent. Certain de faire accélérer votre rythme cardiaque, ce jeu est un must pour tous les accros à l’adrénaline."
 
-#: content/Default/apps/content.json.h:174
+#: content/Default/apps/content.json.h:186
 msgctxt "title"
 msgid "Four in a Row"
 msgstr "Quatre dans une Rangée"
 
-#: content/Default/apps/content.json.h:175
+#: content/Default/apps/content.json.h:187
 msgctxt "subtitle"
 msgid "A simple and addictive game for kids and adults"
 msgstr "Un jeu simple et addictif pour enfants et adultes"
 
-#: content/Default/apps/content.json.h:176
+#: content/Default/apps/content.json.h:188
 msgctxt "description"
 msgid ""
 "This classic game is great for both children and adults alike! The goal is "
@@ -1188,17 +1229,17 @@ msgid ""
 "fun game!"
 msgstr "Ce jeu classique est parfait tant pour les enfants que pour les adultes ! Le but est simple : vous devez créer des lignes droites de quatre de vos cercles avant votre adversaire. Vous pouvez faire des lignes horizontales, verticales ou diagonales, comme dans le jeu du Morpion, mais vous devrez être attentif et vous méfier de ce que votre adversaire est en train de faire si vous voulez gagner ! Vous pouvez jouer contre l’ordinateur, ou contre un ami, et passer des heures à jouer à ce jeu amusant et addictif !"
 
-#: content/Default/apps/content.json.h:177
+#: content/Default/apps/content.json.h:189
 msgctxt "title"
 msgid "FreeCiv"
 msgstr "FreeCiv"
 
-#: content/Default/apps/content.json.h:178
+#: content/Default/apps/content.json.h:190
 msgctxt "subtitle"
 msgid "Guide your own civilization to greatness"
 msgstr "Guidez votre civilisation à la gloire"
 
-#: content/Default/apps/content.json.h:179
+#: content/Default/apps/content.json.h:191
 msgctxt "description"
 msgid ""
 "Create your own world with this action-packed game that lets you travel "
@@ -1210,17 +1251,17 @@ msgid ""
 "conquering the moon and beyond!"
 msgstr "Créez votre propre monde avec ce jeu plein d'action qui vous laisse voyager dans le temps et créer une civilisation personnalisée. Vous commencerez à partir de rien, dans un monde préhistorique, dans lequel vous devrez créer votre propre tribu. Ensuite, vous irez jusqu'au moyen âge, survivrez à la peste et inventerez la roue. Vous continuerez à travers les âges jusqu'à atteindre les temps modernes, et devrez gérer les questions de géopolitique à votre agenda pour conduire votre peuple à conquérir la lune et davantage encore !"
 
-#: content/Default/apps/content.json.h:180
+#: content/Default/apps/content.json.h:192
 msgctxt "title"
 msgid "FreeCol"
 msgstr "FreeCol"
 
-#: content/Default/apps/content.json.h:181
+#: content/Default/apps/content.json.h:193
 msgctxt "subtitle"
 msgid "Create your own country and conquer the world"
 msgstr "Créez votre propre pays et conquérez le monde"
 
-#: content/Default/apps/content.json.h:182
+#: content/Default/apps/content.json.h:194
 msgctxt "description"
 msgid ""
 "Have you ever wanted to start your own country? Well, now you can. Go back "
@@ -1230,17 +1271,17 @@ msgid ""
 "prosperity? You decide."
 msgstr "Avez-vous jamais voulu lancer votre propre pays ? Désormais, vous le pouvez ! Immergez-vous dans un univers alternatif où l’Amérique n’a toujours pas été colonisée et créez des villes, villages et États qui se rangeront sous vos drapeaux. Tenterez-vous de dominer le monde, ou promouvrez-vous la prospérité et la paix internationale ? C’est vous qui décidez."
 
-#: content/Default/apps/content.json.h:183
+#: content/Default/apps/content.json.h:195
 msgctxt "title"
 msgid "FrostTorrent"
 msgstr "FrostTorrent"
 
-#: content/Default/apps/content.json.h:184
+#: content/Default/apps/content.json.h:196
 msgctxt "subtitle"
 msgid "Download nearly anything or share your own files"
 msgstr "Téléchargez à peu près tout ou téléchargez vos propres fichiers"
 
-#: content/Default/apps/content.json.h:185
+#: content/Default/apps/content.json.h:197
 msgctxt "description"
 msgid ""
 "Access, download and share almost any file you'd like to with this useful "
@@ -1252,17 +1293,17 @@ msgid ""
 "**Requires Internet"
 msgstr "Accédez, téléchargez et partagez presque n'importe quel  fichier souhaité avec cette application de partage en ligne de partage qui vous permet de partager vos fichiers avec d'autres  utilisateurs connectés au réseau de BitTorrent. De la musique, des vidéos et des jeux aux téléchargements les plus complexes comme ceux de logiciels, vous pourrez accéder aux fichiers partagés par des millions  d'utilisateurs en ligne. Cette application inclut même un lecteur vidéo intégré pour vous permettre de regarder facilement tous les fichiers vidéos que vous téléchargez. *** L'application nécessite une connexion Internet"
 
-#: content/Default/apps/content.json.h:186
+#: content/Default/apps/content.json.h:198
 msgctxt "title"
 msgid "Frozen Bubbles"
 msgstr "Bulles Glacées"
 
-#: content/Default/apps/content.json.h:187
+#: content/Default/apps/content.json.h:199
 msgctxt "subtitle"
 msgid "Pop bubbles before they all come crashing down"
 msgstr "Éclatez les bulles avant qu'elle ne viennent s'écraser"
 
-#: content/Default/apps/content.json.h:188
+#: content/Default/apps/content.json.h:200
 msgctxt "description"
 msgid ""
 "Play by yourself or challenge your friends to an exciting game of frozen "
@@ -1271,17 +1312,17 @@ msgid ""
 " have a good strategy and develop a quick trigger finger in order to win!"
 msgstr "Jouez seul ou défiez vos amis à un jeu excitant de bulles glacées ! Faites correspondre les bulles colorées afin de les faire tomber et débarrassez-vous-en avant qu’elles ne s’amassent trop haut et ne vous percutent. Vous aurez besoin d’une bonne stratégie et de développer un doigt rapide à la détente afin de gagner !"
 
-#: content/Default/apps/content.json.h:189
+#: content/Default/apps/content.json.h:201
 msgctxt "title"
 msgid "EduGames"
 msgstr "EduGames"
 
-#: content/Default/apps/content.json.h:190
+#: content/Default/apps/content.json.h:202
 msgctxt "subtitle"
 msgid "Puzzles, memory games, and more for kids"
 msgstr " Puzzles, jeux de mémoire, et plus pour les enfants "
 
-#: content/Default/apps/content.json.h:191
+#: content/Default/apps/content.json.h:203
 msgctxt "description"
 msgid ""
 "This app makes learning fun for young children with more than 100 games and "
@@ -1291,17 +1332,17 @@ msgid ""
 "him or her throughout life."
 msgstr "Cette application rend l’apprentissage amusant pour les jeunes enfants avec plus de 100 jeux et activités ! Les matières incluent la lecture, la géographie et les mathématiques, et l’application comprend également des jeux tels que les échecs qui sont excellents pour les jeunes cerveaux. Votre enfant passera des moments merveilleux à développer des compétences précieuses qui l’aideront dans sa vie actuelle et future."
 
-#: content/Default/apps/content.json.h:192
+#: content/Default/apps/content.json.h:204
 msgctxt "title"
 msgid "EduGames Admin"
 msgstr "EduGames Admin"
 
-#: content/Default/apps/content.json.h:193
+#: content/Default/apps/content.json.h:205
 msgctxt "subtitle"
 msgid "For teachers to help their students learn"
 msgstr "Pour les enseignant voulant aider leurs étudiants à apprendre"
 
-#: content/Default/apps/content.json.h:194
+#: content/Default/apps/content.json.h:206
 msgctxt "description"
 msgid ""
 "Use this app to configure the EduGames app and create the exact learning "
@@ -1312,17 +1353,17 @@ msgid ""
 " fun that they'll want to spend hours doing just what you want them to!"
 msgstr "Utilisez cette application pour configurer l'application EduGames et créez l'expérience d'apprentissage précise que vous souhaitez pour vos étudiants ! Vous pouvez changer la liste des activités, ou changer les contrôles de l'application pour qu'ils restent concentrés sur les jeux que vous souhaitez. Pour commencer, téléchargez cette application et l'application EduGames depuis la section \"Jeux\" de la boutique d'applications. Ils s'amuseront tellement qu'ils voudront passer des heures à faire exactement ce que vous voulez qu'ils fassent !"
 
-#: content/Default/apps/content.json.h:195
+#: content/Default/apps/content.json.h:207
 msgctxt "title"
 msgid "Gedit"
 msgstr "Gedit"
 
-#: content/Default/apps/content.json.h:196
+#: content/Default/apps/content.json.h:208
 msgctxt "subtitle"
 msgid "A simple text editor for all of your text editing needs"
 msgstr "Un éditeur de texte simple pour tous vos besoins d'édition de texte"
 
-#: content/Default/apps/content.json.h:197
+#: content/Default/apps/content.json.h:209
 msgctxt "description"
 msgid ""
 "Use this simple app to create and edit files that require plain text inputs."
@@ -1331,17 +1372,17 @@ msgid ""
 "should be perfect for all of your text editing needs."
 msgstr "Utilisez cette application simple pour créer et éditer des fichiers qui requièrent des entrées de texte brut. Que vous soyez un développeur aguerri ou un programmeur en herbe, vous aurez besoin de cette application. Avec des fonctionnalités robustes et une interface facile à utiliser, cet éditeur de texte devrait être parfait pour tous vos besoins d’édition de textes."
 
-#: content/Default/apps/content.json.h:198
+#: content/Default/apps/content.json.h:210
 msgctxt "title"
 msgid "GIMP"
 msgstr "GIMP"
 
-#: content/Default/apps/content.json.h:199
+#: content/Default/apps/content.json.h:211
 msgctxt "subtitle"
 msgid "Advanced image editing tool similar to Photoshop"
 msgstr "Outil avancé d'édition d'image similaire à Photoshop"
 
-#: content/Default/apps/content.json.h:200
+#: content/Default/apps/content.json.h:212
 msgctxt "description"
 msgid ""
 "Edit your photos to create even more beautiful works of art with this "
@@ -1353,17 +1394,17 @@ msgid ""
 "images once you get the hang of this helpful editing app!"
 msgstr "Éditez vos photos pour créer des travaux artistiques encore plus beaux avec cet éditeur photo avancé. Cette application est compatible avec Adobe Photoshop, un éditeur de photographies populaire pour les ordinateurs sous Windows. Si vous êtes un nouvel utilisateur, il peut servir de programme basique de dessin. Les utilisateurs avancés peuvent faire des opérations telles que convertir des formats de fichiers et appliquer de nombreuses retouches et des filtres pour créer des travaux artistiques. Il y a tellement de possibilités pour créer des images cools une fois que vous apprivoisez cette application d’édition pratique !"
 
-#: content/Default/apps/content.json.h:201
+#: content/Default/apps/content.json.h:213
 msgctxt "title"
 msgid "Calculator"
 msgstr "Calculatrice"
 
-#: content/Default/apps/content.json.h:202
+#: content/Default/apps/content.json.h:214
 msgctxt "subtitle"
 msgid "A scientific calculator with many bonus tools"
 msgstr "Une calculatrice scientifique avec de nombreux outils"
 
-#: content/Default/apps/content.json.h:203
+#: content/Default/apps/content.json.h:215
 msgctxt "description"
 msgid ""
 "Do you ever consider how often you need to do basic or even complex math in "
@@ -1375,17 +1416,17 @@ msgid ""
 " again as long as you have this calculator app!"
 msgstr "Avez-vous déjà envisagé à quelle fréquence vous devez faire des opérations mathématiques basiques ou même complexes dans la vie de tous les jours ? Du calcul de votre budget à la conversion de mesures dans une recette jusqu’au calcul des impôts, vous utilisez probablement les équations plus régulièrement que vous ne l’imaginez. C’est pourquoi cette application de calcul est très pratique. Faites de l’arithmétique simple rapidement, ou autorisez la calculatrice à accomplir un travail plus avancé, selon vos besoins. Vous ne serez jamais plus bloqué par une tâche mathématique aussi longtemps que vous aurez cette application de calcul !"
 
-#: content/Default/apps/content.json.h:204
+#: content/Default/apps/content.json.h:216
 msgctxt "title"
 msgid "Math Plotting"
 msgstr "Tracé Mathématique"
 
-#: content/Default/apps/content.json.h:205
+#: content/Default/apps/content.json.h:217
 msgctxt "subtitle"
 msgid "Interactive computation and data visualization tool"
 msgstr "Outil de calcul interactif et de visualisation de données"
 
-#: content/Default/apps/content.json.h:206
+#: content/Default/apps/content.json.h:218
 msgctxt "description"
 msgid ""
 "This math application offers advanced mathematical computing functions that "
@@ -1396,17 +1437,17 @@ msgid ""
 "here."
 msgstr "Cette application de maths offre des fonctions mathématiques avancées qui peuvent être utilisées pour bien plus que du calcul basique. Si vous êtes un féru de maths qui adore expérimenter cette discipline fascinante, c'est l'application pour vous. Et si ce n'est pas le cas, cette application fonctionne parfaitement en tant que calculatrice évoluée. Tout ce que vous avez besoin de savoir sur les mystères numériques se trouve juste ici."
 
-#: content/Default/apps/content.json.h:207
+#: content/Default/apps/content.json.h:219
 msgctxt "title"
 msgid "Mines"
 msgstr "Mines"
 
-#: content/Default/apps/content.json.h:208
+#: content/Default/apps/content.json.h:220
 msgctxt "subtitle"
 msgid "Find and avoid all the dangerous mines to win"
 msgstr "Trouvez et évitez toutes les dangereuses mines pour gagner"
 
-#: content/Default/apps/content.json.h:209
+#: content/Default/apps/content.json.h:221
 msgctxt "description"
 msgid ""
 "Figure out where the dangerous mines are in order to stay alive and win the "
@@ -1416,17 +1457,17 @@ msgid ""
 " each direction. If you figure out where all the mines are, you'll win!"
 msgstr "Devinez où sont les dangereuses mines afin de rester en vie et gagner le jeu ! Chaque carré est soit un océan, soit une mine, et vous ne devrez cliquer que sur les océans ou vous devrez recommencer. À chaque fois que vous cliquez sur un carré, vous découvrirez ce qu’il est et verrez combien de mines se trouvent autour de lui dans toutes les directions. Si vous découvrez où se cachent toutes les mines, vous gagnerez !"
 
-#: content/Default/apps/content.json.h:210
+#: content/Default/apps/content.json.h:222
 msgctxt "title"
 msgid "Screenshot"
 msgstr "Capture d'écran"
 
-#: content/Default/apps/content.json.h:211
+#: content/Default/apps/content.json.h:223
 msgctxt "subtitle"
 msgid "Take a picture of your screen to save"
 msgstr "Prenez une capture d'écran et enregistrez-la"
 
-#: content/Default/apps/content.json.h:212
+#: content/Default/apps/content.json.h:224
 msgctxt "description"
 msgid ""
 "Do you ever wish you could take a picture of your screen to save? Well now "
@@ -1435,18 +1476,18 @@ msgid ""
 "make sure to save just what you need and nothing more."
 msgstr "Avez vous déjà souhaité pouvoir enregistrer une photographie de votre écran ? Désormais vous le pouvez, avec cette application de capture d'écran simple d'utilisation. Vous pouvez choisir de prendre une capture de l'intégralité de votre écran, ou juste de l'une de vos fenêtres. De cette façon, vous pouvez vous assurer de n'enregistrer que ce dont vous avez besoin, et rien de plus."
 
-#: content/Default/apps/content.json.h:213
-#: content/Default/apps/content.json.h:297
+#: content/Default/apps/content.json.h:225
+#: content/Default/apps/content.json.h:306
 msgctxt "title"
 msgid "Sudoku"
 msgstr "Sudoku"
 
-#: content/Default/apps/content.json.h:214
+#: content/Default/apps/content.json.h:226
 msgctxt "subtitle"
 msgid "One of the most popular puzzle games of all time"
 msgstr "Un des jeux de puzzle les plus populaires de tous les temps"
 
-#: content/Default/apps/content.json.h:215
+#: content/Default/apps/content.json.h:227
 msgctxt "description"
 msgid ""
 "If you’re a fan of puzzles and math games, the Sudoku app is perfect for "
@@ -1457,17 +1498,17 @@ msgid ""
 "fun solving Sudoku puzzles and exercising your mind!"
 msgstr "Si vous êtes fan de puzzles et de jeux mathématiques, cette application de Sudoku est parfaite pour vous. Il s’agit d’énigmes amusantes où vous devrez agencer les nombres de 1 à 9 dans une grille de sorte à n’avoir aucun doublon dans aucune ligne ou colonne. Cela peut sembler compliqué au premier coup d’œil, mais avec cette application, vous apprendrez comment jouer et deviendrez accro à cette application en un instant. Vous aurez bientôt des heures d’amusement à résoudre ces puzzles Sudoku et à exercer votre esprit !"
 
-#: content/Default/apps/content.json.h:216
+#: content/Default/apps/content.json.h:228
 msgctxt "title"
 msgid "Terminal"
 msgstr "Terminal"
 
-#: content/Default/apps/content.json.h:217
+#: content/Default/apps/content.json.h:229
 msgctxt "subtitle"
 msgid "Use the command line"
 msgstr "Utilisez les lignes de commandes"
 
-#: content/Default/apps/content.json.h:218
+#: content/Default/apps/content.json.h:230
 msgctxt "description"
 msgid ""
 "If you're an advanced user and want to display system information and launch"
@@ -1477,17 +1518,17 @@ msgid ""
 "in correctly and to help you easily identify any mistakes you have made."
 msgstr "Si vous êtes un utilisateur avancé et voulez afficher des informations systèmes et lancer des applications sans utiliser la souris, vous pouvez maintenant le faire juste avec cette application basique de console de commande. Avec ce terminal moderne, vous pouvez voir toutes les commandes écrites dans des couleurs différentes afin de vous assurer que vous les écrivez correctement, et pour vous aider à identifier facilement toutes les erreurs que vous avez faites."
 
-#: content/Default/apps/content.json.h:219
+#: content/Default/apps/content.json.h:231
 msgctxt "title"
 msgid "Tetravex"
 msgstr "Tetravex"
 
-#: content/Default/apps/content.json.h:220
+#: content/Default/apps/content.json.h:232
 msgctxt "subtitle"
 msgid "Race the clock in a numerical puzzle game"
 msgstr "Courrez contre la montre dans un jeu de puzzle numérique"
 
-#: content/Default/apps/content.json.h:221
+#: content/Default/apps/content.json.h:233
 msgctxt "description"
 msgid ""
 "Try to match up all of the same numbers on the blocks to win this tricky "
@@ -1496,17 +1537,17 @@ msgid ""
 "beat your or your friends' best time!"
 msgstr "Essayez de faire correspondre tous les nombres identiques sur les blocs pour gagner ce jeu de ruse. Vous aurez besoin de réfléchir attentivement, mais rapidement, afin de finir le puzzle. Vous serez chronométré, donc assurez vous de devenir de plus en plus rapide afin de battre votre meilleur score ou celui de vos amis !"
 
-#: content/Default/apps/content.json.h:222
+#: content/Default/apps/content.json.h:234
 msgctxt "title"
 msgid "Notes"
 msgstr "Notes"
 
-#: content/Default/apps/content.json.h:223
+#: content/Default/apps/content.json.h:235
 msgctxt "subtitle"
 msgid "Never lose a note again"
 msgstr "Ne perdez plus jamais une note"
 
-#: content/Default/apps/content.json.h:224
+#: content/Default/apps/content.json.h:236
 msgctxt "description"
 msgid ""
 "Do you find yourself writing down lots of notes on pieces of paper that "
@@ -1517,17 +1558,17 @@ msgid ""
 "notes and stay even more organized!"
 msgstr "Vous surprenez-vous régulièrement à écrire de nombreuses notes sur des bouts de papier qui se retrouveront bientôt perdus ou illisibles ? Ou y a-t-il tellement de notes sur votre bureau que vous commencez à être à court de place ? Peu importe quel genre de note vous voulez prendre, cette application de note peut vous aider à les garder toutes à un endroit. Cette application a également la capacité de lier les notes entre elles afin que vous puissiez facilement accéder à toutes les notes liées et être même encore plus organisé !"
 
-#: content/Default/apps/content.json.h:225
+#: content/Default/apps/content.json.h:237
 msgctxt "title"
 msgid "Dictionary"
 msgstr "Dictionnaire"
 
-#: content/Default/apps/content.json.h:226
+#: content/Default/apps/content.json.h:238
 msgctxt "subtitle"
 msgid "A cool dictionary with lots of bonus tools"
 msgstr "Un dictionnaire chouette avec de nombreux outils en bonus"
 
-#: content/Default/apps/content.json.h:227
+#: content/Default/apps/content.json.h:239
 msgctxt "description"
 msgid ""
 "In reading and conversation, words often come up with which you’re not "
@@ -1537,12 +1578,12 @@ msgid ""
 "word you’re looking for!"
 msgstr "Au cours des lectures et conversations, surviennent régulièrement des mots avec lesquels vous n'êtes pas familier, et mieux vaut avoir un dictionnaire à portée de main afin que vous puissiez enrichir votre vocabulaire et comprendre ce que vous lisez et entendez. Cette application de dictionnaire est facile à utiliser, ainsi vous n'aurez jamais de problème pour trouver exactement le mot que vous cherchez !"
 
-#: content/Default/apps/content.json.h:228
+#: content/Default/apps/content.json.h:240
 msgctxt "title"
 msgid "GT Curriculum"
 msgstr "GT Curriculum"
 
-#: content/Default/apps/content.json.h:230
+#: content/Default/apps/content.json.h:242
 msgctxt "description"
 msgid ""
 "Use this app to find the basic curriculum plan and guidelines for a specific"
@@ -1554,17 +1595,17 @@ msgid ""
 "difference both your child's life and your own."
 msgstr "Utilisez cette application pour trouver les programmes pédagogiques et lignes directrices essentielles pour un niveau d’étude donné, ou utilisez-le pour trouver des fiches d’étude qui aideront les enfants à apprendre des sujets difficiles. Le Ministère de l’Éducation a compilé cette précieuse ressource pour que vous puissiez l’utiliser. Lisez les manuels pour apprendre comment l’éducation d’un enfant est structurée, pour apprendre comment les enfants grandissent sainement, et en savoir plus sur de nombreux autres sujets qui peuvent faire la différence pour la vie de votre enfant et la vôtre."
 
-#: content/Default/apps/content.json.h:231
+#: content/Default/apps/content.json.h:243
 msgctxt "title"
 msgid "EduCollections"
 msgstr "EduCollections"
 
-#: content/Default/apps/content.json.h:232
+#: content/Default/apps/content.json.h:244
 msgctxt "subtitle"
 msgid "All sorts of information to help better your life"
 msgstr "Toutes sortes d'informations pour vous aider à améliorer votre vie"
 
-#: content/Default/apps/content.json.h:233
+#: content/Default/apps/content.json.h:245
 msgctxt "description"
 msgid ""
 "This app is full of reliable information sent directly from the Guatemalan "
@@ -1577,17 +1618,17 @@ msgid ""
 "your age."
 msgstr "Cette application est remplie d’informations fiables transmises directement par le gouvernement guatémaltèque pour vous aider à vivre une vie plus saine et plus prospère. Trouvez des informations pour vous aider à faire pousser différents types de cultures, des astuces pour les mères avant et après la grossesse, des outils pour aider les enseignants à préparer un programme, des feuilles de travail pour les étudiants souhaitant compléter leur apprentissage en classe, des textes pour apprendre la langue maya, et pleins d’informations passionnantes. Cette source de connaissances est prête à utiliser, et peut être un outil utile, quel que soit votre âge."
 
-#: content/Default/apps/content.json.h:234
+#: content/Default/apps/content.json.h:246
 msgctxt "title"
 msgid "Health Guides"
 msgstr "Guides de Santé"
 
-#: content/Default/apps/content.json.h:235
+#: content/Default/apps/content.json.h:247
 msgctxt "subtitle"
 msgid "Health guides that could save your life"
 msgstr "Guides de santé qui peuvent sauver votre vie"
 
-#: content/Default/apps/content.json.h:236
+#: content/Default/apps/content.json.h:248
 msgctxt "description"
 msgid ""
 "This app contains some of the most life saving documents that you'll ever "
@@ -1596,38 +1637,17 @@ msgid ""
 " learn to help your loved ones, those in your community and even yourself!"
 msgstr "Cette application contient certains des documents les plus utiles pour sauver des vies que vous pourrez lire. Ouvrez le dossier de Documents de Santé Hesperian pour apprendre des choses telles que comment faire des examens et des interventions mineures. Vous serez surpris de voir à quel point vous pouvez apprendre des choses pour aider ceux que vous aimez, vos voisins, ainsi que vous-même !"
 
-#: content/Default/apps/content.json.h:237
-msgctxt "title"
-msgid "Textbooks"
-msgstr "Manuels"
-
-#: content/Default/apps/content.json.h:238
-msgctxt "subtitle"
-msgid "Textbooks for students, parents and teachers"
-msgstr "Manuels pour étudiants, parents et enseignants"
-
-#: content/Default/apps/content.json.h:239
-msgctxt "description"
-msgid ""
-"Select a grade level and prepare yourself to learn directly from your "
-"computer! This app contains textbooks, worksheets and other learning tools, "
-"to teach or supplement your learning. Whether you're a student needing extra"
-" homework help, a parent helping to develop a child's education, or someone "
-"seeking to learn more in their spare time, you'll find this app to be "
-"incredibly useful."
-msgstr "Sélectionnez un niveau d’étude et prépare-vous à apprendre directement depuis votre ordinateur ! Cette application contient des manuels, des fiches de travail et d’autres outils d’apprentissage, pour enseigner ou améliorer votre apprentissage. Que vous soyez un étudiant ayant besoin d’aide supplémentaire aux devoirs, un parent aidant à développer l’éducation de ses enfants, ou quelqu’un cherchant à apprendre davantage dans son temps libre, vous trouverez cette application incroyablement utile !"
-
-#: content/Default/apps/content.json.h:240
+#: content/Default/apps/content.json.h:249
 msgctxt "title"
 msgid "Iagno"
 msgstr "Iagno"
 
-#: content/Default/apps/content.json.h:241
+#: content/Default/apps/content.json.h:250
 msgctxt "subtitle"
 msgid "A fun puzzle game that involves lots of thought"
 msgstr "Un jeu de puzzle amusant qui nécessite beaucoup de réflexion"
 
-#: content/Default/apps/content.json.h:242
+#: content/Default/apps/content.json.h:251
 msgctxt "description"
 msgid ""
 "Turn over the pieces in front of you so that they are all the same color. "
@@ -1638,17 +1658,17 @@ msgid ""
 "strategically and see if you can figure this puzzle out!"
 msgstr "Retournez les pièces devant vous afin qu’elles soient toutes de la même couleur. Simple ? Pas du tout ! Vous pouvez rendre des pièces de votre couleur en mettant l’une de vos pièces de façon à faire une ligne, une colonne ou une diagonale avec des pièces consécutives de l’autre couleur. Ainsi, vous devez retourner les pièces stratégiquement pour essayer de rendre TOUTES les pièces de votre couleur. Réfléchissez votre tactique et essayez de résoudre ce puzzle !"
 
-#: content/Default/apps/content.json.h:243
+#: content/Default/apps/content.json.h:252
 msgctxt "title"
 msgid "Inkscape"
 msgstr "Inkscape"
 
-#: content/Default/apps/content.json.h:244
+#: content/Default/apps/content.json.h:253
 msgctxt "subtitle"
 msgid "An advanced graphic design tool"
 msgstr "Un outil de design graphique avancé"
 
-#: content/Default/apps/content.json.h:245
+#: content/Default/apps/content.json.h:254
 msgctxt "description"
 msgid ""
 "This app is for intermediate and advanced graphic designers who need to "
@@ -1659,17 +1679,17 @@ msgid ""
 "presentations and artwork with this great free graphics app!"
 msgstr "Cette application s’adresse aux designers graphiques intermédiaires et avancés qui veulent créer et éditeur leurs graphiques et images. Cette application vous donne accès à des fonctionnalités avancées, et est comparable à Adobe InDesign. Par exemple, elle vous permet de créer des SVG (pour Scalable Vector Graphics, graphiques vectoriels), ce qui permet à vos images d’être redimensionnées à l’infini tout en conservant leur qualité. Créez de magnifiques publicités, brochures, présentations et artworks avec cette géniale application gratuite de graphique !"
 
-#: content/Default/apps/content.json.h:246
+#: content/Default/apps/content.json.h:255
 msgctxt "title"
 msgid "Kalzium"
 msgstr "Kalzium"
 
-#: content/Default/apps/content.json.h:247
+#: content/Default/apps/content.json.h:256
 msgctxt "subtitle"
 msgid "A fun interactive periodic table of elements"
 msgstr "Un tableau périodique des éléments amusant et interactif"
 
-#: content/Default/apps/content.json.h:248
+#: content/Default/apps/content.json.h:257
 msgctxt "description"
 msgid ""
 "The periodic table of the elements is one of the basic building blocks of "
@@ -1682,17 +1702,17 @@ msgid ""
 "simple, and informative app."
 msgstr "Le tableau périodique des éléments est l’une des clés de voute de la science, et maintenant vous pouvez l’avoir à portée de doigts. Cette application embarque un tableau périodique avec un code couleur qui rend l’apprentissage de chaque élément plus facile et plus amusant. Sélectionnez les éléments pour apprendre des informations essentielles à leur sujet, tel que leur point de fusion, leur masse, et davantage. Des informations plus complexes, telles que la visualisation des raies spectrales des éléments, rendent cette application parfaite pour la découverte scientifique. Vous n’en reviendrez pas d’apprendre autant avec cette application soignée, simple et passionnante."
 
-#: content/Default/apps/content.json.h:249
+#: content/Default/apps/content.json.h:258
 msgctxt "title"
 msgid "Kapman"
 msgstr "Kapman"
 
-#: content/Default/apps/content.json.h:250
+#: content/Default/apps/content.json.h:259
 msgctxt "subtitle"
 msgid "The classic game of ghosts and mazes"
 msgstr "Le jeu classique de fantômes et labyrinthes"
 
-#: content/Default/apps/content.json.h:251
+#: content/Default/apps/content.json.h:260
 msgctxt "description"
 msgid ""
 "If you love Pac-Man, then you you'll love this game too! Eat dots to gain "
@@ -1702,17 +1722,17 @@ msgid ""
 "and family, from kids to grandparents, will love the game, too!"
 msgstr "Si vous adorez Pac-Man, alors vous adorerez ce jeu également ! Mangez les ronds pour gagner des points, mais ne vous faites pas attraper par les fantômes ou vous perdrez. Tandis que vous gagnez des compétences et remportez les niveaux, la vitesse du jeu s’accroît, générant un défi de plus en plus excitant. Vous ne voudrez plus jamais vous arrêter de jouer, et vos amis et familles, des enfants aux grands-parents, adoreront le jeu, eux aussi !"
 
-#: content/Default/apps/content.json.h:252
+#: content/Default/apps/content.json.h:261
 msgctxt "title"
 msgid "KAtomic"
 msgstr "KAtomic"
 
-#: content/Default/apps/content.json.h:253
+#: content/Default/apps/content.json.h:262
 msgctxt "subtitle"
 msgid "A fun way to learn chemistry"
 msgstr "Une façon amusante d'apprendre la chimie"
 
-#: content/Default/apps/content.json.h:254
+#: content/Default/apps/content.json.h:263
 msgctxt "description"
 msgid ""
 "If you’re struggling with concepts in chemistry, or simply looking for a way"
@@ -1724,17 +1744,17 @@ msgid ""
 " a ton!"
 msgstr "Si vous êtes en prise avec les concepts de la chimie, ou cherchez simplement un moyen de renforcer votre compréhension, alors vous avez trouvé la bonne application pour vous ! Ce jeu défiant vous fait créer des molécules à partir des atomes — la façon parfaite d’apprendre tout en s’amusant ! L’écran vous montrera ce à quoi votre molécule doit ressembler, et vous pouvez déplacer vos atomes afin de créer la molécule qu’il faut. Ce jeu demande de la stratégie et de la vivacité d’esprit, et vous apprendra beaucoup !"
 
-#: content/Default/apps/content.json.h:255
+#: content/Default/apps/content.json.h:264
 msgctxt "title"
 msgid "KBlackBox"
 msgstr "KBlackBox"
 
-#: content/Default/apps/content.json.h:256
+#: content/Default/apps/content.json.h:265
 msgctxt "subtitle"
 msgid "Find the pattern and uncover the hidden balls"
 msgstr "Trouvez le motif et dévoilez les balles cachées"
 
-#: content/Default/apps/content.json.h:257
+#: content/Default/apps/content.json.h:266
 msgctxt "description"
 msgid ""
 "This game takes some serious logic, but don’t be scared away – it’s also "
@@ -1744,17 +1764,17 @@ msgid ""
 "hidden ones are placed. The more you get right, the higher your score."
 msgstr "Ce jeu demande une sérieuse logique, mais ne soyez pas effrayé — il est également très amusant. Des balles sont cachées dans une boîte noire sur l’écran. Vous pouvez utiliser un rayon laser pour révéler l’emplacement de ces balles. Lorsque vous pensez connaître leur disposition, glissez et déposez les balles sur l’écran là où vous pensez que les balles cachées sont placées. Plus vous en trouvez, plus votre score est élevé."
 
-#: content/Default/apps/content.json.h:258
+#: content/Default/apps/content.json.h:267
 msgctxt "title"
 msgid "KBruch"
 msgstr "KBruch"
 
-#: content/Default/apps/content.json.h:259
+#: content/Default/apps/content.json.h:268
 msgctxt "subtitle"
 msgid "Learn about fractions, percentages and more"
 msgstr "Apprenez les fractions, les pourcentages et davantages"
 
-#: content/Default/apps/content.json.h:260
+#: content/Default/apps/content.json.h:269
 msgctxt "description"
 msgid ""
 "One of the trickiest parts of the math we do every day is calculating "
@@ -1766,17 +1786,17 @@ msgid ""
 "benefit you in unexpected ways!"
 msgstr "L’un des aspects les plus piégeux des mathématiques que nous faisons chaque jour est le calcul de fractions et de pourcentages, et maintenant vous n’aurez plus à deviner vos opérations ! Cette application propose des jeux et exercices pour affiner vos compétences, dont l’arithmétique, les comparaisons, les conversions, et la factorisation. Apprenez tout à propos des fractions et pourcentages, et pratiquez autant que vous le souhaitez. Nous sommes confrontés au quotidien à ce type d’opérations mathématiques, donc vos nouvelles compétences vous seront utiles de façon inattendue !"
 
-#: content/Default/apps/content.json.h:261
+#: content/Default/apps/content.json.h:270
 msgctxt "title"
 msgid "KSnake"
 msgstr "KSnake"
 
-#: content/Default/apps/content.json.h:262
+#: content/Default/apps/content.json.h:271
 msgctxt "subtitle"
 msgid "A fun and very simple game for everyone"
 msgstr "Un jeu amusant et très simple pour toute la famille"
 
-#: content/Default/apps/content.json.h:263
+#: content/Default/apps/content.json.h:272
 msgctxt "description"
 msgid ""
 "Similar to the popular arcade game, Snake, this classic game will help you "
@@ -1785,17 +1805,17 @@ msgid ""
 "snakes grow longer, promising a fun challenge to players of all levels."
 msgstr "Similaire à Snake, le jeu d'arcade bien connu, ce jeu classique vous aidera à tromper l'ennui durant de nombreuses heures ! En mangeant, le serpent grossit, mais une collision avec un autre serpent et tout est perdu. Le jeu devient plus difficile à mesure que le serpent est plus long, promettant un défi amusant pour les joueurs de tous niveaux."
 
-#: content/Default/apps/content.json.h:264
+#: content/Default/apps/content.json.h:273
 msgctxt "title"
 msgid "KGeography"
 msgstr "KGeography"
 
-#: content/Default/apps/content.json.h:265
+#: content/Default/apps/content.json.h:274
 msgctxt "subtitle"
 msgid "Become a geography genius while having fun"
 msgstr "Devenez un génie de la géographie tout en vous amusant"
 
-#: content/Default/apps/content.json.h:266
+#: content/Default/apps/content.json.h:275
 msgctxt "description"
 msgid ""
 "How much do you know about world geography and political affairs? Learn the "
@@ -1806,17 +1826,17 @@ msgid ""
 "and will have had a lot of fun learning it all!"
 msgstr "Vous y connaissez-vous bien à propos de la géographie mondiale et des questions politiques ? Apprenez la géographie du monde entier à travers un jeu stimulant. Tout d’abord, regardez la carte et apprenez à propos des noms, capitales, et drapeaux. Ensuite, il est temps de tester vos connaissances ! Devinez les capitales et drapeaux ou essayez de placer les frontières étatiques sur une carte vierge. Avant que vous ne vous en rendiez compte, vous connaîtrez tous les recoins du monde et vous serez beaucoup amusé à apprendre tout cela !"
 
-#: content/Default/apps/content.json.h:267
+#: content/Default/apps/content.json.h:276
 msgctxt "title"
 msgid "KGoldrunner"
 msgstr "KGoldrunner"
 
-#: content/Default/apps/content.json.h:268
+#: content/Default/apps/content.json.h:277
 msgctxt "subtitle"
 msgid "Look for treasure and hide from enemies"
 msgstr "Cherchez le trésor et abritez-vous des ennemis"
 
-#: content/Default/apps/content.json.h:269
+#: content/Default/apps/content.json.h:278
 msgctxt "description"
 msgid ""
 "Your enemies are right on your heels as you move through mazes collecting "
@@ -1826,17 +1846,17 @@ msgid ""
 " through any trapdoors!"
 msgstr "Vos ennemis sont à vos trousses tandis que vous essayez de vous déplacer à travers des labyrinthes pour collecter de l’or dans ce jeu stimulant. Avec des énigmes et un objectif excitant, ce jeu est certain de devenir l’un de vos favoris. Vous y trouverez des centaines de niveaux pour des heures d’expérience ludique, avec de nouveaux labyrinthes à chaque niveau. Essayez juste de ne pas tomber dans un piège !"
 
-#: content/Default/apps/content.json.h:270
+#: content/Default/apps/content.json.h:279
 msgctxt "title"
 msgid "KHangMan"
 msgstr "KHangMan"
 
-#: content/Default/apps/content.json.h:271
+#: content/Default/apps/content.json.h:280
 msgctxt "subtitle"
 msgid "One of the most fun word games on earth"
 msgstr "Un des jeux de mots les plus amusants du monde"
 
-#: content/Default/apps/content.json.h:272
+#: content/Default/apps/content.json.h:281
 msgctxt "description"
 msgid ""
 "Practice your vocabulary the fun way! You'll learn new words with this "
@@ -1848,17 +1868,17 @@ msgid ""
 "have to start over with a new word!"
 msgstr "Pratiquez votre vocabulaire de façon amusante ! Vous apprendrez de nouveaux mots avec ce jeu de puzzle, et toute la famille peut participer ! Comment jouer ? L’ordinateur choisira un mot et les joueurs essayeront de deviner ce mot en devinant ses lettres une par une jusqu’à ce qu’ils puissent deviner le mot en entier. Tandis que les joueurs devinent correctement, le mot est de plus en plus affiché, mais si vous faites trop d’erreurs, vous perdrez et devrez commencer un nouveau mot !"
 
-#: content/Default/apps/content.json.h:273
+#: content/Default/apps/content.json.h:282
 msgctxt "title"
 msgid "Kigo"
 msgstr "Kigo"
 
-#: content/Default/apps/content.json.h:274
+#: content/Default/apps/content.json.h:283
 msgctxt "subtitle"
 msgid "The ancient game of skill, updated for modern play"
 msgstr "L'ancestral jeu d'adresse, repensé pour l'amusement moderne"
 
-#: content/Default/apps/content.json.h:275
+#: content/Default/apps/content.json.h:284
 msgctxt "description"
 msgid ""
 "Based on a two-player board game popular in Asia, this app has easy-to-learn"
@@ -1870,17 +1890,17 @@ msgid ""
 "too!"
 msgstr "Basée sur un jeu de plateau à deux joueurs populaire en Asie, cette application a des règles faciles à apprendre, mais nécessite beaucoup de stratégie. C’est la façon parfaite pour passer le temps tout en entraînant votre esprit. Le but est simple : déplacez vos pièces noires ou blanches sur la grille (la taille de la grille dépend du niveau de difficulté que vous avez choisi), et essayez d’investir davantage le plateau que votre adversaire. Si vous aimez les jeux tels que les échecs, vous adorerez également cet excellent jeu de stratégie !"
 
-#: content/Default/apps/content.json.h:276
+#: content/Default/apps/content.json.h:285
 msgctxt "title"
 msgid "Killbots"
 msgstr "Killbots"
 
-#: content/Default/apps/content.json.h:277
+#: content/Default/apps/content.json.h:286
 msgctxt "subtitle"
 msgid "Outsmart the killer robots to win"
 msgstr "Déjouez les robots tueurs pour gagner"
 
-#: content/Default/apps/content.json.h:278
+#: content/Default/apps/content.json.h:287
 msgctxt "description"
 msgid ""
 "How will you get away from the killer robots bent on destruction? Figure it "
@@ -1890,17 +1910,17 @@ msgid ""
 "tell the tale!"
 msgstr "Comment allez vous débarrasser des robots tueurs assoiffés de destruction ? Trouvez une solution avec ce jeu de divertissement simple. Vous pourrez vous trouver envahi par des vagues incessantes de robots, mais grâce à votre intelligente et votre appareil portable de téléportation, vous parviendrez à les vaincre. Déjouez les tentatives de tous ces robots tueurs pour gagner et survivre pour raconter vos exploits !"
 
-#: content/Default/apps/content.json.h:279
+#: content/Default/apps/content.json.h:288
 msgctxt "title"
 msgid "Kolor Lines"
 msgstr "Kolor Lines"
 
-#: content/Default/apps/content.json.h:280
+#: content/Default/apps/content.json.h:289
 msgctxt "subtitle"
 msgid "Line up balls of the same color to win"
 msgstr "Alignez des balles de la même couleur pour gagner"
 
-#: content/Default/apps/content.json.h:281
+#: content/Default/apps/content.json.h:290
 msgctxt "description"
 msgid ""
 "This game is so fun and addicting, you’ll never want to stop playing. The "
@@ -1911,17 +1931,17 @@ msgid ""
 "possible; you lose if it fills up completely!"
 msgstr "Ce jeu est tellement amusant et addictif que vous ne voudrez jamais vous arrêter de jouer. Le concept est simple : agencez les billes colorées sur le plateau de jeu pour former des lignes de cinq billes de couleur identique, ce qui les retirera du plateau. C’est un défi plus important que ce à quoi vous vous attendez, cependant, parce que de nouvelles billes arrivent après chaque mouvement. C’est votre travail de vider le plateau de jeu autant que vous le pouvez ; vous perdrez s’il est complètement rempli !"
 
-#: content/Default/apps/content.json.h:282
+#: content/Default/apps/content.json.h:291
 msgctxt "title"
 msgid "KMines"
 msgstr "KMines"
 
-#: content/Default/apps/content.json.h:283
+#: content/Default/apps/content.json.h:292
 msgctxt "subtitle"
 msgid "Stay away from the exploding mines"
 msgstr "Restez à l'écart des mines explosives"
 
-#: content/Default/apps/content.json.h:284
+#: content/Default/apps/content.json.h:293
 msgctxt "description"
 msgid ""
 "Don't take a wrong step or you'll explode! You'll need to use logic and "
@@ -1929,17 +1949,17 @@ msgid ""
 "safely across the field."
 msgstr "Ne faites pas un pas de travers sous peine d’exploser ! Vous devrez utiliser votre logique et redoubler d’astuces dans ce jeu pour vous débarrasser de toutes les mines souterraines et tracer votre chemin en toute sécurité à travers le champ de mines."
 
-#: content/Default/apps/content.json.h:285
+#: content/Default/apps/content.json.h:294
 msgctxt "title"
 msgid "Battleships"
 msgstr "Vaisseaux de guerre"
 
-#: content/Default/apps/content.json.h:286
+#: content/Default/apps/content.json.h:295
 msgctxt "subtitle"
 msgid "Blow your opponents out of the water"
 msgstr "Explosez votre adversaire pour le faire couler"
 
-#: content/Default/apps/content.json.h:287
+#: content/Default/apps/content.json.h:296
 msgctxt "description"
 msgid ""
 "Try to guess where your enemies ships are to blow them out of the water "
@@ -1950,17 +1970,17 @@ msgid ""
 "Arrr you ready for some great naval fun?"
 msgstr "Essayez de deviner où sont les bateaux de vos ennemis pour les faire couler dans l’eau avant qu’ils ne vous aient ! Il s’agit d’un jeu de stratégie amusant pour deux joueurs. Vous pouvez jouer contre un ami, contre quelqu’un d’autre sur internet, ou contre votre ordinateur. À chaque tour, vous essayerez de deviner où est chacun des bateaux de votre ennemi, et la première personne à couler tous les bateaux de son ennemi gagne. Êtes-vous prêt pour un peu d’amusement naval ?"
 
-#: content/Default/apps/content.json.h:288
+#: content/Default/apps/content.json.h:297
 msgctxt "title"
 msgid "KNetwalk"
 msgstr "KNetwalk"
 
-#: content/Default/apps/content.json.h:289
+#: content/Default/apps/content.json.h:298
 msgctxt "subtitle"
 msgid "Make the right cable connections and win"
 msgstr "Faites la bonne connexion de câbles pour gagner"
 
-#: content/Default/apps/content.json.h:290
+#: content/Default/apps/content.json.h:299
 msgctxt "description"
 msgid ""
 "Who knew building computer networks could be fun? You'll need to create the "
@@ -1971,17 +1991,17 @@ msgid ""
 "enjoyable and competitive game you’ll love to play."
 msgstr "Qui aurait cru que la construction de réseaux informatiques pouvait être amusante ? Vous devrez créer la bonne connexion en aussi peu de tours que possible pour gagner — soyez donc prêt à déplacer les câbles et résolvez le puzzle rapidement ! Une fois que vous avez réussi, vous trouverez une liste des meilleurs scores, vous permettant de trouver des adversaires ! Cette application aide à comprendre comment les réseaux informatiques fonctionnent, mais surtout, c’est un jeu amusant et compétitif auquel vous adorerez jouer."
 
-#: content/Default/apps/content.json.h:291
+#: content/Default/apps/content.json.h:300
 msgctxt "title"
 msgid "Kobo Deluxe"
 msgstr "Kobo Deluxe"
 
-#: content/Default/apps/content.json.h:292
+#: content/Default/apps/content.json.h:301
 msgctxt "subtitle"
 msgid "Destroy enemy bases in space"
 msgstr "Détruisez les bases ennemies dans l'espace"
 
-#: content/Default/apps/content.json.h:293
+#: content/Default/apps/content.json.h:302
 msgctxt "description"
 msgid ""
 "Fans of arcade-style games will love this fun shooting game. Protect "
@@ -1990,17 +2010,17 @@ msgid ""
 "to play. You'll have hours and hours of fun blowing up things in space!"
 msgstr "Les fans de jeux d’arcade adoreront ce jeu de tir amusant. Protégez-vous des vaisseaux ennemis et détruisez-les tandis qu’ils vous poursuivent à travers l’espace ! Ce jeu profite de graphismes amusants et de nombreux défis, avec plus de 50 niveaux jouables. Vous aurez des heures et des heures d’amusement à exploser des choses dans l’espace !"
 
-#: content/Default/apps/content.json.h:294
+#: content/Default/apps/content.json.h:303
 msgctxt "title"
 msgid "KSquares"
 msgstr "KSquares"
 
-#: content/Default/apps/content.json.h:295
+#: content/Default/apps/content.json.h:304
 msgctxt "subtitle"
 msgid "Connect the dots in this challenging strategy game"
 msgstr "Connectez les points dans ce jeu de stratégie stimulant"
 
-#: content/Default/apps/content.json.h:296
+#: content/Default/apps/content.json.h:305
 msgctxt "description"
 msgid ""
 "Based on a popular old game, this fun app lets you stretch your mind and "
@@ -2011,12 +2031,12 @@ msgid ""
 "entertainment. Be careful – you just might become addicted!"
 msgstr "Basé sur un célèbre jeu ancien, cette application amusante vous permet de vous remuer les méninges en résolvant des puzzles. L'objectif est d'avoir plus de carrés sur la grille que votre adversaire. Tracez des lignes entre les points chacun votre tour et formez des carrés tout en essayant de bloquer ceux de votre adversaire. Ce jeu demande de penser géométriquement et stratégiquement, et vous divertira assurément pendant des heures. Attention, vous pourriez ne plus pouvoir vous en passer !"
 
-#: content/Default/apps/content.json.h:298
+#: content/Default/apps/content.json.h:307
 msgctxt "subtitle"
 msgid "A challenging numerical puzzle game"
 msgstr "Un jeu stimulant de puzzle numérique"
 
-#: content/Default/apps/content.json.h:299
+#: content/Default/apps/content.json.h:308
 msgctxt "description"
 msgid ""
 "Are you better than your friend is at puzzles? Find out by playing this fun "
@@ -2028,17 +2048,17 @@ msgid ""
 "Sudoku, or are an experienced player, you'll love this app!"
 msgstr "Êtes-vous meilleur que vos amis aux puzzles ? Découvrez la réponse en jouant à ce jeu amusant de puzzle numérique ! Vous pouvez jouer seul, vous faire aider par d'autres personnes, ou défier vos amis et votre famille pour voir qui peut résoudre le puzzle en premier. Cette application a des fonctionnalités spéciales, comme la possibilité de créer des jeux que vous pouvez imprimer ou de vous aider à résoudre n'importe quel puzzle Sudoku de façon à ce que vous appreniez à les résoudre vous-même. Que vous soyez débutant total ou un joueur expérimenté, vous adorerez cette application !"
 
-#: content/Default/apps/content.json.h:300
+#: content/Default/apps/content.json.h:309
 msgctxt "title"
 msgid "KSnakeDuel"
 msgstr "KSnakeDuel"
 
-#: content/Default/apps/content.json.h:301
+#: content/Default/apps/content.json.h:310
 msgctxt "subtitle"
 msgid "Survival depends on your reflexes and wits"
 msgstr "La survie dépend de vos réflexes et de votre esprit"
 
-#: content/Default/apps/content.json.h:302
+#: content/Default/apps/content.json.h:311
 msgctxt "description"
 msgid ""
 "Guide your snake to eat the apples and to avoid the other snakes, balls and "
@@ -2049,17 +2069,17 @@ msgid ""
 "fun challenge!"
 msgstr "Guidez votre serpent pour le faire manger les pommes et pour éviter les autres serpents, les balles et les murs ! Certains des serpents et des balles vous ralentiront simplement, alors que les autres vous tueront, donc il est préférable de rester éloigner de tout ça ! Si vous réussissez à manger toutes les pommes, vous devrez quitter le labyrinthe pour passer au niveau suivant. Ce jeu peut sembler simple, mais ce n’est pas le cas, donc soyez prêt pour un défi des plus amusants !"
 
-#: content/Default/apps/content.json.h:303
+#: content/Default/apps/content.json.h:312
 msgctxt "title"
 msgid "Potato Guy"
 msgstr " Potato Guy"
 
-#: content/Default/apps/content.json.h:304
+#: content/Default/apps/content.json.h:313
 msgctxt "subtitle"
 msgid "Give your potato a funny face"
 msgstr "Donnez à votre patate un visage amusant"
 
-#: content/Default/apps/content.json.h:305
+#: content/Default/apps/content.json.h:314
 msgctxt "description"
 msgid ""
 "This is a silly game for children and their parents to play together. Based "
@@ -2069,17 +2089,17 @@ msgid ""
 "lots of laughter. Make the goofiest face you can!"
 msgstr "Il s’agit d’un jeu idiot pour permettre aux enfants et à leurs parents de jouer ensemble. Basé sur le jeu Monsieur Patate, il vous permet de faire glisser et déposer des éléments de visage sur une patate, faisant des visages marrants avec l’aide de moustaches, oreilles de lutins, queues de cheval blondes, et autres nœuds papillons. Il n’y a pas d’autre objectif à ce jeu que de faire rire ! Réalisez le visage le plus désopilant que vous pouvez !"
 
-#: content/Default/apps/content.json.h:306
+#: content/Default/apps/content.json.h:315
 msgctxt "title"
 msgid "Kubrick"
 msgstr "Kubrick"
 
-#: content/Default/apps/content.json.h:307
+#: content/Default/apps/content.json.h:316
 msgctxt "subtitle"
 msgid "Like Rubik's Cube - create solid color sides to win"
 msgstr "Comme le Rubik's Cube - créez des face de couleur homogène pour gagner"
 
-#: content/Default/apps/content.json.h:308
+#: content/Default/apps/content.json.h:317
 msgctxt "description"
 msgid ""
 "This puzzling game has lots of options to keep your brain working! Modeled "
@@ -2091,17 +2111,17 @@ msgid ""
 "even design your very own challenge!"
 msgstr "Ce jeu de puzzle propose de nombreuses options pour faire travailler votre cerveau ! Conçu d’après le populaire Rubik’s Cube, ce jeu est une expérience 3D qui vous fait tourner les petites briques d’un grand cube pour tenter et réussir à rendre chacune des faces du cube de la même couleur. Des objets plus grands, plus petits, et de formes différentes, proposent leur propre défi. Le jeu comprend également des démonstrations des méthodes de résolutions les plus impressionnantes, afin que vous puissiez devenir un expert, et que vous puissiez même concevoir votre propre défi !"
 
-#: content/Default/apps/content.json.h:309
+#: content/Default/apps/content.json.h:318
 msgctxt "title"
 msgid "KWordQuiz"
 msgstr "KWordQuiz"
 
-#: content/Default/apps/content.json.h:310
+#: content/Default/apps/content.json.h:319
 msgctxt "subtitle"
 msgid "Grow your vocabulary and test your learning"
 msgstr "Améliorez votre vocabulaire et testez votre apprentissage"
 
-#: content/Default/apps/content.json.h:311
+#: content/Default/apps/content.json.h:320
 msgctxt "description"
 msgid ""
 "Learning new words is a great way to speak and write more clearly, but "
@@ -2112,17 +2132,17 @@ msgid ""
 "learning all you want."
 msgstr "Apprendre de nouveaux mots est une excellente façon de parler et écrire de façon plus claire, mais parfois cela peut être difficile à faire. Utiliser des fiches de vocabulaire peut être d’une grande aide, que vous étudiiez une langue étrangère ou essayiez de mémoriser de nouveaux mots de vocabulaire. Cette application rend la mémorisation facile et amusante avec des fiches de vocabulaire interactives et des jeux qui vous aideront à tester votre connaissance et à continuer d’apprendre tout ce que vous voulez."
 
-#: content/Default/apps/content.json.h:312
+#: content/Default/apps/content.json.h:321
 msgctxt "title"
 msgid "Breakout"
 msgstr "Breakout"
 
-#: content/Default/apps/content.json.h:313
+#: content/Default/apps/content.json.h:322
 msgctxt "subtitle"
 msgid "Destroy all the bricks to win this fun game"
 msgstr "Détruisez toutes les briques pour gagner à ce jeu amusant"
 
-#: content/Default/apps/content.json.h:314
+#: content/Default/apps/content.json.h:323
 msgctxt "description"
 msgid ""
 "This classic paddle game is tons of fun! The aim is to destroy bricks with "
@@ -2132,17 +2152,17 @@ msgid ""
 " graphics and animation, intuitive controls, and plenty of levels to beat."
 msgstr "Ce jeu classique de casse-brique apporte des heures de plaisir ! Le but est de détruire les briques avec votre balle en les frappant avec votre raquette, ce qui vous permet de passer au niveau du dessus. Le jeu original, Breakout, est sorti en 1976. Depuis, tout le monde adore toujours ce jeu simple, mais addictif. Prenez votre dose de cassage de briques avec de superbes graphismes et animation, des contrôles intuitifs, et de nombreux niveaux à résoudre."
 
-#: content/Default/apps/content.json.h:315
+#: content/Default/apps/content.json.h:324
 msgctxt "title"
 msgid "Spreadsheet"
 msgstr "Tableur"
 
-#: content/Default/apps/content.json.h:316
+#: content/Default/apps/content.json.h:325
 msgctxt "subtitle"
 msgid "A spreadsheet program with many functions"
 msgstr "Un programme de tableur avec de nombreuses fonctions"
 
-#: content/Default/apps/content.json.h:317
+#: content/Default/apps/content.json.h:326
 msgctxt "description"
 msgid ""
 "Whatever you need to keep track of, the spreadsheet app can help you do it. "
@@ -2153,17 +2173,17 @@ msgid ""
 " job market."
 msgstr "Quoi que vous ayez besoin de surveiller et enregistrer, l’application tableur vous aide à le faire. Ce tableur avancé, mais facile à utiliser conviendra à tout le monde : une interface simple et facile à comprendre, avec la possibilité de réaliser des opérations complexes. Les tableaux sont utilisés pour de nombreuses applications professionnelles à travers le monde, donc se familiariser avec cette application peut aussi vous fournir des compétences utiles pour le marché du travail."
 
-#: content/Default/apps/content.json.h:318
+#: content/Default/apps/content.json.h:327
 msgctxt "title"
 msgid "Presentation"
 msgstr "Présentation"
 
-#: content/Default/apps/content.json.h:319
+#: content/Default/apps/content.json.h:328
 msgctxt "subtitle"
 msgid "Create great presentations with this easy-to-use app"
 msgstr "Créez de superbes présentation avec cette application facile à utiliser"
 
-#: content/Default/apps/content.json.h:320
+#: content/Default/apps/content.json.h:329
 msgctxt "description"
 msgid ""
 "Create clean, attractive, and professional presentations with this "
@@ -2174,17 +2194,17 @@ msgid ""
 "need."
 msgstr "Créez des présentations propres, attractives et professionnelles avec cette application de création de présentations. Cette application permet d'utiliser du texte, des outils de dessin, des transitions, des éléments graphiques en 2D et en 3D, et même des animations pour faire votre démonstration d'une façon élégante et persuasive. Cerise sur le gâteau, cette application est facile à comprendre et à utiliser, avec des étapes simplifiées pour créer exactement ce dont vous avez besoin."
 
-#: content/Default/apps/content.json.h:321
+#: content/Default/apps/content.json.h:330
 msgctxt "title"
 msgid "Writer"
 msgstr "Écriture"
 
-#: content/Default/apps/content.json.h:322
+#: content/Default/apps/content.json.h:331
 msgctxt "subtitle"
 msgid "Free, similar to & compatible with Microsoft Word"
 msgstr "Gratuit, similaire et compatible à Microsoft Word"
 
-#: content/Default/apps/content.json.h:323
+#: content/Default/apps/content.json.h:332
 msgctxt "description"
 msgid ""
 "This app gives you all the features of the best word processing applications"
@@ -2196,17 +2216,17 @@ msgid ""
 "notes; either way, you’ll have simple yet powerful tools available."
 msgstr "Cette application vous donne accès à toutes les fonctionnalités des meilleures applications de traitement de texte et est compatible avec Microsoft Office. Créez et éditez facilement des documents, créez de courtes notes et de plus longues rédactions avec annotations et diagrammes. Tout cela est possible avec cette application. Vos documents auront un rendu suffisamment professionnel pour être présentés à des employeurs, des professeurs, ou d’autres personnes importantes. Utilisez cette application pour composer votre prochain chef-d’œuvre ou pour prendre de bonnes notes ; de toute façon, vous aurez des outils simples et puissants à portée de main."
 
-#: content/Default/apps/content.json.h:324
+#: content/Default/apps/content.json.h:333
 msgctxt "title"
 msgid "Maps"
 msgstr "Maps"
 
-#: content/Default/apps/content.json.h:325
+#: content/Default/apps/content.json.h:334
 msgctxt "subtitle"
 msgid "Maps of the entire world"
 msgstr "Cartes du monde entier"
 
-#: content/Default/apps/content.json.h:326
+#: content/Default/apps/content.json.h:335
 msgctxt "description"
 msgid ""
 "Where do players from FC Barcelona or Real Madrid live? How far away are you"
@@ -2217,17 +2237,17 @@ msgid ""
 "has changed over time!"
 msgstr "Où vivent les joueurs du FC Barcelone ou du Real Madrid ? À quelle distance êtes-vous d’un pays où les éléphants et les lions vivent en liberté ? Quel est le volcan le plus proche de vous ? Toutes ces questions peuvent trouver leur réponse avec la carte adéquate. Cette application vous donne accès à toutes sortes de cartes du monde entier et de différentes époques, afin que vous puissiez même voir comment le monde a changé à travers le temps !"
 
-#: content/Default/apps/content.json.h:327
+#: content/Default/apps/content.json.h:336
 msgctxt "title"
 msgid "M.A.R.S."
 msgstr "M.A.R.S."
 
-#: content/Default/apps/content.json.h:328
+#: content/Default/apps/content.json.h:337
 msgctxt "subtitle"
 msgid "A shooting game in space"
 msgstr "Jeu de tir dans l'espace"
 
-#: content/Default/apps/content.json.h:329
+#: content/Default/apps/content.json.h:338
 msgctxt "description"
 msgid ""
 "In the year 3547, civilizations across the galaxy have settled their own "
@@ -2240,17 +2260,17 @@ msgid ""
 "keep playing until you succeed in returning peace to your planet!"
 msgstr "Dans l'année 3547, les civilisations à travers la galaxie ont parachevées leurs planètes. Votre peuple vit en paix et harmonie avec son environnement. Mais à l'extérieur de votre paisible planète, une grande guerre fait rage. Vous êtes un célèbre combattant connu pour son honneur et ses compétences, et vous devrez protéger votre planète des voisins jaloux qui veulent la détruire ! Ce jeu possède une option multijoueur, vous permet de choisir parmi de nombreuses armes pour combattre, et même "
 
-#: content/Default/apps/content.json.h:330
+#: content/Default/apps/content.json.h:339
 msgctxt "title"
 msgid "MegaGlest"
 msgstr "MegaGlest"
 
-#: content/Default/apps/content.json.h:331
+#: content/Default/apps/content.json.h:340
 msgctxt "subtitle"
 msgid "A fantasy world with kings, queens and magic"
 msgstr "Un monde fantastique avec rois, reines et magie"
 
-#: content/Default/apps/content.json.h:332
+#: content/Default/apps/content.json.h:341
 msgctxt "description"
 msgid ""
 "Kings, castles, and dragons all unite in this awesome strategy game that "
@@ -2260,17 +2280,17 @@ msgid ""
 "you desire!"
 msgstr "Les rois, les châteaux, et les dragons sont tous réunis dans cet excellent jeu de stratégie qui vous donnera envie de diriger votre propre civilisation. Jouez contre vos amis pour voir qui est en mesure de diriger ce monde sauvage fantastique où la magie vous rend encore plus puissant et où vous pouvez conquérir toutes les parties du royaume que vous désirez !"
 
-#: content/Default/apps/content.json.h:333
+#: content/Default/apps/content.json.h:342
 msgctxt "title"
 msgid "Minetest"
 msgstr "Minetest"
 
-#: content/Default/apps/content.json.h:334
+#: content/Default/apps/content.json.h:343
 msgctxt "subtitle"
 msgid "Create your dream world"
 msgstr "Créez le monde de vos rêves"
 
-#: content/Default/apps/content.json.h:335
+#: content/Default/apps/content.json.h:344
 msgctxt "description"
 msgid ""
 "What kind of a world would you build? Start with just land and water, and "
@@ -2282,17 +2302,17 @@ msgid ""
 " your city!"
 msgstr "Quel type de monde construiriez-vous ? Commencez avec juste de l'eau et de la terre, et de là ajoutez tous les détails qui vous traversent l'esprit ! Soyez créatif et créez un château incroyable, un gratte-ciel géant, un manoir gigantesque, et n'oubliez pas d'ajouter des murailles pour la protection. Explorez le monde et construisez ce que vous voulez pendant la journée mais assurez-vous de vous préparer pour la nuit. Vous pourriez vous rendre compte que des araignées, des squelettes et des zombies essayent d'attaquer votre ville !"
 
-#: content/Default/apps/content.json.h:336
+#: content/Default/apps/content.json.h:345
 msgctxt "title"
 msgid "Numpty Physics"
 msgstr " Numpty Physics"
 
-#: content/Default/apps/content.json.h:337
+#: content/Default/apps/content.json.h:346
 msgctxt "subtitle"
 msgid "Fun physics puzzle games"
 msgstr "Jeux de puzzle de physique amusante"
 
-#: content/Default/apps/content.json.h:338
+#: content/Default/apps/content.json.h:347
 msgctxt "description"
 msgid ""
 "Who knew the laws of physics could be so much fun? With this app, you can "
@@ -2303,17 +2323,17 @@ msgid ""
 "learning."
 msgstr "Qui eut cru que les lois de la physique pouvaient être si amusantes ? Avec cette application, vous pouvez résoudre des puzzles en dessinant des objets tels que des poulies, des leviers et des rampes. Si votre création se révèle concluante, vous accomplirez la tâche du niveau et passerez au niveau suivant. Ce jeu stimulant vous apprendra également quelques bases de physique, mais vous vous amuserez tellement que vous ne réaliserez même pas que vous apprenez."
 
-#: content/Default/apps/content.json.h:339
+#: content/Default/apps/content.json.h:348
 msgctxt "title"
 msgid "OpenSCAD"
 msgstr ""
 
-#: content/Default/apps/content.json.h:340
+#: content/Default/apps/content.json.h:349
 msgctxt "subtitle"
 msgid "Solid 3D CAD modeller"
 msgstr ""
 
-#: content/Default/apps/content.json.h:341
+#: content/Default/apps/content.json.h:350
 msgctxt "description"
 msgid ""
 "OpenSCAD is software for creating solid 3D CAD models. It reads in a script "
@@ -2321,17 +2341,17 @@ msgid ""
 "file. The resulting model can be sent to a 3D printer."
 msgstr ""
 
-#: content/Default/apps/content.json.h:342
+#: content/Default/apps/content.json.h:351
 msgctxt "title"
 msgid "Palapeli"
 msgstr "Palapeli"
 
-#: content/Default/apps/content.json.h:343
+#: content/Default/apps/content.json.h:352
 msgctxt "subtitle"
 msgid "A fun jigsaw puzzle game"
 msgstr "Un jeu de puzzle amusant"
 
-#: content/Default/apps/content.json.h:344
+#: content/Default/apps/content.json.h:353
 msgctxt "description"
 msgid ""
 "If you’re a big fan of jigsaw puzzles, you’ll love this game. Unlike other "
@@ -2341,17 +2361,17 @@ msgid ""
 "rewarding, and as true to life as can be."
 msgstr "Si vous êtes un grand fan de puzzles, vous adorerez ce jeu. Contrairement aux autres jeux de ce type, il n’est pas nécessaire d’aligner les pièces sur une grille. Au lieu de cela, Palapeli donne une sensation plus réaliste, avec des pièces que l’on peut déplacer librement. Choisissez votre puzzle et commencez à assembler les pièces. Ce jeu est amusant, récompensant, et est aussi vrai que la vie peut l’être."
 
-#: content/Default/apps/content.json.h:345
+#: content/Default/apps/content.json.h:354
 msgctxt "title"
 msgid "Pingus"
 msgstr "Pingus"
 
-#: content/Default/apps/content.json.h:346
+#: content/Default/apps/content.json.h:355
 msgctxt "subtitle"
 msgid "Save your penguin friends from falling into the water"
 msgstr "Sauvez vos amis pingouins d'une chute dans l'eau"
 
-#: content/Default/apps/content.json.h:347
+#: content/Default/apps/content.json.h:356
 msgctxt "description"
 msgid ""
 "Penguins are among the cutest animals, so who wouldn’t want to play a fun "
@@ -2361,17 +2381,17 @@ msgid ""
 " them in order to avoid an untimely end."
 msgstr "Le pingouin est l’un des animaux les plus mignons, donc pourquoi ne pas jouer à un jeu amusant consistant à protéger ces créatures adorées d’une chute depuis les falaises dans des eaux glaciales ? Avec de nombreux niveaux et des personnages adorables, il s’agit sûrement de votre nouveau jeu favori. Regardez vos pingouins utiliser les outils que vous leur donnez pour éviter une fin prématurée."
 
-#: content/Default/apps/content.json.h:348
+#: content/Default/apps/content.json.h:357
 msgctxt "title"
 msgid "Video Editor"
 msgstr "Éditeur de vidéos"
 
-#: content/Default/apps/content.json.h:349
+#: content/Default/apps/content.json.h:358
 msgctxt "subtitle"
 msgid "Hundreds of transitions, effects, and filters to edit your videos"
 msgstr "Des centaines de transitions, d'effets, et de filtres pour éditer vos vidéos"
 
-#: content/Default/apps/content.json.h:350
+#: content/Default/apps/content.json.h:359
 msgctxt "description"
 msgid ""
 "Create videos for projects, friends, family, or just for fun! Look through "
@@ -2381,17 +2401,17 @@ msgid ""
 "yourself, this video editor will help you do it!"
 msgstr "Créez des vidéos pour vos projets, vos amis, votre famille, ou juste pour vous amuser ! Explorez des centaines de transitions, d'effets vidéo, d'effets audio, et de filtres et réalisez la vidéo de vos rêves. Que vous vouliez raconter une histoire, offrir un cadeau à un ami, créer une vidéo de qualité professionnelle, ou juste vous exprimer, cet éditeur de vidéo vous aidera à atteindre votre objectif !"
 
-#: content/Default/apps/content.json.h:351
+#: content/Default/apps/content.json.h:360
 msgctxt "title"
 msgid "Quadrapassel"
 msgstr "Quadrapassel"
 
-#: content/Default/apps/content.json.h:352
+#: content/Default/apps/content.json.h:361
 msgctxt "subtitle"
 msgid "A tetris-like puzzle game"
 msgstr "Un jeu de puzzle similaire à Tetris"
 
-#: content/Default/apps/content.json.h:353
+#: content/Default/apps/content.json.h:362
 msgctxt "description"
 msgid ""
 "You'll need to be quick if you want to win this game! Change the shape of "
@@ -2402,17 +2422,17 @@ msgid ""
 "challenge!"
 msgstr "Vous devrez être rapide si vous voulez gagner à ce jeu ! Changez la forme des pièces qui tombent du haut afin de faire correspondre les couleurs et les faire disparaître. Si vous ne faites pas disparaître suffisamment de blocs de couleur, vous verrez rapidement votre écran se remplir, et vous devrez recommencer. Et juste au moment où vous croyez être suffisamment rapide, le jeu s’accélérera, donc soyez prêt à un nouveau défi !"
 
-#: content/Default/apps/content.json.h:354
+#: content/Default/apps/content.json.h:363
 msgctxt "title"
 msgid "Music"
 msgstr "Musique"
 
-#: content/Default/apps/content.json.h:355
+#: content/Default/apps/content.json.h:364
 msgctxt "subtitle"
 msgid "Listen to all your music, and to the radio"
 msgstr "Écoutez toute votre musique ainsi que la radio"
 
-#: content/Default/apps/content.json.h:356
+#: content/Default/apps/content.json.h:365
 msgctxt "description"
 msgid ""
 "In addition to listening to your favorite music, this app lets you search "
@@ -2422,17 +2442,17 @@ msgid ""
 "in one convenient app."
 msgstr "En plus d’écouter votre musique favorite, cette application vous permet de chercher à travers votre bibliothèque, créer des listes de lecture, jouer et graver des CD, montrer vos pochettes d’album et même les paroles des chansons. Cette application supporte également les radios en streaming par internet et les visualisations audio. Profitez de toutes vos chansons favorites, stockées et triées en une application pratique."
 
-#: content/Default/apps/content.json.h:357
+#: content/Default/apps/content.json.h:366
 msgctxt "title"
 msgid "Toy Train"
 msgstr "Train jouet"
 
-#: content/Default/apps/content.json.h:358
+#: content/Default/apps/content.json.h:367
 msgctxt "subtitle"
 msgid "A fun train game for kids of all ages"
 msgstr "Un jeu de train amusant pour les enfants de tout âges"
 
-#: content/Default/apps/content.json.h:359
+#: content/Default/apps/content.json.h:368
 msgctxt "description"
 msgid ""
 "Sure to be an instant hit with the whole family, this is a game featuring a "
@@ -2440,17 +2460,17 @@ msgid ""
 "coaches as you go. Collect all the coaches to win the game!"
 msgstr "Sûr de convaincre instantanément toute la famille, il s’agit d’un jeu mettant en scène une locomotive à vapeur que vous utilisez pour parcourir les nombreux niveaux afin de collecter les wagons sur votre chemin. Collectez tous les wagons pour gagner le jeu !"
 
-#: content/Default/apps/content.json.h:360
+#: content/Default/apps/content.json.h:369
 msgctxt "title"
 msgid "Scorched 3D"
 msgstr "Scorched 3D"
 
-#: content/Default/apps/content.json.h:361
+#: content/Default/apps/content.json.h:370
 msgctxt "subtitle"
 msgid "A battle adventure multi-player game"
 msgstr "Un jeux de combat et d'aventure multijoueur"
 
-#: content/Default/apps/content.json.h:362
+#: content/Default/apps/content.json.h:371
 msgctxt "description"
 msgid ""
 "Do you love games with jets, naval vessels, and all sorts of weapons? If so,"
@@ -2462,17 +2482,17 @@ msgid ""
 "shake things up!"
 msgstr "Aimez-vous les jeux avec des jets, des navires de guerre, et toutes sortes d’armes ? Si oui, alors vous adorerez Scorched3D. Ce jeu vous propose différents terrains à visiter et sur lesquels combattre. Vous devrez développer une bonne stratégie pour venir à bout de vos ennemis et vous assurer de sortir victorieux. Vous pouvez jouer seul, avec des amis, ou combattre d’autres communautés de membres en ligne. Accrochez-vous à votre casque, car ce jeu est certain de vous remuer !"
 
-#: content/Default/apps/content.json.h:363
+#: content/Default/apps/content.json.h:372
 msgctxt "title"
 msgid "Scratch"
 msgstr "Gratter"
 
-#: content/Default/apps/content.json.h:364
+#: content/Default/apps/content.json.h:373
 msgctxt "subtitle"
 msgid "Learn basic computer programming"
 msgstr "Apprenez les bases de la programmation"
 
-#: content/Default/apps/content.json.h:365
+#: content/Default/apps/content.json.h:374
 msgctxt "description"
 msgid ""
 "Do you love computer games and applications? Why not learn how to make your "
@@ -2484,17 +2504,17 @@ msgid ""
 "will you someday make? "
 msgstr "Aimez-vous les jeux vidéos et les applications ? Pourquoi ne pas apprendre à faire les vôtres ? Cette application vous apprend les bases de la programmation d'une manière amusante et facile. Vous pouvez choisir les caractères et les éléments que vous aimez et ensuite ajouter les instructions pour qu'ils fassent ce que vous souhaitez. A mesure que vous progressez, vous verrez que vous pourrez donner vie à presque tout ce que vous voulez sur l'écran grâce aux bonnes instructions. Quel jeu vidéo créerez-vous un jour ?"
 
-#: content/Default/apps/content.json.h:366
+#: content/Default/apps/content.json.h:375
 msgctxt "title"
 msgid "Photos"
 msgstr "Photos"
 
-#: content/Default/apps/content.json.h:367
+#: content/Default/apps/content.json.h:376
 msgctxt "subtitle"
 msgid "Easily edit, organize, and share photos."
 msgstr "Éditez, organisez et partagez facilement vos photos."
 
-#: content/Default/apps/content.json.h:368
+#: content/Default/apps/content.json.h:377
 msgctxt "description"
 msgid ""
 "We all love to take pictures in our everyday lives – and we especially love "
@@ -2505,17 +2525,17 @@ msgid ""
 "networks, like Facebook."
 msgstr "Nous aimons tous photographier notre vie quotidienne — en nous aimons particulièrement les télécharger sur notre ordinateur pour les éditer et les partager sur les réseaux sociaux. Cette application vous permet d’importer aisément vos photos depuis un appareil photo numérique ou d’un téléphone portable. Vous pouvez les ranger dans des albums, les éditer pour qu’elles soient plus belles et aient de meilleurs effets, et bien sûr, les partager sur vos réseaux sociaux favoris, tels que Facebook."
 
-#: content/Default/apps/content.json.h:369
+#: content/Default/apps/content.json.h:378
 msgctxt "title"
 msgid "Simple Scan"
 msgstr "Un simple balayage"
 
-#: content/Default/apps/content.json.h:370
+#: content/Default/apps/content.json.h:379
 msgctxt "subtitle"
 msgid "Make a digital copy of your photos and documents"
 msgstr "aites  des copies numériquesvos photos et documents"
 
-#: content/Default/apps/content.json.h:371
+#: content/Default/apps/content.json.h:380
 msgctxt "description"
 msgid ""
 "Preserving your photos and important documents by making digital copies has "
@@ -2526,17 +2546,17 @@ msgid ""
 "sure the things you scan are clear, straight, and in any format you need!"
 msgstr "Préserver vos photos et documents importants en  faisant des copies numériques n'a jamais été aussi simple ! Il suffit de brancher tout simplement le scanner à votre ordinateur, d'ouvrir cette application  et de lancer la numérisation. Une fois le document ou la photo  numérisé, le/la partager est aussi simple que l'envoyer par émail, le/la mettre en ligne sur votre réseau  social préféré, ou l'envoyer vers une clé USB. Grâce à cette application,  vous serez assuré d'avoir des copies numériques claires, droites  et qui respectent le format que vous souhaitez !"
 
-#: content/Default/apps/content.json.h:372
+#: content/Default/apps/content.json.h:381
 msgctxt "title"
 msgid "Skype"
 msgstr "Skype"
 
-#: content/Default/apps/content.json.h:373
+#: content/Default/apps/content.json.h:382
 msgctxt "subtitle"
 msgid "Free internet calls with cheap rates to phones"
 msgstr "Appels par internet gratuit avec des tarifs bas pour les téléphones"
 
-#: content/Default/apps/content.json.h:374
+#: content/Default/apps/content.json.h:383
 msgctxt "description"
 msgid ""
 "Skype makes staying in touch incredibly easy and fun! If you have a webcam "
@@ -2545,17 +2565,17 @@ msgid ""
 "you can stay in touch with people anywhere in world!  **Requires Internet"
 msgstr "Skype rend le maintien de contact incroyablement facile et amusant ! Si vous avez une webcam et un microphone, vous pouvez facilement passer des appels vidéos et des appels audio avec n’importe qui dans le monde qui a Skype. Les fonctionnalités de cette application sont simples d’utilisation et vous permettent de rester en contact avec des gens partout dans le monde ! **Nécessite une connexion internet"
 
-#: content/Default/apps/content.json.h:375
+#: content/Default/apps/content.json.h:384
 msgctxt "title"
 msgid "Slingshot"
 msgstr "Slingshot"
 
-#: content/Default/apps/content.json.h:376
+#: content/Default/apps/content.json.h:385
 msgctxt "subtitle"
 msgid "A shooting strategy game set in space"
 msgstr "Un jeu de tir stratégique situé dans l'espace"
 
-#: content/Default/apps/content.json.h:377
+#: content/Default/apps/content.json.h:386
 msgctxt "description"
 msgid ""
 "Gravity is your best friend in this fun shooting game set in outer space. "
@@ -2564,17 +2584,17 @@ msgid ""
 "in this fun and addictive game!"
 msgstr "La gravité est votre meilleure amie dans ce jeu de tir amusant situé dans l’espace ! Utilisez la gravité des différentes planètes à votre avantage, et utilisez votre fidèle fronde pour détruire le vaisseau spatial ennemi. Jamais deux manches ne se ressemblent dans ce jeu amusant et addictif !"
 
-#: content/Default/apps/content.json.h:378
+#: content/Default/apps/content.json.h:387
 msgctxt "title"
 msgid "Freecell"
 msgstr "Freecell"
 
-#: content/Default/apps/content.json.h:379
+#: content/Default/apps/content.json.h:388
 msgctxt "subtitle"
 msgid "Solitare based single player card game"
 msgstr "Jeu de carte pour un joueur basé sur le solitaire"
 
-#: content/Default/apps/content.json.h:380
+#: content/Default/apps/content.json.h:389
 msgctxt "description"
 msgid ""
 "This application lets you play a new type of solitaire that will keep you "
@@ -2584,17 +2604,17 @@ msgid ""
 "to enjoy."
 msgstr "Cette application vous laisse jouer à un nouveau type de solitaire qui vous divertira durant des heures ! L’idée générale est de placer les cartes de la même suite suivant leur ordre numérique, mais c’est un peu plus compliqué que cela. Ce jeu de cartes défie l’esprit et vous gratifie de nombreuses heures de divertissement."
 
-#: content/Default/apps/content.json.h:381
+#: content/Default/apps/content.json.h:390
 msgctxt "title"
 msgid "Solitaire"
 msgstr "Solitaire"
 
-#: content/Default/apps/content.json.h:382
+#: content/Default/apps/content.json.h:391
 msgctxt "subtitle"
 msgid "The classic single player card game"
 msgstr "Le jeu de carte classique à un joueur"
 
-#: content/Default/apps/content.json.h:383
+#: content/Default/apps/content.json.h:392
 msgctxt "description"
 msgid ""
 "Solitaire is a classic card game that is fun for people of all ages. It’s "
@@ -2604,17 +2624,17 @@ msgid ""
 "entertain you, hour after hour."
 msgstr "Le solitaire est un jeu de cartes classique amusant pour les gens de tout âge. Il est facile d’en comprendre les règles, mais maîtriser le jeu vous prendra davantage de temps. Heureusement, vous voudrez investir ce temps à apprendre comment jouer tellement vous vous amuserez. Ce jeu captivant et enrichissant pour l’esprit est assuré de vous divertir, heure après heure."
 
-#: content/Default/apps/content.json.h:384
+#: content/Default/apps/content.json.h:393
 msgctxt "title"
 msgid "Steam"
 msgstr "Steam"
 
-#: content/Default/apps/content.json.h:385
+#: content/Default/apps/content.json.h:394
 msgctxt "subtitle"
 msgid "Browse hundreds of the most popular games online"
 msgstr "Naviguez entre des centaines des jeux en ligne les plus populaires"
 
-#: content/Default/apps/content.json.h:386
+#: content/Default/apps/content.json.h:395
 msgctxt "description"
 msgid ""
 "If you like playing video games, you're going to have a great time exploring"
@@ -2625,18 +2645,18 @@ msgid ""
 " a time!"
 msgstr "Si vous aimez jouer aux jeux vidéos, vous allez vraiment vous amuser en explorant tous les jeux Linux sympas sur le portail Steam de Valve ! Vous aurez besoin d'une connexion Internet pour consulter et acheter des jeux sur la boutique de Steam, alors assurez-vous que votre Wi-Fi est allumé avant d'ouvrir cette application. Préparez-vous à trouver les jeux les plus populaires au monde qui vous divertiront assurément pendant des heures à la fois !"
 
-#: content/Default/apps/content.json.h:387
+#: content/Default/apps/content.json.h:396
 msgctxt "title"
 msgid "Stellarium"
 msgstr "Stellarium"
 
-#: content/Default/apps/content.json.h:388
+#: content/Default/apps/content.json.h:397
 msgctxt "subtitle"
 msgid ""
 "Planetarium software that shows what you see when you look at the stars"
 msgstr "Logiciel de planétarium qui vous affiche ce que vous voyez lorsque vous contemplez les étoiles"
 
-#: content/Default/apps/content.json.h:389
+#: content/Default/apps/content.json.h:398
 msgctxt "description"
 msgid ""
 "Discover the night sky with this application. With a catalogue of more than "
@@ -2647,17 +2667,17 @@ msgid ""
 "coordinates and learn about the stars above you!"
 msgstr "Découvrez le ciel de la nuit avec cette application. Avec un catalogue de plus de 600 000 étoiles, des constellations de plus d’une douzaine de cultures, et bien d’autres fonctionnalités, cette application vous laisse voir et apprendre à connaître les étoiles depuis votre ordinateur. Cette application vous montre un ciel nocturne tellement réaliste qu’il correspondra à celui que vous voyez au-dessus de vous. Définissez vos coordonnées de localisation afin de vous informer sur les étoiles qui se trouvent au-dessus de vous !"
 
-#: content/Default/apps/content.json.h:390
+#: content/Default/apps/content.json.h:399
 msgctxt "title"
 msgid "Super Tux"
 msgstr "Super Tux"
 
-#: content/Default/apps/content.json.h:391
+#: content/Default/apps/content.json.h:400
 msgctxt "subtitle"
 msgid "Jump your way through different levels to win"
 msgstr "Sautez à travers les différents niveaux pour gagner"
 
-#: content/Default/apps/content.json.h:392
+#: content/Default/apps/content.json.h:401
 msgctxt "description"
 msgid ""
 "This game is similar to the original Super Mario Brothers games where you "
@@ -2666,17 +2686,17 @@ msgid ""
 " can follow along with as you play."
 msgstr "Ce jeu est similaire aux jeux originaux Super Mario Brothers dans lesquels vous devez courir et sauter pour parcourir les différents niveaux. Ce jeu comprend 26 niveaux avec différents ennemis à combattre, une musique amusante, en plus d’une histoire que vous pouvez suivre au fur et à mesure que vous jouez."
 
-#: content/Default/apps/content.json.h:393
+#: content/Default/apps/content.json.h:402
 msgctxt "title"
 msgid "Tux Kart"
 msgstr "Tux Kart"
 
-#: content/Default/apps/content.json.h:394
+#: content/Default/apps/content.json.h:403
 msgctxt "subtitle"
 msgid "Race alone or against your friends and family"
 msgstr "Faites la course, seul ou contre vos amis et votre famille"
 
-#: content/Default/apps/content.json.h:395
+#: content/Default/apps/content.json.h:404
 msgctxt "description"
 msgid ""
 "Do you love racing games? Then this is the app for you! Race down easy, "
@@ -2687,17 +2707,17 @@ msgid ""
 "is sure to entertain you and your friends for hours!"
 msgstr "Aimez-vous les jeux de course ? Alors c’est l’application qu’il vous faut ! Dévalez des pistes de course faciles, moyennes ou difficiles en incarnant Tux, le pingouin, et tentez de battre votre temps ou celui d’un ami. Si vous êtes en mesure d’obtenir le poisson rouge, vous gagnerez des pouvoirs spéciaux qui vous aideront à gagner, mais soyez sûr d’éviter le poisson vert ou vous serez ralenti. Ce jeu est excellent, tant pour les enfants que pour les adultes, et vous divertira durant des heures avec vos amis !"
 
-#: content/Default/apps/content.json.h:396
+#: content/Default/apps/content.json.h:405
 msgctxt "title"
 msgid "Teeworlds"
 msgstr "Teeworlds"
 
-#: content/Default/apps/content.json.h:397
+#: content/Default/apps/content.json.h:406
 msgctxt "subtitle"
 msgid "Exciting multi-player shooting game"
 msgstr "Jeu de tir multijoueur excitant"
 
-#: content/Default/apps/content.json.h:398
+#: content/Default/apps/content.json.h:407
 msgctxt "description"
 msgid ""
 "Shoot your way to victory in death matches and more! This game has an old-"
@@ -2709,17 +2729,17 @@ msgid ""
 "and go!"
 msgstr "Faites votre chemin vers la victoire à travers des deathmatchs et plus ! Ce jeu a un goût old school et est un jeu de tir multijoueur excitant avec des batailles épiques avec jusqu’à 16 joueurs simultanés. Jouez à la Capture de Drapeau ou aux Deathmatchs en équipe où vous devrez essayer de survivre dans l’arène meurtrière en essayant de vous débarrasser de vos ennemis. Ce jeu comprends des fonctionnalités sympathiques telles que la possibilité de créer votre propre terrain de jeu ! Un divertissement empli d’hémoglobine vous attends, donc emparez vous de vos armes virtuelles et foncez !"
 
-#: content/Default/apps/content.json.h:399
+#: content/Default/apps/content.json.h:408
 msgctxt "title"
 msgid "TORCS"
 msgstr "TORCS"
 
-#: content/Default/apps/content.json.h:400
+#: content/Default/apps/content.json.h:409
 msgctxt "subtitle"
 msgid "Race cool 3D cars in this realistic game"
 msgstr "Faites la course à bord de voitures en 3D dans ce jeu réaliste"
 
-#: content/Default/apps/content.json.h:401
+#: content/Default/apps/content.json.h:410
 msgctxt "description"
 msgid ""
 "Rip around turns and scream past other drivers in this exciting 3D car "
@@ -2730,17 +2750,17 @@ msgid ""
 "want to play too!"
 msgstr "Dérapez dans les virages et criez aux oreilles des autres chauffeurs dans ce jeu de course en 3D excitant ! Il est tellement réaliste que vous jurerez sentir les pneus brûler ! Les utilisateurs avancés ont aussi l'opportunité de créer leurs propres chauffeurs personnalisés afin d'avoir un avantage encore plus grand sur leurs adversaires. Vous adorerez conduire vos bolides et bientôt vous verrez que vos amis voudront jouer aussi !"
 
-#: content/Default/apps/content.json.h:402
+#: content/Default/apps/content.json.h:411
 msgctxt "title"
 msgid "Videos"
 msgstr "Vidéos"
 
-#: content/Default/apps/content.json.h:403
+#: content/Default/apps/content.json.h:412
 msgctxt "subtitle"
 msgid "Full function video and media player"
 msgstr "Lecteur multimédia multifonctions"
 
-#: content/Default/apps/content.json.h:404
+#: content/Default/apps/content.json.h:413
 msgctxt "description"
 msgid ""
 "Do you love watching movies? Do it the right way with this video application"
@@ -2750,17 +2770,17 @@ msgid ""
 "your family and friends to join you in watching all of your favorite movies!"
 msgstr "Aimez-vous regarder des films ? Faites-le de la bonne façon avec cette application vidéo qui vous permet de regarder des films que vous avez téléchargés en mode plein écran. D’autres fonctions indispensables, comme le contrôle du volume et des playlists, rendent votre expérience de visionnage vidéo facile et amusant. Avec cette application vous voudrez inviter toute votre famille et vos amis à vous rejoindre pour visionner tous vos films préférés !"
 
-#: content/Default/apps/content.json.h:405
+#: content/Default/apps/content.json.h:414
 msgctxt "title"
 msgid "Tux Football"
 msgstr "Tux Football"
 
-#: content/Default/apps/content.json.h:406
+#: content/Default/apps/content.json.h:415
 msgctxt "subtitle"
 msgid "A fun soccer game starring Tux the penguin"
 msgstr "Un jeu de football amusant mettant en scène Tux le pingouin"
 
-#: content/Default/apps/content.json.h:407
+#: content/Default/apps/content.json.h:416
 msgctxt "description"
 msgid ""
 "Do you love soccer? Now you can play all day with your favorite penguins! "
@@ -2769,17 +2789,17 @@ msgid ""
 "professionals!"
 msgstr "Aimez-vous le football ? Désormais, vous pouvez y jouer toute la journée avec votre pingouin préféré ! Démontrez vos compétences et votre stratégie tout en contrôlant le joueur avec la balle. Bientôt, vous vous sentirez prêt à prendre la relève des professionnels !"
 
-#: content/Default/apps/content.json.h:408
+#: content/Default/apps/content.json.h:417
 msgctxt "title"
 msgid "Tux Math"
 msgstr "Tux Math"
 
-#: content/Default/apps/content.json.h:409
+#: content/Default/apps/content.json.h:418
 msgctxt "subtitle"
 msgid "Math games for kids"
 msgstr "Jeux mathématiques pour les enfants"
 
-#: content/Default/apps/content.json.h:410
+#: content/Default/apps/content.json.h:419
 msgctxt "description"
 msgid ""
 "Learn math by playing games! Starring kids’ favorite buddy, Tux the Penguin,"
@@ -2789,17 +2809,17 @@ msgid ""
 "both worlds and will help your child learn to love math!"
 msgstr "Apprenez les mathématiques en jouant à des jeux ! Mettant en scène le héros préféré des enfants, Tux le Pingouin, ce jeu amusant de mathématiques initie les enfants à des questions mathématiques amusantes et stimulantes. Vous souhaitez voir s’améliorer les compétences mathématiques de vos enfants, et ils veulent jouer à des jeux — les encourager à jouer permet donc de lier le meilleur des deux mondes et aidera vos enfants à apprendre à aimer les maths !"
 
-#: content/Default/apps/content.json.h:411
+#: content/Default/apps/content.json.h:420
 msgctxt "title"
 msgid "Tux Paint"
 msgstr "Tux Paint"
 
-#: content/Default/apps/content.json.h:412
+#: content/Default/apps/content.json.h:421
 msgctxt "subtitle"
 msgid "A fun drawing app for kids"
 msgstr "Une application amusante de dessin pour les enfants"
 
-#: content/Default/apps/content.json.h:413
+#: content/Default/apps/content.json.h:422
 msgctxt "description"
 msgid ""
 "Create beautiful artwork with this fun and easy to use app! Tux the penguin "
@@ -2810,17 +2830,17 @@ msgid ""
 "then download this app and get them started on their next masterpiece!"
 msgstr "Réalisez de magnifiques illustrations avec cette application amusante et facile à utiliser ! Tux le pingouin aide et guide les enfants pour qu'ils puissent utiliser tous les outils. La tranche d'âge recommandée pour utiliser cette application est de 3 à 12 ans, mais quiconque est encore jeune dans son cœur l'adorera ! Utilisez des tampons, jouez avec les formes, ou dessinez à main levée afin de créer quelque chose d'unique. Si votre enfant aime dessiner et réaliser des illustrations, téléchargez cette application et laissez-les débuter leur prochain chef-d’œuvre !"
 
-#: content/Default/apps/content.json.h:414
+#: content/Default/apps/content.json.h:423
 msgctxt "title"
 msgid "Tux Puck"
 msgstr "Tux Puck"
 
-#: content/Default/apps/content.json.h:415
+#: content/Default/apps/content.json.h:424
 msgctxt "subtitle"
 msgid "Exciting air hockey game for you and your friends"
 msgstr "Jeu de air hockey excitant pour vous et vos amis"
 
-#: content/Default/apps/content.json.h:416
+#: content/Default/apps/content.json.h:425
 msgctxt "description"
 msgid ""
 "An air hockey game in which you try to knock the puck past your opponent's "
@@ -2829,17 +2849,17 @@ msgid ""
 " or F6 to adjust your paddle speed.)"
 msgstr "Un jeu de air hockey dans lequel vous essayez de frapper le palet au travers de la défense adverse. C'est un super jeu pour toute la famille ! Testez votre adresse et vos réflexes pour gagner ce match palpitant ! (Pressez F5 ou F6 quand vous jouez pour ajuster la vitesse du curseur.)"
 
-#: content/Default/apps/content.json.h:417
+#: content/Default/apps/content.json.h:426
 msgctxt "title"
 msgid "Tux Typing"
 msgstr "Tux Typing"
 
-#: content/Default/apps/content.json.h:418
+#: content/Default/apps/content.json.h:427
 msgctxt "subtitle"
 msgid "Learn to type by playing games"
 msgstr "Apprenez à taper au clavier en jouant à des jeux"
 
-#: content/Default/apps/content.json.h:419
+#: content/Default/apps/content.json.h:428
 msgctxt "description"
 msgid ""
 "This fun application is a great way for kids, and even adults, to learn how "
@@ -2851,17 +2871,17 @@ msgid ""
 "encouraging them to play!"
 msgstr "Cette amusante application est une excellente façon pour les enfants, et même les adultes, d’apprendre comment taper au clavier ! Apprenez les bases, ou améliorez vos compétences en jouant à des jeux qui vous enseignent comment utiliser le clavier sans même le regarder. Les enfants d’aujourd’hui grandissent entourés d’ordinateurs et d’appareils mobiles, et apprendre comment utiliser correctement ces technologies sera de plus en plus important dans le futur. Donnez-leur une base solide en téléchargeant cette application et en les encourageant à jouer !"
 
-#: content/Default/apps/content.json.h:420
+#: content/Default/apps/content.json.h:429
 msgctxt "title"
 msgid "Warmux"
 msgstr "Warmux"
 
-#: content/Default/apps/content.json.h:421
+#: content/Default/apps/content.json.h:430
 msgctxt "subtitle"
 msgid "Make your computer a battle of wit and war"
 msgstr "Transformez votre ordinateur en champ de bataille de l'esprit"
 
-#: content/Default/apps/content.json.h:422
+#: content/Default/apps/content.json.h:431
 msgctxt "description"
 msgid ""
 "Exterminate your opponent in a cartoon word using dynamite, grenades, "
@@ -2870,17 +2890,17 @@ msgid ""
 " member of each team attempts to destroy his opponents."
 msgstr "Exterminez votre adversaire dans un monde cartoon en utilisant de la dynamite, des grenades, des lance-roquettes, ou même une batte de baseball. Chaque joueur contrôle sa propre équipe et doit détruire son adversaire en utilisant son arsenal et sa stratégie, car tour après tour, chaque membre de chaque équipe essaye de détruire ses ennemis."
 
-#: content/Default/apps/content.json.h:423
+#: content/Default/apps/content.json.h:432
 msgctxt "title"
 msgid "Warzone 2100"
 msgstr "Warzone 2100"
 
-#: content/Default/apps/content.json.h:424
+#: content/Default/apps/content.json.h:433
 msgctxt "subtitle"
 msgid "Lead your troops to rebuild the world"
 msgstr "Dirigez vos troupes pour reconstruire le monde"
 
-#: content/Default/apps/content.json.h:425
+#: content/Default/apps/content.json.h:434
 msgctxt "description"
 msgid ""
 "In Warzone 2100 you command forces to rebuild the world after nuclear war "
@@ -2890,17 +2910,17 @@ msgid ""
 "of strategy, tactics, and wit."
 msgstr "Dans Warzone 2100, vous commandez des forces pour reconstruire le monde après qu’une guerre nucléaire l’ait détruit. Jouez seul ou avec des amis ; de toute façon vous plongerez la tête la première dans un autre monde où vous vivrez et respirerez votre stratégie militaire. Recherchez des technologies, construisez des unités, et planifiez des batailles dans ce jeu de stratégie, de tactique et d’esprit. "
 
-#: content/Default/apps/content.json.h:426
+#: content/Default/apps/content.json.h:435
 msgctxt "title"
 msgid "Wesnoth"
 msgstr "Wesnoth"
 
-#: content/Default/apps/content.json.h:427
+#: content/Default/apps/content.json.h:436
 msgctxt "subtitle"
 msgid "Fantasy turn-based strategy game"
 msgstr "Jeu de stratégie fantastique au tour par tour"
 
-#: content/Default/apps/content.json.h:428
+#: content/Default/apps/content.json.h:437
 msgctxt "description"
 msgid ""
 "Battle for control of the land, villages, and resources in this fantasy-"
@@ -2909,17 +2929,17 @@ msgid ""
 "strategy, this game is sure to reveal a great leader inside you."
 msgstr "Battez-vous pour contrôler les territoires, villages, et ressources dans ce jeu de stratégie à thème fantastique. Chaque joueur contrôle l’armée qu’il conçoit lui-même et utilise pour chercher à dominer. Avec son excitant mélange d’histoire, de fantastique et de stratégie, ce jeu est certain de révéler le grand dirigeant qui se trouve en vous."
 
-#: content/Default/apps/content.json.h:429
+#: content/Default/apps/content.json.h:438
 msgctxt "title"
 msgid "X-Moto"
 msgstr "X-Moto"
 
-#: content/Default/apps/content.json.h:430
+#: content/Default/apps/content.json.h:439
 msgctxt "subtitle"
 msgid "A motorcycle racing game"
 msgstr "Un jeu de course de moto"
 
-#: content/Default/apps/content.json.h:431
+#: content/Default/apps/content.json.h:440
 msgctxt "description"
 msgid ""
 "Love motorcycles? Then you're going to love this racing game where physics "
@@ -2929,17 +2949,17 @@ msgid ""
 "time in this fast-paced, exciting test of speed!"
 msgstr "Vous adorez les motos ? Alors vous allez adorer ce jeu de course dans lequel la physique joue un rôle important pour la victoire ! Vous devez contrôler votre moto dans ses limites physiques si vous voulez avoir une chance de finir les courses difficiles. Apprenez-en davantage sur la science et exercez vos compétences de conduite en même temps dans ce test de vitesse haletant !"
 
-#: content/Default/apps/content.json.h:432
+#: content/Default/apps/content.json.h:441
 msgctxt "title"
 msgid "KBlocks"
 msgstr "KBlocks"
 
-#: content/Default/apps/content.json.h:433
+#: content/Default/apps/content.json.h:442
 msgctxt "subtitle"
 msgid "Match blocks to destroy them and win"
 msgstr "Faites correspondre les blocs pour les détruire et gagner"
 
-#: content/Default/apps/content.json.h:434
+#: content/Default/apps/content.json.h:443
 msgctxt "description"
 msgid ""
 "This game is similar to Tetris, so if you love that game, you will love this"
@@ -2948,17 +2968,17 @@ msgid ""
 " lose, so pay attention and get ready for some very fast-actioned fun!"
 msgstr "Ce jeu est similaire à Tetris, donc si vous adorez ce jeu, vous adorerez celui-là également ! Faites correspondre les formes des blocs afin de les faire disparaître et empêchez-les d'emplir l'écran. Vous aurez besoin d'être vraiment rapide pour ne pas perdre, donc restez aux aguets et soyez prêt à vous amuser intensément !"
 
-#: content/Default/apps/content.json.h:435
+#: content/Default/apps/content.json.h:444
 msgctxt "title"
 msgid "KBounce"
 msgstr "KBounce"
 
-#: content/Default/apps/content.json.h:436
+#: content/Default/apps/content.json.h:445
 msgctxt "subtitle"
 msgid "The ball-bouncing game sure to hook you"
 msgstr "Le jeu de balle rebondissante sûr de vous rendre accro"
 
-#: content/Default/apps/content.json.h:437
+#: content/Default/apps/content.json.h:446
 msgctxt "description"
 msgid ""
 "This is a fun game with a simple goal: you must build walls to decrease the "
@@ -2968,17 +2988,17 @@ msgid ""
 "It requires quick thinking and fast reflexes!"
 msgstr "Il s’agit d’un jeu amusant avec un objectif simple : vous devez construire des murs pour réduire la zone dans laquelle la balle rebondissante à l’écran peut bouger. Une fois que vous avez rempli la majeure partie de l’écran avec des murs, vous serez en mesure d’atteindre le niveau suivant. Ce jeu possède des éléments de résolution de puzzle, et est rythmé et divertissant. Il demande une réflexion rapide et de prompts réflexes !"
 
-#: content/Default/apps/content.json.h:438
+#: content/Default/apps/content.json.h:447
 msgctxt "title"
 msgid "KDiamond"
 msgstr "KDiamond"
 
-#: content/Default/apps/content.json.h:439
+#: content/Default/apps/content.json.h:448
 msgctxt "subtitle"
 msgid "Create lines of three diamonds"
 msgstr "Créez des lignes de trois diamants"
 
-#: content/Default/apps/content.json.h:440
+#: content/Default/apps/content.json.h:449
 msgctxt "description"
 msgid ""
 "In this fast-paced game, your job is to build lines of three diamonds of the"
@@ -2989,17 +3009,17 @@ msgid ""
 "many age levels."
 msgstr "Dans ce jeu rythmé, votre job est de construire des lignes de trois diamants du même type. Inversez simplement les diamants avec leurs voisins pour créer vos lignes. Mieux vaut le faire rapidement, afin que vous puissiez construire autant de lignes que possible avant que le tour ne soit fini ! C’est un jeu facile et très distrayant auquel vous pouvez jouer pour juste quelques instants, ou pour des heures entières au final. C’est amusant, rapide, et parfait pour de nombreuses tranches d’âge."
 
-#: content/Default/apps/content.json.h:441
+#: content/Default/apps/content.json.h:450
 msgctxt "title"
 msgid "KJumpingCube"
 msgstr "KJumpingCube"
 
-#: content/Default/apps/content.json.h:442
+#: content/Default/apps/content.json.h:451
 msgctxt "subtitle"
 msgid "Develop a good strategy to conquer all the squares"
 msgstr "Développez une stratégie efficace pour conquérir tous les carrés"
 
-#: content/Default/apps/content.json.h:443
+#: content/Default/apps/content.json.h:452
 msgctxt "description"
 msgid ""
 "Practice your strategic thinking with this challenging dice-based game! You "
@@ -3014,17 +3034,17 @@ msgid ""
 " toes! "
 msgstr "Entraînez-vous à la pensée stratégique avec ce jeu exigeant basé sur des dés ! Vous vous déplacez en cliquant sur un carré libre ou un carré que vous possédez déjà. Si vous cliquez sur un carré libre, sa couleur change et devient la vôtre. Chaque fois que vous cliquez sur un carré, sa valeur augmente de un. Une fois qu'un carré a plus de points que ses voisins immédiats, ses points sont distribués entre ses voisins (les points se déplacent). Si un carré voisin appartient à votre adversaire, vous en prenez le contrôle ainsi que tous ses points. Vous devrez bien réfléchir pour contrôler tous les carrés, et comme les dés peuvent changer de mains très rapidement, ce jeu vous gardera assurément en haleine !"
 
-#: content/Default/apps/content.json.h:444
+#: content/Default/apps/content.json.h:453
 msgctxt "title"
 msgid "KSame"
 msgstr "KSame"
 
-#: content/Default/apps/content.json.h:445
+#: content/Default/apps/content.json.h:454
 msgctxt "subtitle"
 msgid "Get rid of all the marbles to win"
 msgstr "Débarrassez-vous de toutes les billes pour gagner"
 
-#: content/Default/apps/content.json.h:446
+#: content/Default/apps/content.json.h:455
 msgctxt "description"
 msgid ""
 "Show off your pattern-finding skills in this addicting game. Match all of "
@@ -3034,17 +3054,17 @@ msgid ""
 " challenge. A really fun challenge!"
 msgstr "Prouvez votre aptitude à la recherche de chemin dans ce jeu addictif. Faites correspondre toutes les billes de même couleur pour vider le plateau et gagnez, mais souvenez-vous : plus vous nettoyez de billes d’un coup, et plus votre score sera élevé, donc réfléchissez tous vos coups de façon stratégique ! Ce qui peut sembler simple au premier coup d’œil est en fait un véritable défi. Un défi vraiment amusant !"
 
-#: content/Default/apps/content.json.h:447
+#: content/Default/apps/content.json.h:456
 msgctxt "title"
 msgid "Open Arena"
 msgstr "Arène Ouverte"
 
-#: content/Default/apps/content.json.h:448
+#: content/Default/apps/content.json.h:457
 msgctxt "subtitle"
 msgid "Shoot your way out of trouble in this fun game"
 msgstr "Tirez dans le tas pour vous en sortir dans ce jeu amusant"
 
-#: content/Default/apps/content.json.h:449
+#: content/Default/apps/content.json.h:458
 msgctxt "description"
 msgid ""
 "If arena battles are your idea of a good time, then you’ll love this "
@@ -3054,7 +3074,7 @@ msgid ""
 "of these modes offers its own form of excitement as you battle your enemies!"
 msgstr "Si vous rêvez de batailler dans des arènes, alors vous adorerez cette application. Mais attention — c’est un jeu de compétences exigeantes, et d’effusions abondantes d’hémoglobine. Utilisez différents types d’armes dans des défis tels que la Capture de Drapeau, les Deathmatchs, les Deathmatchs en équipe, le Dernier Homme Debout, et les Tournois. Chacun de ces modes offre sa propre forme d’excitation tandis que vous combattez vos ennemis !"
 
-#: content/Default/apps/content.json.h:159
+#: content/Default/apps/content.json.h:171
 msgctxt "description"
 msgid ""
 "Need to safely store all of your important documents, photos, songs, and "

--- a/po/pt.po
+++ b/po/pt.po
@@ -16,8 +16,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: eos-shell-content\n"
 "Report-Msgid-Bugs-To: https://www.transifex.com/projects/p/eos-shell-content/\n"
-"POT-Creation-Date: 2015-02-24 12:56-0800\n"
-"PO-Revision-Date: 2015-02-24 21:02+0000\n"
+"POT-Creation-Date: 2015-02-24 16:21-0800\n"
+"PO-Revision-Date: 2015-02-25 00:22+0000\n"
 "Last-Translator: Roddy Shuler <roddy@endlessm.com>\n"
 "Language-Team: Portuguese (http://www.transifex.com/projects/p/eos-shell-content/language/pt/)\n"
 "MIME-Version: 1.0\n"
@@ -554,7 +554,7 @@ msgid "Curriculum"
 msgstr "Currículo"
 
 #: content/Default/apps/content.json.h:83
-#: content/Default/apps/content.json.h:229
+#: content/Default/apps/content.json.h:241
 msgctxt "subtitle"
 msgid "From the Guatemalan Ministry of Education"
 msgstr "Do Ministério da Educação da Guatemala"
@@ -852,16 +852,34 @@ msgid ""
 msgstr "A melhor maneira de criar uma boa impressão em um novo chefe em potencial é ter um currículo de destaque e este programa está aqui para ajudá-lo a conseguir isso. Com modelos convenientes e atrativos, você pode usar diversos exemplos para criar um currículo de causar inveja. Saiba exatamente o que é um currículo e o que ele deve conter, obtenha dicas em cada seção e receba também orientações sobre como se preparar para entrevistas de emprego. Este programa pode ajudá-lo a chegar mais perto do emprego dos seus sonhos."
 
 #: content/Default/apps/content.json.h:124
+#: content/Default/apps/content.json.h:127
 msgctxt "title"
 msgid "Football"
 msgstr "Futebol"
 
 #: content/Default/apps/content.json.h:125
+#: content/Default/apps/content.json.h:137
+#: content/Default/apps/content.json.h:161
+msgctxt "subtitle"
+msgid "Deprecated version"
+msgstr ""
+
+#: content/Default/apps/content.json.h:126
+#: content/Default/apps/content.json.h:138
+#: content/Default/apps/content.json.h:162
+msgctxt "description"
+msgid ""
+"If you have internet access, there may be a newer version of this "
+"application available to download and install. In the meantime, you may "
+"continue to use this version that is already installed on your computer."
+msgstr ""
+
+#: content/Default/apps/content.json.h:128
 msgctxt "subtitle"
 msgid "Learn about your favorite team and players"
 msgstr "Mantenha-se atualizado sobre os seus times de futebol, leia sobre jogadores famosos e  conheça as regras do jogo"
 
-#: content/Default/apps/content.json.h:126
+#: content/Default/apps/content.json.h:129
 msgctxt "description"
 msgid ""
 "Football is a major sport with fans all around the world. Are you one of "
@@ -871,17 +889,17 @@ msgid ""
 " with thousands of articles about your favorite sport!"
 msgstr "Futebol é um esporte de grande importância que agrega fãs em todo o mundo. Você é um deles? Então este programa é para você. Ele apresenta tudo o que você precisa saber sobre os maiores times do mundo, jogadores e campeonatos. Saiba sobre os acontecimentos do esporte e sua história, descubra as complexidades das regras e fique atualizado com artigos sobre o seu esporte favorito!"
 
-#: content/Default/apps/content.json.h:127
+#: content/Default/apps/content.json.h:130
 msgctxt "title"
 msgid "Social Enterprises"
 msgstr "Negócios Sociais"
 
-#: content/Default/apps/content.json.h:128
+#: content/Default/apps/content.json.h:131
 msgctxt "subtitle"
 msgid "All about non-profit organizations"
 msgstr "Tudo sobre organizações sem fins lucrativos"
 
-#: content/Default/apps/content.json.h:129
+#: content/Default/apps/content.json.h:132
 msgctxt "description"
 msgid ""
 "Have you thought of starting your own non-profit organization, or of joining"
@@ -891,17 +909,17 @@ msgid ""
 "your impact in the world even larger!"
 msgstr "Já pensou em começar sua própria organização sem fins lucrativos ou se juntar à uma? Elas possuem benefícios fiscais especiais, que geralmente são criados para trazer um impacto social real. Leia aqui para entender mais sobre a estrutura sem fins lucrativos e como operá-las de modo que você possa fazer o seu impacto no mundo ainda maior!"
 
-#: content/Default/apps/content.json.h:130
+#: content/Default/apps/content.json.h:133
 msgctxt "title"
 msgid "Social Sciences"
 msgstr "Ciências Sociais"
 
-#: content/Default/apps/content.json.h:131
+#: content/Default/apps/content.json.h:134
 msgctxt "subtitle"
 msgid "Subjects that explore the individual and society"
 msgstr "Temas que exploram sobre o indivíduo e a sociedade"
 
-#: content/Default/apps/content.json.h:132
+#: content/Default/apps/content.json.h:135
 msgctxt "description"
 msgid ""
 "Human beings and the relationships and societies they form are complicated. "
@@ -913,17 +931,39 @@ msgid ""
 "understanding of human behavior."
 msgstr "Os seres humanos, as relações e as sociedades que eles formam são complicadas. Este programa irá apresentar-lhe muitas das disciplinas que examinam a história humana, culturas e interações. Você terá acesso às noções básicas de psicologia, sociologia, antropologia, ciência política, e muito mais. Compreender os fundamentos de tais disciplinas irá ajudá-lo a entender as maneiras como eles interagem e se relacionam entre si. Você vai sair com uma rica compreensão do comportamento humano."
 
-#: content/Default/apps/content.json.h:133
+#: content/Default/apps/content.json.h:136
+#: content/Default/apps/content.json.h:139
+msgctxt "title"
+msgid "Textbooks"
+msgstr "Livros Didáticos"
+
+#: content/Default/apps/content.json.h:140
+msgctxt "subtitle"
+msgid "Math and science textbooks"
+msgstr ""
+
+#: content/Default/apps/content.json.h:141
+msgctxt "description"
+msgid ""
+"Find information to help you with your homework, or learn about a subject "
+"you've always wanted to know more about! You can scroll through photos, "
+"tables, and graphs to learn more about each. Not only are these textbooks "
+"very thorough and informative, but they are also easy to read and helpful. "
+"Whether you’re a student, parent, teacher, or just someone eager to learn, "
+"you'll be sure to find something interesting and useful here!"
+msgstr ""
+
+#: content/Default/apps/content.json.h:142
 msgctxt "title"
 msgid "Translate"
 msgstr "Tradutor"
 
-#: content/Default/apps/content.json.h:134
+#: content/Default/apps/content.json.h:143
 msgctxt "subtitle"
 msgid "Translate text between many languages instantly"
 msgstr "Traduz rapidamente textos em várias línguas"
 
-#: content/Default/apps/content.json.h:135
+#: content/Default/apps/content.json.h:144
 msgctxt "description"
 msgid ""
 "Download this app to help you understand and be understood in virtually any "
@@ -934,17 +974,17 @@ msgid ""
 " – with the world’s languages at your fingertips.  **Requires internet"
 msgstr "A tradução de um idioma para outro é uma boa maneira de unir culturas. Ela também é importante em muitas atividades do dia-a-dia em nosso mundo cada vez mais globalizado. Com o programa Tradutor você consegue entender e ser compreendido em praticamente qualquer idioma. O programa apresenta configuração de fácil compreensão, assim você pode usá-lo sem qualquer dificuldade. É agradavelmente simples. Faça novas conexões - e até mesmo novos amigos - com os idiomas do mundo na ponta de seus dedos."
 
-#: content/Default/apps/content.json.h:136
+#: content/Default/apps/content.json.h:145
 msgctxt "title"
 msgid "Travel"
 msgstr "Viagem"
 
-#: content/Default/apps/content.json.h:137
+#: content/Default/apps/content.json.h:146
 msgctxt "subtitle"
 msgid "Travel around the world from your living room"
 msgstr "Explore sites online de todo o mundo direto da sua sala-de-estar"
 
-#: content/Default/apps/content.json.h:138
+#: content/Default/apps/content.json.h:147
 msgctxt "description"
 msgid ""
 "The world is an amazing and beautiful place! Start exploring it with this "
@@ -955,17 +995,17 @@ msgid ""
 "sites in the world!"
 msgstr "O mundo é um lugar surpreendente e lindo! Comece a explorá-lo com este programa irado que permite ver fotos e saber sobre acontecimentos de regiões de todo o mundo. Ele apresenta informações sobre os principais lugares como as Américas, Europa, Ásia e mais. Aprenda sobre as maravilhas naturais, explore novas culturas e descubra alguns dos lugares sagrados mais importantes do mundo!"
 
-#: content/Default/apps/content.json.h:139
+#: content/Default/apps/content.json.h:148
 msgctxt "title"
 msgid "Typing"
 msgstr "Digitando"
 
-#: content/Default/apps/content.json.h:140
+#: content/Default/apps/content.json.h:149
 msgctxt "subtitle"
 msgid "Learn to type with games and songs"
 msgstr "Aprenda a digitar com jogos e músicas"
 
-#: content/Default/apps/content.json.h:141
+#: content/Default/apps/content.json.h:150
 msgctxt "description"
 msgid ""
 "How fast can you type? Whether you're already fast or just learning how to "
@@ -976,17 +1016,17 @@ msgid ""
 "now it can be a whole lot of fun too!"
 msgstr "A digitação é uma habilidade valorizada em praticamente qualquer ambiente educacional e profissional. Mas você sabia que também pode ser muito divertida? Com jogos estimulantes, este programa de digitação irá ensiná-lo a usar o teclado com eficiência e ajudá-lo a desenvolver memória muscular para digitação. E o melhor, você irá aprender esta importante habilidade digitando as letras de suas músicas preferidas! O que pode ser mais legal do que acompanhar as músicas que você adora e ao mesmo tempo ganhar uma nova habilidade?"
 
-#: content/Default/apps/content.json.h:142
+#: content/Default/apps/content.json.h:151
 msgctxt "title"
 msgid "Virtual School"
 msgstr "Escola Virtual"
 
-#: content/Default/apps/content.json.h:143
+#: content/Default/apps/content.json.h:152
 msgctxt "subtitle"
 msgid "Free educational videos on almost any subject"
 msgstr "Saiba mais sobre matemática, computadores, economia, ciência, medicina, finanças, história e muito mais, gratuitamente."
 
-#: content/Default/apps/content.json.h:144
+#: content/Default/apps/content.json.h:153
 msgctxt "description"
 msgid ""
 "Learning is easy and fun with video courses on subjects like math, biology, "
@@ -998,17 +1038,17 @@ msgid ""
 " this app and these videos can help you succeed in school and in life!"
 msgstr "Um mundo inteiro de conhecimento está ao seu alcance com o programa Khan Academy. Um dos maiores recursos educacionais no mundo, Khan Academy, oferece vídeo aulas online em uma grande variedade de áreas de conteúdo, incluindo matemática, biologia, química e física. Estes emocionantes vídeos lhe darão acesso a conteúdos fascinantes, e te ajudará a aprender mais do que a educação da sua sala de aula. Os vídeos são gratuitos, de fácil acesso, e proporcionarão oportunidades de aprendizagem que com certeza vão expandir sua mente."
 
-#: content/Default/apps/content.json.h:145
+#: content/Default/apps/content.json.h:154
 msgctxt "title"
 msgid "Sanitation"
 msgstr "Saneamento "
 
-#: content/Default/apps/content.json.h:146
+#: content/Default/apps/content.json.h:155
 msgctxt "subtitle"
 msgid "All about clean water and sanitation"
 msgstr "Tudo sobre água potável e saneamento básico"
 
-#: content/Default/apps/content.json.h:147
+#: content/Default/apps/content.json.h:156
 msgctxt "description"
 msgid ""
 "Drinking clean water is essential for survival. There can often be terrible "
@@ -1017,17 +1057,17 @@ msgid ""
 "that you create a sanitary environment around you where you can thrive. "
 msgstr "Beber água limpa é essencial para a sobrevivência. Más condições de saneamento e consumo de água imprópria podem causar sérias doenças.  Saiba como se certificar de que você bebe água potável e como garantir um ambiente sanitário seguro em torno de você, onde você pode prosperar."
 
-#: content/Default/apps/content.json.h:148
+#: content/Default/apps/content.json.h:157
 msgctxt "title"
 msgid "Weather"
 msgstr "Tempo"
 
-#: content/Default/apps/content.json.h:149
+#: content/Default/apps/content.json.h:158
 msgctxt "subtitle"
 msgid "Get daily local forecasts from trusted sources"
 msgstr "Receba diáriamente previsões do tempo de fontes seguras"
 
-#: content/Default/apps/content.json.h:150
+#: content/Default/apps/content.json.h:159
 msgctxt "description"
 msgid ""
 "“How’s the weather out there?” Answer this question easily, every day, with "
@@ -1037,17 +1077,18 @@ msgid ""
 "about the weather to take advantage of your day!  **Requires internet"
 msgstr "Como está o clima lá fora? Responda a essa pergunta facilmente, todos os dias, com o clique de um botão. Este programa despretensioso de clima permite que você veja o que está acontecendo do lado de fora de sua porta. O tempo estará frio? Preciso me preparar para a chuva? Está um dia perfeito para ficar ao ar livre? Fique por dentro de tudo o que você precisa saber sobre o clima e tire maior proveito do seu dia!"
 
-#: content/Default/apps/content.json.h:151
+#: content/Default/apps/content.json.h:160
+#: content/Default/apps/content.json.h:163
 msgctxt "title"
 msgid "World Literature"
 msgstr "Mundo Literário"
 
-#: content/Default/apps/content.json.h:152
+#: content/Default/apps/content.json.h:164
 msgctxt "subtitle"
 msgid "Read all of the world's great literature"
 msgstr "Leia tudo sobre a literatura mundial"
 
-#: content/Default/apps/content.json.h:153
+#: content/Default/apps/content.json.h:165
 msgctxt "description"
 msgid ""
 "Find some of your favorite books in this app! To begin browsing, open the "
@@ -1059,17 +1100,17 @@ msgid ""
 "entertained for hours expanding your literary knowledge."
 msgstr "Encontre alguns de seus livros favoritos neste programa! Para começar, abra a pasta, clique em \"Índice\" e selecione  o gênero que mais lhe interessa. Você vai encontrar alguns dos livros mais famosos já escritos, incluindo livros atuais incríveis. Esta biblioteca virtual tem uma coleção impressionante de romances, poemas, biografias, histórias, entre outros. Se você encontrar seu livro favorito ou descobrir um novo, vai se divertir por horas, além de expandir seu conhecimento literário. "
 
-#: content/Default/apps/content.json.h:154
+#: content/Default/apps/content.json.h:166
 msgctxt "title"
 msgid "YouVideos"
 msgstr "YouVídeos"
 
-#: content/Default/apps/content.json.h:155
+#: content/Default/apps/content.json.h:167
 msgctxt "subtitle"
 msgid "Discover and share great videos online"
 msgstr "Compartilhe os seus vídeos com amigos, família e o resto do mundo"
 
-#: content/Default/apps/content.json.h:156
+#: content/Default/apps/content.json.h:168
 msgctxt "description"
 msgid ""
 "This app makes finding videos on the popular video site, YouTube, and "
@@ -1080,27 +1121,27 @@ msgid ""
 "family, and the world!  ** Requires internet"
 msgstr "O YouTube é um dos sites onde mais se encontra diversão e informação na internet. Você pode encontrar vídeos de seus artistas musicais preferidos, tutoriais que ensinam a fazer praticamente tudo, vídeos encantadores ou engraçados e muito mais! O programa YouTube permite encontrar vídeos de maneira inovadora, fácil e atrativa. Este programa é o que há de melhor para encontrar aquele vídeo que você estava procurando."
 
-#: content/Default/apps/content.json.h:157
+#: content/Default/apps/content.json.h:169
 msgctxt "title"
 msgid "Dropbox"
 msgstr "Dropbox"
 
-#: content/Default/apps/content.json.h:158
+#: content/Default/apps/content.json.h:170
 msgctxt "subtitle"
 msgid "Access your files from any computer"
 msgstr "Acesse seus arquivos à partir de qualquer computador"
 
-#: content/Default/apps/content.json.h:162
+#: content/Default/apps/content.json.h:174
 msgctxt "title"
 msgid "Chat"
 msgstr "Chat"
 
-#: content/Default/apps/content.json.h:163
+#: content/Default/apps/content.json.h:175
 msgctxt "subtitle"
 msgid "Chat with all of your friends in one place"
 msgstr "Programa de mensagens instantâneas com suporte de texto, voz, chat por vídeo e transferência de arquivos"
 
-#: content/Default/apps/content.json.h:164
+#: content/Default/apps/content.json.h:176
 msgctxt "description"
 msgid ""
 "Do you love to chat with friends? And, do you use many different programs to"
@@ -1113,17 +1154,17 @@ msgid ""
 "and family easier than ever before!  **Requires internet"
 msgstr "Este programa de conversação é uma ferramenta fantástica. É compatível com chats de vários sites na internet, como o Facebook, Jabber, MSN, AIM, Gadu Gadu e muitos mais, para que você possa trocar mensagens instantâneas, conversas de vídeo e áudio num só programa, independentemente do número de contatos que você tenha em todos os programas. Basta configurar esta aplicação com as outras contas que você tiver e estará pronto para conversar com todas as pessoas que você conhece sem ter que trocar de uma aplicação para outra. Este programa também permite o compartilhamento de arquivos, para quando quiser enviar fotos, documentos ou outros arquivos pelo chat. Com este programa você vai manter sempre contato com todos os teus amigos e sua família!"
 
-#: content/Default/apps/content.json.h:165
+#: content/Default/apps/content.json.h:177
 msgctxt "title"
 msgid "Documents"
 msgstr "Documentos"
 
-#: content/Default/apps/content.json.h:166
+#: content/Default/apps/content.json.h:178
 msgctxt "subtitle"
 msgid "Access all of your documents and files"
 msgstr "Gerenciador de Arquivos"
 
-#: content/Default/apps/content.json.h:167
+#: content/Default/apps/content.json.h:179
 msgctxt "description"
 msgid ""
 "Get organized with this app, which helps you find all of your documents and "
@@ -1134,17 +1175,17 @@ msgid ""
 "special photo again."
 msgstr "Organize-se com esse programa que ajuda a encontrar documentos e arquivos no seu computador, não importa há quanto tempo eles tenham sido salvos. Organize as coisas de uma maneira que faça sentido para você. Crie e renomeie pastas para que você possa encontrar quando quiser.  Com este programa você pode armazenar tudo em um só lugar e nunca vai perder um arquivo importante ou aquela foto especial novamente."
 
-#: content/Default/apps/content.json.h:168
+#: content/Default/apps/content.json.h:180
 msgctxt "title"
 msgid "E-mail"
 msgstr "E-mail"
 
-#: content/Default/apps/content.json.h:169
+#: content/Default/apps/content.json.h:181
 msgctxt "subtitle"
 msgid "Your e-mail, address book and calendar in one place"
 msgstr "Ferramenta completa para gestão de e-mail, contatos e calendário"
 
-#: content/Default/apps/content.json.h:170
+#: content/Default/apps/content.json.h:182
 msgctxt "description"
 msgid ""
 "Staying in touch is an important part of modern life, and email has become "
@@ -1155,17 +1196,17 @@ msgid ""
 "  **Requires internet"
 msgstr "Ficar em contato é uma parte importante da vida moderna, e o e-mail tornou-se uma das melhores maneiras de fazê-lo. Você pode receber e-mails de amigos e familiares distantes, receber mensagens contendo piadas diárias, vocabulário, ou notícias, e até mesmo lidar com questões importantes - tudo via e-mail. Quando você precisa verificar seu e-mail de forma rápida e simples, este programa estará lá para você."
 
-#: content/Default/apps/content.json.h:171
+#: content/Default/apps/content.json.h:183
 msgctxt "title"
 msgid "Tux Racer"
 msgstr "Tux Racer"
 
-#: content/Default/apps/content.json.h:172
+#: content/Default/apps/content.json.h:184
 msgctxt "subtitle"
 msgid "Race down icy mountains"
 msgstr "Corrida pelas montanhas geladas "
 
-#: content/Default/apps/content.json.h:173
+#: content/Default/apps/content.json.h:185
 msgctxt "description"
 msgid ""
 "Make it down a snow and ice-covered mountain as quickly as possible in this "
@@ -1174,17 +1215,17 @@ msgid ""
 "get your heart racing, this game is a must play for any adrenaline addict."
 msgstr "Desça pela montanha coberta de neve o mais rápido possível neste jogo incrível de corrida! Mas não vai ser fácil! Você vai precisar para evitar as árvores, pedras e até ossos de peixes que ficam no seu caminho e te atrapalham. Com certeza seu coração ficará acelerado, neste jogo obrigatório para os viciados em adrenalina."
 
-#: content/Default/apps/content.json.h:174
+#: content/Default/apps/content.json.h:186
 msgctxt "title"
 msgid "Four in a Row"
 msgstr "Quatro na Linha"
 
-#: content/Default/apps/content.json.h:175
+#: content/Default/apps/content.json.h:187
 msgctxt "subtitle"
 msgid "A simple and addictive game for kids and adults"
 msgstr "Um simples e divertido jogo de quebra-cabeça para crianças e adultos"
 
-#: content/Default/apps/content.json.h:176
+#: content/Default/apps/content.json.h:188
 msgctxt "description"
 msgid ""
 "This classic game is great for both children and adults alike! The goal is "
@@ -1196,17 +1237,17 @@ msgid ""
 "fun game!"
 msgstr "Esse jogo clássico é ótimo tanto para crianças como para adultos! O objetivo é simples: você precisa criar uma linha reta com 4 círculos antes do seu oponente. Você pode fazer linhas horizontais, verticais ou diagonais, como no Jogo da Velha, mas você vai precisar tomar muito cuidado e prestar atenção no que seu oponente está fazendo se você quiser ganhar! Você pode jogar contra o computador ou contra um amigo. Passe horas jogando e se divertindo!"
 
-#: content/Default/apps/content.json.h:177
+#: content/Default/apps/content.json.h:189
 msgctxt "title"
 msgid "FreeCiv"
 msgstr "FreeCiv"
 
-#: content/Default/apps/content.json.h:178
+#: content/Default/apps/content.json.h:190
 msgctxt "subtitle"
 msgid "Guide your own civilization to greatness"
 msgstr "Viaje através do tempo para criar a sua própria civilização e levá-la à ser nobre"
 
-#: content/Default/apps/content.json.h:179
+#: content/Default/apps/content.json.h:191
 msgctxt "description"
 msgid ""
 "Create your own world with this action-packed game that lets you travel "
@@ -1218,17 +1259,17 @@ msgid ""
 "conquering the moon and beyond!"
 msgstr "Crie seu próprio mundo com este jogo cheio de ação que lhe permite viajar no tempo e começar sua própria civilização. Você começará em um mundo pré-histórico, onde você vai precisar criar a sua própria tribo. Depois, você vai passar para a Idade Média, sobreviver à praga e inventar a roda. Você vai continuar a viajar através dos tempos até alcançar a modernidade e precisará saber administrar suas obrigações frente a tudo que está acontecendo no mundo, para poder conduzir o seu povo na conquista da lua e muito mais! Não é incrível?"
 
-#: content/Default/apps/content.json.h:180
+#: content/Default/apps/content.json.h:192
 msgctxt "title"
 msgid "FreeCol"
 msgstr "FreeCol"
 
-#: content/Default/apps/content.json.h:181
+#: content/Default/apps/content.json.h:193
 msgctxt "subtitle"
 msgid "Create your own country and conquer the world"
 msgstr "Crie o seu próprio país e deixe sua marca no mundo"
 
-#: content/Default/apps/content.json.h:182
+#: content/Default/apps/content.json.h:194
 msgctxt "description"
 msgid ""
 "Have you ever wanted to start your own country? Well, now you can. Go back "
@@ -1238,17 +1279,17 @@ msgid ""
 "prosperity? You decide."
 msgstr "Alguma vez você já quis começar seu próprio país? Bem, agora você pode. Volte para um universo alternativo onde a América ainda não havia sido colonizada e crie vilas, cidades e estados que irão apoiar todos os seus planos. Você vai tentar dominar o mundo ou você irá promover a paz mundial e a prosperidade? Você decide!"
 
-#: content/Default/apps/content.json.h:183
+#: content/Default/apps/content.json.h:195
 msgctxt "title"
 msgid "FrostTorrent"
 msgstr "FrostTorrent"
 
-#: content/Default/apps/content.json.h:184
+#: content/Default/apps/content.json.h:196
 msgctxt "subtitle"
 msgid "Download nearly anything or share your own files"
 msgstr "Gestor de downloads BitTorrent para compartilhamento de arquivos"
 
-#: content/Default/apps/content.json.h:185
+#: content/Default/apps/content.json.h:197
 msgctxt "description"
 msgid ""
 "Access, download and share almost any file you'd like to with this useful "
@@ -1260,17 +1301,17 @@ msgid ""
 "**Requires Internet"
 msgstr "Acesse, baixe e compartilhe quase todo tipo de arquivo que você quiser com este programa que permite que você compartilhe seus arquivos com outros usuários que estão conectados á rede BitTorrent. De música, vídeos e jogos até download de arquivos complexos como programas, você poderá acessar arquivos compartilhados de milhares de usuários. Este programa inclui um programa de vídeos dentro dele para que você possa assistir e ouvir todo tipo de mídias que você baixar. **Necessária conexão à internet."
 
-#: content/Default/apps/content.json.h:186
+#: content/Default/apps/content.json.h:198
 msgctxt "title"
 msgid "Frozen Bubbles"
 msgstr "Bolhinhas"
 
-#: content/Default/apps/content.json.h:187
+#: content/Default/apps/content.json.h:199
 msgctxt "subtitle"
 msgid "Pop bubbles before they all come crashing down"
 msgstr "O jogo de computador mais viciante de todos"
 
-#: content/Default/apps/content.json.h:188
+#: content/Default/apps/content.json.h:200
 msgctxt "description"
 msgid ""
 "Play by yourself or challenge your friends to an exciting game of frozen "
@@ -1279,17 +1320,17 @@ msgid ""
 " have a good strategy and develop a quick trigger finger in order to win!"
 msgstr "Jogue sozinho ou desafie seus amigos em um jogo emocionante de bolhas congeladas! Combine as bolhas coloridas para derrubá-las e tirá-las do caminho antes que fiquem empilhadas até o alto e estourem em você. Você precisa de uma boa estratégia e dedos rápidos para conseguir vencer!"
 
-#: content/Default/apps/content.json.h:189
+#: content/Default/apps/content.json.h:201
 msgctxt "title"
 msgid "EduGames"
 msgstr "Joguinhos"
 
-#: content/Default/apps/content.json.h:190
+#: content/Default/apps/content.json.h:202
 msgctxt "subtitle"
 msgid "Puzzles, memory games, and more for kids"
 msgstr "Atividades para crianças como aprender as horas, quebra-cabeça, jogos de memória e muito mais"
 
-#: content/Default/apps/content.json.h:191
+#: content/Default/apps/content.json.h:203
 msgctxt "description"
 msgid ""
 "This app makes learning fun for young children with more than 100 games and "
@@ -1299,17 +1340,17 @@ msgid ""
 "him or her throughout life."
 msgstr "Com mais de 100 jogos e atividades este programa torna o aprendizado divertido para qualquer crianças! Temas educativos incluem leitura, geografia e matemática, e o programa também possui jogos como xadrez e conecta-quatro, que são ótimos para cérebros jovens. Seu filho terá uma experiência maravilhosa desenvolvendo habilidades valiosas que vão ajudá-lo ao longo da vida."
 
-#: content/Default/apps/content.json.h:192
+#: content/Default/apps/content.json.h:204
 msgctxt "title"
 msgid "EduGames Admin"
 msgstr "EduJogos Admin"
 
-#: content/Default/apps/content.json.h:193
+#: content/Default/apps/content.json.h:205
 msgctxt "subtitle"
 msgid "For teachers to help their students learn"
 msgstr "Para professores ajudarem seus alunos a aprender"
 
-#: content/Default/apps/content.json.h:194
+#: content/Default/apps/content.json.h:206
 msgctxt "description"
 msgid ""
 "Use this app to configure the EduGames app and create the exact learning "
@@ -1320,17 +1361,17 @@ msgid ""
 " fun that they'll want to spend hours doing just what you want them to!"
 msgstr "Use este programa para configurar o programa EduJogos e criar a experiência exata que você gostaria que eles experimentassem. Você pode alterar a lista de atividades, ou mudar os controles do programa para que eles fiquem focados apenas nos jogos que você quer indicar. Para começar, baixe este programa e o programa EduJogos na seção de 'Jogos' da Central de Programas. Eles vão se divertir tanto que vão querer passar horas fazendo apenas o que você determinar que eles façam!"
 
-#: content/Default/apps/content.json.h:195
+#: content/Default/apps/content.json.h:207
 msgctxt "title"
 msgid "Gedit"
 msgstr "Gedit"
 
-#: content/Default/apps/content.json.h:196
+#: content/Default/apps/content.json.h:208
 msgctxt "subtitle"
 msgid "A simple text editor for all of your text editing needs"
 msgstr "Um simples editor de texto para todas as suas necessidades"
 
-#: content/Default/apps/content.json.h:197
+#: content/Default/apps/content.json.h:209
 msgctxt "description"
 msgid ""
 "Use this simple app to create and edit files that require plain text inputs."
@@ -1339,17 +1380,17 @@ msgid ""
 "should be perfect for all of your text editing needs."
 msgstr "Use esse programa bem simples para criar e editar textos sem formatação. Se você é programador, ou está aprendendo a programar, você vai precisar desse programa. Com uma interface fácil de usar, este editor de texto é perfeito para produzir todos os textos que você precisar criar."
 
-#: content/Default/apps/content.json.h:198
+#: content/Default/apps/content.json.h:210
 msgctxt "title"
 msgid "GIMP"
 msgstr "GIMP"
 
-#: content/Default/apps/content.json.h:199
+#: content/Default/apps/content.json.h:211
 msgctxt "subtitle"
 msgid "Advanced image editing tool similar to Photoshop"
 msgstr "Ferramenta de edição e retoque de imagens"
 
-#: content/Default/apps/content.json.h:200
+#: content/Default/apps/content.json.h:212
 msgctxt "description"
 msgid ""
 "Edit your photos to create even more beautiful works of art with this "
@@ -1361,17 +1402,17 @@ msgid ""
 "images once you get the hang of this helpful editing app!"
 msgstr "Esta é a aplicação gratuita semelhante ao Adobe Photoshop. Esta ferramenta permite que você edite fotos de diversas  maneiras, criando fotos ainda mais bonitas que as originais. Este programa também pode fazer coisas como converter formatos de arquivos ou servir como um programa básico de pintura. Existem muitas possibilidades para criar imagens legais uma vez que você souber utilizar esse programa de edição!"
 
-#: content/Default/apps/content.json.h:201
+#: content/Default/apps/content.json.h:213
 msgctxt "title"
 msgid "Calculator"
 msgstr "Calculadora"
 
-#: content/Default/apps/content.json.h:202
+#: content/Default/apps/content.json.h:214
 msgctxt "subtitle"
 msgid "A scientific calculator with many bonus tools"
 msgstr "Calculadora científica com várias ferramentas adicionais"
 
-#: content/Default/apps/content.json.h:203
+#: content/Default/apps/content.json.h:215
 msgctxt "description"
 msgid ""
 "Do you ever consider how often you need to do basic or even complex math in "
@@ -1383,17 +1424,17 @@ msgid ""
 " again as long as you have this calculator app!"
 msgstr "Você já pensou quantas vezes você precisa fazer cálculos matemáticos básicos ou mesmo complexos no seu dia à dia? Entre calcular um orçamento, converter medidas de uma receita, ou descobrir os impostos, você provavelmente usa equações mais regularmente do que você pensa. É por isso que este programa de calculadora é super útil. Faça operações aritméticas simples rapidamente, ou use a calculadora para fazer um trabalho mais avançado, dependendo de suas necessidades. Enquanto você tiver este programa de calculadora você nunca mais vai ter dificuldades para realizar tarefas matemáticas!"
 
-#: content/Default/apps/content.json.h:204
+#: content/Default/apps/content.json.h:216
 msgctxt "title"
 msgid "Math Plotting"
 msgstr "Matemática"
 
-#: content/Default/apps/content.json.h:205
+#: content/Default/apps/content.json.h:217
 msgctxt "subtitle"
 msgid "Interactive computation and data visualization tool"
 msgstr "Ambiente de computação numérica e linguagem de programação"
 
-#: content/Default/apps/content.json.h:206
+#: content/Default/apps/content.json.h:218
 msgctxt "description"
 msgid ""
 "This math application offers advanced mathematical computing functions that "
@@ -1404,17 +1445,17 @@ msgid ""
 "here."
 msgstr "Esta aplicação matemática oferece funções matemáticas avançadas que podem ser utilizadas para bem mais do que apenas cálculos básicos. Se você é um gênio da matemática que gosta de experimentar com esta disciplina emocionante, este é o programa para você. E mesmo se você não for, o programa funciona maravilhosamente como uma calculadora de alto nível. Tudo o que você precisa descobrir sobre mistérios numéricos esta bem aqui."
 
-#: content/Default/apps/content.json.h:207
+#: content/Default/apps/content.json.h:219
 msgctxt "title"
 msgid "Mines"
 msgstr "Campo Minado"
 
-#: content/Default/apps/content.json.h:208
+#: content/Default/apps/content.json.h:220
 msgctxt "subtitle"
 msgid "Find and avoid all the dangerous mines to win"
 msgstr "Descubra onde estão as minas para ser o campeão deste jogo"
 
-#: content/Default/apps/content.json.h:209
+#: content/Default/apps/content.json.h:221
 msgctxt "description"
 msgid ""
 "Figure out where the dangerous mines are in order to stay alive and win the "
@@ -1424,17 +1465,17 @@ msgid ""
 " each direction. If you figure out where all the mines are, you'll win!"
 msgstr "Descubra onde estão as perigosas minas para permanecer vivo e ganhar o jogo! Cada quadrado é uma mina ou um número e você precisa clicar apenas nos números ou vai precisar começar de novo. Cada vez que você clicar em um quadrado irá descobrir o que é, vendo quantas minas tem em volta e em que direção elas estão. Se você descobrir onde cada mina está você ganhará o jogo!"
 
-#: content/Default/apps/content.json.h:210
+#: content/Default/apps/content.json.h:222
 msgctxt "title"
 msgid "Screenshot"
 msgstr "Captura de Tela"
 
-#: content/Default/apps/content.json.h:211
+#: content/Default/apps/content.json.h:223
 msgctxt "subtitle"
 msgid "Take a picture of your screen to save"
 msgstr "Tire uma foto da sua tela para salvar"
 
-#: content/Default/apps/content.json.h:212
+#: content/Default/apps/content.json.h:224
 msgctxt "description"
 msgid ""
 "Do you ever wish you could take a picture of your screen to save? Well now "
@@ -1443,18 +1484,18 @@ msgid ""
 "make sure to save just what you need and nothing more."
 msgstr "Você já teve vontade de tirar uma foto da tela do computador para salvar? Agora você pode, com esse programa de captura de tela fácil de usar. Você pode optar por fotografar a tela inteira ou apenas uma das janelas abertas. Assim você salva somente o que deseja e nada mais.  "
 
-#: content/Default/apps/content.json.h:213
-#: content/Default/apps/content.json.h:297
+#: content/Default/apps/content.json.h:225
+#: content/Default/apps/content.json.h:306
 msgctxt "title"
 msgid "Sudoku"
 msgstr "Sudoku"
 
-#: content/Default/apps/content.json.h:214
+#: content/Default/apps/content.json.h:226
 msgctxt "subtitle"
 msgid "One of the most popular puzzle games of all time"
 msgstr "Joga num dos quebra-cabeças mais populares de sempre"
 
-#: content/Default/apps/content.json.h:215
+#: content/Default/apps/content.json.h:227
 msgctxt "description"
 msgid ""
 "If you’re a fan of puzzles and math games, the Sudoku app is perfect for "
@@ -1465,17 +1506,17 @@ msgid ""
 "fun solving Sudoku puzzles and exercising your mind!"
 msgstr "Se você é um fã de quebra-cabeças e jogos de matemática, o programa Sudoku é perfeito para você. Estes divertidos quebra-cabeças exigem que você insira números em uma grade para que você tenha linhas, colunas e regiões de grade exclusivas,  contendo todos os números de 1 a 9. Pode parecer complicado no começo, mas com este programa, você vai aprender a jogar e pode pegar o jeito do jogo muito rápido. Em breve você terá horas de diversão ao resolver enigmas do Sudoku e exercitar sua mente!"
 
-#: content/Default/apps/content.json.h:216
+#: content/Default/apps/content.json.h:228
 msgctxt "title"
 msgid "Terminal"
 msgstr "Terminal"
 
-#: content/Default/apps/content.json.h:217
+#: content/Default/apps/content.json.h:229
 msgctxt "subtitle"
 msgid "Use the command line"
 msgstr "Use a linha de comando"
 
-#: content/Default/apps/content.json.h:218
+#: content/Default/apps/content.json.h:230
 msgctxt "description"
 msgid ""
 "If you're an advanced user and want to display system information and launch"
@@ -1485,17 +1526,17 @@ msgid ""
 "in correctly and to help you easily identify any mistakes you have made."
 msgstr "Se você é um usuário avançado e deseja exibir informações do sistema e iniciar programas sem usar o mouse, agora você pode fazer isso com este programa de terminal básico. Com este terminal moderno, você pode ver todos os seus comandos escritos em cores diferentes para ajudar a certificar-se de que você está digitando-los corretamente e ajudá-lo a identificar facilmente os erros que você fez."
 
-#: content/Default/apps/content.json.h:219
+#: content/Default/apps/content.json.h:231
 msgctxt "title"
 msgid "Tetravex"
 msgstr "Tetravex"
 
-#: content/Default/apps/content.json.h:220
+#: content/Default/apps/content.json.h:232
 msgctxt "subtitle"
 msgid "Race the clock in a numerical puzzle game"
 msgstr "Combine os números nesse jogo cronometrado estilo Sudoku"
 
-#: content/Default/apps/content.json.h:221
+#: content/Default/apps/content.json.h:233
 msgctxt "description"
 msgid ""
 "Try to match up all of the same numbers on the blocks to win this tricky "
@@ -1504,17 +1545,17 @@ msgid ""
 "beat your or your friends' best time!"
 msgstr "Tente combinar os números iguais dentro dos blocos para ganhar esse jogo desafiador. Você vai precisar pensar com cuidado e agilidade para terminar esse jogo. Você será cronometrado, então seja rápido para superar o seu tempo ou o do seus amigos."
 
-#: content/Default/apps/content.json.h:222
+#: content/Default/apps/content.json.h:234
 msgctxt "title"
 msgid "Notes"
 msgstr "Anotações"
 
-#: content/Default/apps/content.json.h:223
+#: content/Default/apps/content.json.h:235
 msgctxt "subtitle"
 msgid "Never lose a note again"
 msgstr "Faça suas anotações e as encontre facilmente na sua área de trabalho"
 
-#: content/Default/apps/content.json.h:224
+#: content/Default/apps/content.json.h:236
 msgctxt "description"
 msgid ""
 "Do you find yourself writing down lots of notes on pieces of paper that "
@@ -1525,17 +1566,17 @@ msgid ""
 "notes and stay even more organized!"
 msgstr "Você costuma fazer anotações em vários pedaços de papel que depois se perdem ou rasgam? Ou, você tem tantas anotações em cima da sua mesa que você já está ficando sem espaço? Não importa que tipo de anotações você precisa fazer, este programa de anotações pode te ajudar a manter todas elas em um só lugar. Ele também tem a capacidade de juntar as anotações que combinam para que você possa acessar facilmente todos os assuntos por categoria e ficar ainda mais organizado!"
 
-#: content/Default/apps/content.json.h:225
+#: content/Default/apps/content.json.h:237
 msgctxt "title"
 msgid "Dictionary"
 msgstr "Dicionário"
 
-#: content/Default/apps/content.json.h:226
+#: content/Default/apps/content.json.h:238
 msgctxt "subtitle"
 msgid "A cool dictionary with lots of bonus tools"
 msgstr "Software para pesquisa de termos em dicionários, com muitas ferramentas adicionais"
 
-#: content/Default/apps/content.json.h:227
+#: content/Default/apps/content.json.h:239
 msgctxt "description"
 msgid ""
 "In reading and conversation, words often come up with which you’re not "
@@ -1545,12 +1586,12 @@ msgid ""
 "word you’re looking for!"
 msgstr "Em leitura e conversação, agumas vezes aparecem palavras com as quais você não está familiarizado. Ao invés de fingir que você sabe o que elas querem dizer, é melhor ter um programa de dicionário onde você possa aprender um novo vocabulário e compreender o que lê e ouve. Este programa de dicionário é fácil de usar e navegar, então você nunca terá dificuldade em encontrar a palavra que você está procurando."
 
-#: content/Default/apps/content.json.h:228
+#: content/Default/apps/content.json.h:240
 msgctxt "title"
 msgid "GT Curriculum"
 msgstr "Currículo Escolar"
 
-#: content/Default/apps/content.json.h:230
+#: content/Default/apps/content.json.h:242
 msgctxt "description"
 msgid ""
 "Use this app to find the basic curriculum plan and guidelines for a specific"
@@ -1562,17 +1603,17 @@ msgid ""
 "difference both your child's life and your own."
 msgstr "Programa somente disponível em língua espanhola."
 
-#: content/Default/apps/content.json.h:231
+#: content/Default/apps/content.json.h:243
 msgctxt "title"
 msgid "EduCollections"
 msgstr "EduColeções"
 
-#: content/Default/apps/content.json.h:232
+#: content/Default/apps/content.json.h:244
 msgctxt "subtitle"
 msgid "All sorts of information to help better your life"
 msgstr "Informações de todo tipo para ajudar a melhorar a sua vida"
 
-#: content/Default/apps/content.json.h:233
+#: content/Default/apps/content.json.h:245
 msgctxt "description"
 msgid ""
 "This app is full of reliable information sent directly from the Guatemalan "
@@ -1585,17 +1626,17 @@ msgid ""
 "your age."
 msgstr "Programas somente disponíveis em língua espanhola."
 
-#: content/Default/apps/content.json.h:234
+#: content/Default/apps/content.json.h:246
 msgctxt "title"
 msgid "Health Guides"
 msgstr "Guias de Saúde"
 
-#: content/Default/apps/content.json.h:235
+#: content/Default/apps/content.json.h:247
 msgctxt "subtitle"
 msgid "Health guides that could save your life"
 msgstr "Guias de saúde que podem salvar sua vida"
 
-#: content/Default/apps/content.json.h:236
+#: content/Default/apps/content.json.h:248
 msgctxt "description"
 msgid ""
 "This app contains some of the most life saving documents that you'll ever "
@@ -1604,38 +1645,17 @@ msgid ""
 " learn to help your loved ones, those in your community and even yourself!"
 msgstr "Esse programa contém alguns dos mais importantes documentos vitais que você poderá ler sempre. Abra a pasta Documentos Hesperian Saúde e aprenda mais sobre como realizar exames e pequenos procedimentos. Você vai se surpreender com o quanto você pode aprender e ajudar seus ente queridos, pessoas da sua comunidade e até a você mesmo! "
 
-#: content/Default/apps/content.json.h:237
-msgctxt "title"
-msgid "Textbooks"
-msgstr "Livros Didáticos"
-
-#: content/Default/apps/content.json.h:238
-msgctxt "subtitle"
-msgid "Textbooks for students, parents and teachers"
-msgstr "Livros didáticos para alunos, pais e professores"
-
-#: content/Default/apps/content.json.h:239
-msgctxt "description"
-msgid ""
-"Select a grade level and prepare yourself to learn directly from your "
-"computer! This app contains textbooks, worksheets and other learning tools, "
-"to teach or supplement your learning. Whether you're a student needing extra"
-" homework help, a parent helping to develop a child's education, or someone "
-"seeking to learn more in their spare time, you'll find this app to be "
-"incredibly useful."
-msgstr "Selecione um nível de ensino e prepare-se para aprender diretamente de seu computador! Este programa contém livros, planilhas e outros recursos para te ensinar ou complementar seu aprendizado.  Se você é um estudante que precisa de ajuda na lição de casa, um pai ajudando a desenvolver a educação de uma criança ou alguém buscando aprender mais em seu tempo livre, este programa será extremamente útil. "
-
-#: content/Default/apps/content.json.h:240
+#: content/Default/apps/content.json.h:249
 msgctxt "title"
 msgid "Iagno"
 msgstr "Iagno"
 
-#: content/Default/apps/content.json.h:241
+#: content/Default/apps/content.json.h:250
 msgctxt "subtitle"
 msgid "A fun puzzle game that involves lots of thought"
 msgstr "Tente virar todas as peças para a sua cor nesse jogo de quebrar a cabeça"
 
-#: content/Default/apps/content.json.h:242
+#: content/Default/apps/content.json.h:251
 msgctxt "description"
 msgid ""
 "Turn over the pieces in front of you so that they are all the same color. "
@@ -1646,17 +1666,17 @@ msgid ""
 "strategically and see if you can figure this puzzle out!"
 msgstr "Vire as peças que estão na sua frente de forma que todas fiquem com a mesma cor. Simples? Nem um pouco! Você pode mudar as peças para a sua cor se você conseguir organizar suas peças de forma que elas criem uma linha, coluna ou diagonal através das peças de outras cores. Então, você precisa virar as peças com cuidado para tentar fazer com que todas fiquem da sua cor. Pense estrategicamente e veja se consegue desvendar esse quebra-cabeça!"
 
-#: content/Default/apps/content.json.h:243
+#: content/Default/apps/content.json.h:252
 msgctxt "title"
 msgid "Inkscape"
 msgstr "Inkscape"
 
-#: content/Default/apps/content.json.h:244
+#: content/Default/apps/content.json.h:253
 msgctxt "subtitle"
 msgid "An advanced graphic design tool"
 msgstr "Edição de gráficos vetorizados com transparências, gradientes, edição de nódulos, padrões de preenchimento, PNG e muito mais"
 
-#: content/Default/apps/content.json.h:245
+#: content/Default/apps/content.json.h:254
 msgctxt "description"
 msgid ""
 "This app is for intermediate and advanced graphic designers who need to "
@@ -1667,17 +1687,17 @@ msgid ""
 "presentations and artwork with this great free graphics app!"
 msgstr "Este programa é para designers gráficos intermediários e avançados que precisam criar e editar gráficos e imagens. Este programa oferece recursos avançados e é comparável ao InDesign da Adobe. Por exemplo, você pode criar SVGs (Scalable Vector Graphics), que permite que os gráficos permaneçam com alta qualidade independente do tamanho. Crie belos anúncios, brochuras, apresentações e trabalhos de arte com este ótimo programa de gráficos gratuito!"
 
-#: content/Default/apps/content.json.h:246
+#: content/Default/apps/content.json.h:255
 msgctxt "title"
 msgid "Kalzium"
 msgstr "Kalzium"
 
-#: content/Default/apps/content.json.h:247
+#: content/Default/apps/content.json.h:256
 msgctxt "subtitle"
 msgid "A fun interactive periodic table of elements"
 msgstr "Uma divertida tabela periódica interativa"
 
-#: content/Default/apps/content.json.h:248
+#: content/Default/apps/content.json.h:257
 msgctxt "description"
 msgid ""
 "The periodic table of the elements is one of the basic building blocks of "
@@ -1690,17 +1710,17 @@ msgid ""
 "simple, and informative app."
 msgstr "A tabela periódica dos elementos é um dos blocos básicos de construção da ciência, e agora você pode tê-la ao seu alcance.  Este programa possui um código de cores que torna o aprendizado de cada elemento mais fácil e divertido. Selecione elementos para aprender informações básicas sobre eles, como seus pontos de fusão, massa e muito mais. Informações mais complexas, como a visualização das linhas espectrais dos elementos, tornam este programa perfeito para a descoberta científica. Você não vai acreditar o quanto você pode aprender com este programa bonito, simples e informativo. "
 
-#: content/Default/apps/content.json.h:249
+#: content/Default/apps/content.json.h:258
 msgctxt "title"
 msgid "Kapman"
 msgstr "Kapman"
 
-#: content/Default/apps/content.json.h:250
+#: content/Default/apps/content.json.h:259
 msgctxt "subtitle"
 msgid "The classic game of ghosts and mazes"
 msgstr "O clássico jogo de fantasmas e labirintos"
 
-#: content/Default/apps/content.json.h:251
+#: content/Default/apps/content.json.h:260
 msgctxt "description"
 msgid ""
 "If you love Pac-Man, then you you'll love this game too! Eat dots to gain "
@@ -1710,17 +1730,17 @@ msgid ""
 "and family, from kids to grandparents, will love the game, too!"
 msgstr "Se você gosta de Pac-Man, vai adorar esse jogo também! Coma os pontinhos para ganhar pontos, mas fuja dos fantasmas, se não você perde. À medida em que você vai ganhando habilidades e subindo de nível, a velocidade do jogo aumenta e o desafio fica cada vez mais emocionante. Você não vai querer parar de jogar e seus amigos e família, das crianças ao avô, vão adorar o jogo também! "
 
-#: content/Default/apps/content.json.h:252
+#: content/Default/apps/content.json.h:261
 msgctxt "title"
 msgid "KAtomic"
 msgstr "KAtomic"
 
-#: content/Default/apps/content.json.h:253
+#: content/Default/apps/content.json.h:262
 msgctxt "subtitle"
 msgid "A fun way to learn chemistry"
 msgstr "Um jeito divertido de aprender química"
 
-#: content/Default/apps/content.json.h:254
+#: content/Default/apps/content.json.h:263
 msgctxt "description"
 msgid ""
 "If you’re struggling with concepts in chemistry, or simply looking for a way"
@@ -1732,17 +1752,17 @@ msgid ""
 " a ton!"
 msgstr "Se você está lutando com os conceitos de química ou simplesmente está procurando uma maneira de reforçar sua compreensão, você encontrou o programa certo para te ajudar! Este jogo é um desafio de criar moléculas - a maneira perfeita para aprender enquanto se diverte! A tela irá mostrar a aparência da molécula, e você pode mover os átomos ao redor para montar a molécula correta.  Este jogo requer estratégia e raciocínio rápido e vai te ensinar uma tonelada!"
 
-#: content/Default/apps/content.json.h:255
+#: content/Default/apps/content.json.h:264
 msgctxt "title"
 msgid "KBlackBox"
 msgstr "KBlackBox"
 
-#: content/Default/apps/content.json.h:256
+#: content/Default/apps/content.json.h:265
 msgctxt "subtitle"
 msgid "Find the pattern and uncover the hidden balls"
 msgstr "Encontre o padrão e descubra as bolas escondidas"
 
-#: content/Default/apps/content.json.h:257
+#: content/Default/apps/content.json.h:266
 msgctxt "description"
 msgid ""
 "This game takes some serious logic, but don’t be scared away – it’s also "
@@ -1752,17 +1772,17 @@ msgid ""
 "hidden ones are placed. The more you get right, the higher your score."
 msgstr "Esse jogo tem uma lógica difícil, mas não se assuste - é também muito divertido. Você pode usar o raio laser para revelar a localização das bolas. Ao achar que descobriu o padrão, arraste e solte onde você suspeita que elas estão. Quanto mais você acertar, maior a pontuação. "
 
-#: content/Default/apps/content.json.h:258
+#: content/Default/apps/content.json.h:267
 msgctxt "title"
 msgid "KBruch"
 msgstr "KBruch"
 
-#: content/Default/apps/content.json.h:259
+#: content/Default/apps/content.json.h:268
 msgctxt "subtitle"
 msgid "Learn about fractions, percentages and more"
 msgstr "Saiba mais sobre frações, porcentagens e muito mais"
 
-#: content/Default/apps/content.json.h:260
+#: content/Default/apps/content.json.h:269
 msgctxt "description"
 msgid ""
 "One of the trickiest parts of the math we do every day is calculating "
@@ -1774,17 +1794,17 @@ msgid ""
 "benefit you in unexpected ways!"
 msgstr "Uma das partes mais difíceis da matemática do dia a dia está no cálculo de frações e porcentagens, mas agora você não precisará mais tentar adivinhar suas contas de novo. Este programa possui jogos e exercícios para aprimorar suas habilidades, incluindo aritmética, comparação, conversão e fatoração. Saiba tudo sobre frações e porcentagens, e pratique o quanto quiser. Encontramos esse tipo de matemática quase todos os dias, então suas novas habilidades vão lhe beneficiar de formas inesperadas!"
 
-#: content/Default/apps/content.json.h:261
+#: content/Default/apps/content.json.h:270
 msgctxt "title"
 msgid "KSnake"
 msgstr "Cobrinha"
 
-#: content/Default/apps/content.json.h:262
+#: content/Default/apps/content.json.h:271
 msgctxt "subtitle"
 msgid "A fun and very simple game for everyone"
 msgstr "Um jogo divertido e muito simples para todo mundo"
 
-#: content/Default/apps/content.json.h:263
+#: content/Default/apps/content.json.h:272
 msgctxt "description"
 msgid ""
 "Similar to the popular arcade game, Snake, this classic game will help you "
@@ -1793,17 +1813,17 @@ msgid ""
 "snakes grow longer, promising a fun challenge to players of all levels."
 msgstr "Cobrinha é um jogo clássico que vai ajudá-lo a afastar o tédio por horas! Enquanto come, a cobrinha vai crescendo, mas se bater em outra,  o jogo está perdido. O jogo fica mais difícil à medida que as cobrinhas ficam mais longas, prometendo um desafio divertido para os jogadores de todos os níveis."
 
-#: content/Default/apps/content.json.h:264
+#: content/Default/apps/content.json.h:273
 msgctxt "title"
 msgid "KGeography"
 msgstr "KGeografia"
 
-#: content/Default/apps/content.json.h:265
+#: content/Default/apps/content.json.h:274
 msgctxt "subtitle"
 msgid "Become a geography genius while having fun"
 msgstr "Transforme-se em um gênio da geografia enquanto se diverte "
 
-#: content/Default/apps/content.json.h:266
+#: content/Default/apps/content.json.h:275
 msgctxt "description"
 msgid ""
 "How much do you know about world geography and political affairs? Learn the "
@@ -1814,17 +1834,17 @@ msgid ""
 "and will have had a lot of fun learning it all!"
 msgstr "O que você sabe sobre a geografia mundial e assuntos políticos? Aprenda através de um jogo envolvente. Primeiro, confira o mapa e saiba mais sobre os nomes, capitais e bandeiras. Depois disso, é hora de testar seus conhecimentos! Adivinhe capitais e bandeiras ou tente colocar as fronteiras nacionais em um mapa vazio. Antes que você perceba, você vai saber sobre todos os cantos do mundo e vai ter se divertido enquanto aprendia tudo isso! "
 
-#: content/Default/apps/content.json.h:267
+#: content/Default/apps/content.json.h:276
 msgctxt "title"
 msgid "KGoldrunner"
 msgstr "Corrida Dourada"
 
-#: content/Default/apps/content.json.h:268
+#: content/Default/apps/content.json.h:277
 msgctxt "subtitle"
 msgid "Look for treasure and hide from enemies"
 msgstr "Procure pelo tesouro e se esconda dos inimigos "
 
-#: content/Default/apps/content.json.h:269
+#: content/Default/apps/content.json.h:278
 msgctxt "description"
 msgid ""
 "Your enemies are right on your heels as you move through mazes collecting "
@@ -1834,17 +1854,17 @@ msgid ""
 " through any trapdoors!"
 msgstr "Seus inimigos estão na sua cola enquanto você se move pelo labirinto, recolhendo ouro. Com quebra cabeças desafiadores e um objetivo emocionante, esse jogo com certeza será um de seus favoritos. Você vai encontrar vários níveis, com labirintos novos em todos eles. Só não caia nas armadilhas!  "
 
-#: content/Default/apps/content.json.h:270
+#: content/Default/apps/content.json.h:279
 msgctxt "title"
 msgid "KHangMan"
 msgstr "Forca"
 
-#: content/Default/apps/content.json.h:271
+#: content/Default/apps/content.json.h:280
 msgctxt "subtitle"
 msgid "One of the most fun word games on earth"
 msgstr "Um dos jogos de palavra mais divertidos do planeta"
 
-#: content/Default/apps/content.json.h:272
+#: content/Default/apps/content.json.h:281
 msgctxt "description"
 msgid ""
 "Practice your vocabulary the fun way! You'll learn new words with this "
@@ -1856,17 +1876,17 @@ msgid ""
 "have to start over with a new word!"
 msgstr "Treine seu vocabulário de forma divertida! Você vai aprender novas palavras com este jogo e isso é algo que toda a família pode jogar junto. Como se joga? Bem, o computador irá escolher uma palavra e os jogadores vão tentar descobrir, adivinhando letra por letra, até conseguir adivinhar a palavra inteira. Enquanto os jogadores adivinham corretamente, mais palavras vão sendo mostradas. Mas se você faz muitas suposições erradas, perde o jogo e começa de novo com uma nova palavra!"
 
-#: content/Default/apps/content.json.h:273
+#: content/Default/apps/content.json.h:282
 msgctxt "title"
 msgid "Kigo"
 msgstr "Kigo "
 
-#: content/Default/apps/content.json.h:274
+#: content/Default/apps/content.json.h:283
 msgctxt "subtitle"
 msgid "The ancient game of skill, updated for modern play"
 msgstr "O antigo jogo de habilidade, atualizado para um jogo moderno"
 
-#: content/Default/apps/content.json.h:275
+#: content/Default/apps/content.json.h:284
 msgctxt "description"
 msgid ""
 "Based on a two-player board game popular in Asia, this app has easy-to-learn"
@@ -1878,17 +1898,17 @@ msgid ""
 "too!"
 msgstr "Esse jogo é baseado em um jogo de tabuleiro para dois jogadores muito popular na Ásia. Este programa tem regras fáceis de aprender mas requer uma grande dose de estratégia. É a maneira perfeita para passar o tempo enquanto exercita sua mente. O objetivo é simples: mover suas peças pretas ou brancas no grid (o tamanho da grade depende do nível de dificuldade que você escolher), e tentar cercar as peças do adversário. Se você gosta de jogos como xadrez, então você vai adorar este grande jogo de estratégia também!"
 
-#: content/Default/apps/content.json.h:276
+#: content/Default/apps/content.json.h:285
 msgctxt "title"
 msgid "Killbots"
 msgstr "Killbots"
 
-#: content/Default/apps/content.json.h:277
+#: content/Default/apps/content.json.h:286
 msgctxt "subtitle"
 msgid "Outsmart the killer robots to win"
 msgstr "Seja mais esperto que os robôs assassinos e ganhe o jogo "
 
-#: content/Default/apps/content.json.h:278
+#: content/Default/apps/content.json.h:287
 msgctxt "description"
 msgid ""
 "How will you get away from the killer robots bent on destruction? Figure it "
@@ -1898,17 +1918,17 @@ msgid ""
 "tell the tale!"
 msgstr "Como você vai fugir dos robôs assassinos determinados a destruir coisas? Descubra isso nesse jogo simples e divertido. Você pode ficar em desvantagem pelo grande fluxo de robôs, mas com sua inteligência e um aparelho de teletransporte você pode derrotá-los. Seja mais esperto que todos os robôs assassinos para ganhar e contar essa história. "
 
-#: content/Default/apps/content.json.h:279
+#: content/Default/apps/content.json.h:288
 msgctxt "title"
 msgid "Kolor Lines"
 msgstr "Linhas Coloridas"
 
-#: content/Default/apps/content.json.h:280
+#: content/Default/apps/content.json.h:289
 msgctxt "subtitle"
 msgid "Line up balls of the same color to win"
 msgstr "Alinhe as bolas da mesma cor para ganhar"
 
-#: content/Default/apps/content.json.h:281
+#: content/Default/apps/content.json.h:290
 msgctxt "description"
 msgid ""
 "This game is so fun and addicting, you’ll never want to stop playing. The "
@@ -1919,17 +1939,17 @@ msgid ""
 "possible; you lose if it fills up completely!"
 msgstr "Esse jogo é muito divertido e viciante. Você nunca mais vai querer parar de jogar. O objetivo é simples: forme linhas usando cinco bolas da mesma cor. Isso irá removê-las do tabuleiro. Mas não é tão fácil assim, pois a cada movimento chegam mais bolas. Seu trabalho é fazer o tabuleiro ficar o mais livre possível. Se o tabuleiro ficar completamente cheio, você perde o jogo. "
 
-#: content/Default/apps/content.json.h:282
+#: content/Default/apps/content.json.h:291
 msgctxt "title"
 msgid "KMines"
 msgstr "Campo Minado"
 
-#: content/Default/apps/content.json.h:283
+#: content/Default/apps/content.json.h:292
 msgctxt "subtitle"
 msgid "Stay away from the exploding mines"
 msgstr "Fique longe das minas explosivas"
 
-#: content/Default/apps/content.json.h:284
+#: content/Default/apps/content.json.h:293
 msgctxt "description"
 msgid ""
 "Don't take a wrong step or you'll explode! You'll need to use logic and "
@@ -1937,17 +1957,17 @@ msgid ""
 "safely across the field."
 msgstr "Não dê nenhum passo errado ou você explodirá! Você vai precisar usar a lógica e a inteligência neste jogo para dar a volta em todas as minas, fazendo o seu caminho pelo campo com segurança. "
 
-#: content/Default/apps/content.json.h:285
+#: content/Default/apps/content.json.h:294
 msgctxt "title"
 msgid "Battleships"
 msgstr "Batalha Naval"
 
-#: content/Default/apps/content.json.h:286
+#: content/Default/apps/content.json.h:295
 msgctxt "subtitle"
 msgid "Blow your opponents out of the water"
 msgstr "Exploda os navios oponentes"
 
-#: content/Default/apps/content.json.h:287
+#: content/Default/apps/content.json.h:296
 msgctxt "description"
 msgid ""
 "Try to guess where your enemies ships are to blow them out of the water "
@@ -1958,17 +1978,17 @@ msgid ""
 "Arrr you ready for some great naval fun?"
 msgstr "Tente adivinhar onde estão os navios inimigos para explodi-los antes que eles te peguem! Este é um divertido jogo de estratégia que requer duas pessoas. Você pode jogar contra um amigo, contra outra pessoa na internet ou contra o computador. Vocês se revezam tentando adivinhar onde estão os navios uns dos outros e o primeiro jogador que afundar todos os navios oponentes vence o jogo. Você está pronto para uma grande diversão naval? "
 
-#: content/Default/apps/content.json.h:288
+#: content/Default/apps/content.json.h:297
 msgctxt "title"
 msgid "KNetwalk"
 msgstr "KNetwalk"
 
-#: content/Default/apps/content.json.h:289
+#: content/Default/apps/content.json.h:298
 msgctxt "subtitle"
 msgid "Make the right cable connections and win"
 msgstr "Conecte os cabos corretamente e vença "
 
-#: content/Default/apps/content.json.h:290
+#: content/Default/apps/content.json.h:299
 msgctxt "description"
 msgid ""
 "Who knew building computer networks could be fun? You'll need to create the "
@@ -1979,17 +1999,17 @@ msgid ""
 "enjoyable and competitive game you’ll love to play."
 msgstr "Quem diria que a construção de redes de computadores pode ser divertida? Você vai precisar criar conexões com a menor quantidade de voltas possível, então esteja pronto para mover os cabos e descobrir o enigma rapidamente. Se conseguir, você encontrará uma lista de pontuações altas, permitindo-lhe encontrar concorrentes. Este programa te ajuda a entender como funcionam as redes de computadores mas, o mais importante, é um jogo agradável e competitivo que você vai adorar. "
 
-#: content/Default/apps/content.json.h:291
+#: content/Default/apps/content.json.h:300
 msgctxt "title"
 msgid "Kobo Deluxe"
 msgstr "Kobo Deluxe"
 
-#: content/Default/apps/content.json.h:292
+#: content/Default/apps/content.json.h:301
 msgctxt "subtitle"
 msgid "Destroy enemy bases in space"
 msgstr "Destrua as bases inimigas no espaço"
 
-#: content/Default/apps/content.json.h:293
+#: content/Default/apps/content.json.h:302
 msgctxt "description"
 msgid ""
 "Fans of arcade-style games will love this fun shooting game. Protect "
@@ -1998,17 +2018,17 @@ msgid ""
 "to play. You'll have hours and hours of fun blowing up things in space!"
 msgstr "Os fãs de jogos estilo arcade vão adorar o programa Kobo Deluxe. Este jogo de naves permite que você se proteja e destrua naves inimigas enquanto elas te perseguem, atirando e lançando-se em você. Tudo isso acontece no espaço, com gráficos divertidos e desafios táticos estimulantes. Mova-se através dos 50 níveis e saia um campeão."
 
-#: content/Default/apps/content.json.h:294
+#: content/Default/apps/content.json.h:303
 msgctxt "title"
 msgid "KSquares"
 msgstr "Ponto a Ponto"
 
-#: content/Default/apps/content.json.h:295
+#: content/Default/apps/content.json.h:304
 msgctxt "subtitle"
 msgid "Connect the dots in this challenging strategy game"
 msgstr "Ligue os pontos neste jogo de estratégia desafiador"
 
-#: content/Default/apps/content.json.h:296
+#: content/Default/apps/content.json.h:305
 msgctxt "description"
 msgid ""
 "Based on a popular old game, this fun app lets you stretch your mind and "
@@ -2019,12 +2039,12 @@ msgid ""
 "entertainment. Be careful – you just might become addicted!"
 msgstr "Baseado em um jogo popular antigo, esse programa divertido permite que você estique sua mente e resolva quebra-cabeças. O objetivo é completar a maior quantidade de quadrados na grade do seu oponente. Revezando-se, desenhem linhas entre os pontos e tente bloquear os quadrados do seu oponente, ao mesmo tempo que forma seus quadrados. Este jogo requer pensamento geométrico, bem como uma boa estratégia, e com certeza proporcionará várias horas de entretenimento. Tenha cuidado - você pode se viciar!"
 
-#: content/Default/apps/content.json.h:298
+#: content/Default/apps/content.json.h:307
 msgctxt "subtitle"
 msgid "A challenging numerical puzzle game"
 msgstr "Um desafiador quebra-cabeça numérico"
 
-#: content/Default/apps/content.json.h:299
+#: content/Default/apps/content.json.h:308
 msgctxt "description"
 msgid ""
 "Are you better than your friend is at puzzles? Find out by playing this fun "
@@ -2036,17 +2056,17 @@ msgid ""
 "Sudoku, or are an experienced player, you'll love this app!"
 msgstr "Você é melhor que seus amigos jogando Sudoku? Descubra isso agora! Você pode jogar sozinho, com a ajuda de outras pessoas ou desafiar os amigos e familiares para ver quem consegue resolver o desafio primeiro. Este programa contém características especiais, como criar jogos para você imprimir. Ele também pode te ajudar a aprender a jogar para depois você possa tentar sozinho. Mesmo que você ainda seja iniciante, vai adorar jogar Sudoku."
 
-#: content/Default/apps/content.json.h:300
+#: content/Default/apps/content.json.h:309
 msgctxt "title"
 msgid "KSnakeDuel"
 msgstr "Cobrinha"
 
-#: content/Default/apps/content.json.h:301
+#: content/Default/apps/content.json.h:310
 msgctxt "subtitle"
 msgid "Survival depends on your reflexes and wits"
 msgstr "Sobreviver depende de seus reflexos e inteligência"
 
-#: content/Default/apps/content.json.h:302
+#: content/Default/apps/content.json.h:311
 msgctxt "description"
 msgid ""
 "Guide your snake to eat the apples and to avoid the other snakes, balls and "
@@ -2057,17 +2077,17 @@ msgid ""
 "fun challenge!"
 msgstr "Guie a cobra para comer as maças e fugir de outras cobras, paredes e bolas! Alguns destes obstáculos apenas o tornam mais lento, mas outros matam, então é melhor ficar longe de todos eles. Se você conseguir comer todas as maçãs, saia do labirinto e avance para o próximo nível. Este jogo pode parecer fácil, mas não é, por isso prepare-se para um desafio divertido! "
 
-#: content/Default/apps/content.json.h:303
+#: content/Default/apps/content.json.h:312
 msgctxt "title"
 msgid "Potato Guy"
 msgstr "Sr. Batata"
 
-#: content/Default/apps/content.json.h:304
+#: content/Default/apps/content.json.h:313
 msgctxt "subtitle"
 msgid "Give your potato a funny face"
 msgstr "Dê uma cara engraçada ao Sr. Batata"
 
-#: content/Default/apps/content.json.h:305
+#: content/Default/apps/content.json.h:314
 msgctxt "description"
 msgid ""
 "This is a silly game for children and their parents to play together. Based "
@@ -2077,17 +2097,17 @@ msgid ""
 "lots of laughter. Make the goofiest face you can!"
 msgstr "Esse é um joguinho para crianças e adultos jogarem juntos. Baseado no Sr. Cabeça de Batata, esse jogo permite que você altere as características do rosto da batata, fazendo caretas, usando bigodes, orelhões, etc. O objetivo é montar o rosto mais engraçado e garantir boas risadas.  "
 
-#: content/Default/apps/content.json.h:306
+#: content/Default/apps/content.json.h:315
 msgctxt "title"
 msgid "Kubrick"
 msgstr "Kubrick"
 
-#: content/Default/apps/content.json.h:307
+#: content/Default/apps/content.json.h:316
 msgctxt "subtitle"
 msgid "Like Rubik's Cube - create solid color sides to win"
 msgstr "Como em um Cubo Mágico - crie lados de uma única cor e vença o jogo "
 
-#: content/Default/apps/content.json.h:308
+#: content/Default/apps/content.json.h:317
 msgctxt "description"
 msgid ""
 "This puzzling game has lots of options to keep your brain working! Modeled "
@@ -2099,17 +2119,17 @@ msgid ""
 "even design your very own challenge!"
 msgstr "Esse jogo tem muitas maneiras de manter seu cérebro trabalhando! Baseado no tradicional Cubo Mágico, este é um jogo 3D, onde você precisa transformar pequenas peças em um grande cubo. Mas, atenção: todas as peças de cada lateral do cubo precisam ser da mesma cor. Objetos menores, maiores e de diferentes formatos oferecem os seus próprios desafios especiais. O jogo também inclui demonstrações de movimentos legais de solução para que você possa seguir e aprender junto com os especialistas. Você pode até mesmo criar o seu próprio desafio!"
 
-#: content/Default/apps/content.json.h:309
+#: content/Default/apps/content.json.h:318
 msgctxt "title"
 msgid "KWordQuiz"
 msgstr "Mais Palavras"
 
-#: content/Default/apps/content.json.h:310
+#: content/Default/apps/content.json.h:319
 msgctxt "subtitle"
 msgid "Grow your vocabulary and test your learning"
 msgstr "Aumente seu vocabulário e teste seu aprendizado"
 
-#: content/Default/apps/content.json.h:311
+#: content/Default/apps/content.json.h:320
 msgctxt "description"
 msgid ""
 "Learning new words is a great way to speak and write more clearly, but "
@@ -2120,17 +2140,17 @@ msgid ""
 "learning all you want."
 msgstr "Aprender novas palavras é uma ótima maneira de falar e escrever de forma mais clara, mas às vezes pode ser difícil de fazer. Usar flashcards pode ser uma grande ajuda, se você está estudando uma língua estrangeira ou mesmo tentando memorizar novas palavras. Este programa torna a memorização fácil e divertida com flashcards interativos e questionários rápidos que te ajudarão a testar seus conhecimentos e continuar aprendendo tudo o que quiser."
 
-#: content/Default/apps/content.json.h:312
+#: content/Default/apps/content.json.h:321
 msgctxt "title"
 msgid "Breakout"
 msgstr "Breakout"
 
-#: content/Default/apps/content.json.h:313
+#: content/Default/apps/content.json.h:322
 msgctxt "subtitle"
 msgid "Destroy all the bricks to win this fun game"
 msgstr "O clássico jogo Arcade repleto de novas funcionalidades"
 
-#: content/Default/apps/content.json.h:314
+#: content/Default/apps/content.json.h:323
 msgctxt "description"
 msgid ""
 "This classic paddle game is tons of fun! The aim is to destroy bricks with "
@@ -2140,17 +2160,17 @@ msgid ""
 " graphics and animation, intuitive controls, and plenty of levels to beat."
 msgstr "Este jogo clássico é pura diversão! O objetivo é destruir os tijolos rebatendo a bola com a sua raquete, o que lhe permite subir de nível. O jogo Breakout original foi lançado em 1976 e desde então as pessoas amaram este jogo simples e viciante. Conserte os seus tijolos quebrados com ótimos gráficos e animações, controles intuitivos e muitos  níveis para serem batidos."
 
-#: content/Default/apps/content.json.h:315
+#: content/Default/apps/content.json.h:324
 msgctxt "title"
 msgid "Spreadsheet"
 msgstr "Planilha"
 
-#: content/Default/apps/content.json.h:316
+#: content/Default/apps/content.json.h:325
 msgctxt "subtitle"
 msgid "A spreadsheet program with many functions"
 msgstr "Programa de planilhas com diversas funções avançadas"
 
-#: content/Default/apps/content.json.h:317
+#: content/Default/apps/content.json.h:326
 msgctxt "description"
 msgid ""
 "Whatever you need to keep track of, the spreadsheet app can help you do it. "
@@ -2161,17 +2181,17 @@ msgid ""
 " job market."
 msgstr "Toda informação que você precise controlar e acompanhar este programa de planilha pode ajudá-lo a fazer. Esta planilha avançada, e fácil de usar, serve para todos por ter visual simples, ser fácil de entender, além de ter a capacidade de fazer cálculos complexos. Planilhas são usadas ​​em muitas trabalhos em todo o mundo,. Dessa forma, aprender esse programa também pode ajudar você a ganhar habilidades valiosas para o mercado de trabalho."
 
-#: content/Default/apps/content.json.h:318
+#: content/Default/apps/content.json.h:327
 msgctxt "title"
 msgid "Presentation"
 msgstr "Apresentação"
 
-#: content/Default/apps/content.json.h:319
+#: content/Default/apps/content.json.h:328
 msgctxt "subtitle"
 msgid "Create great presentations with this easy-to-use app"
 msgstr "Faz apresentações com modelos pré-definidos, arte, efeitos especiais e ferramentas de desenho especializadas"
 
-#: content/Default/apps/content.json.h:320
+#: content/Default/apps/content.json.h:329
 msgctxt "description"
 msgid ""
 "Create clean, attractive, and professional presentations with this "
@@ -2182,17 +2202,17 @@ msgid ""
 "need."
 msgstr "Crie apresentações limpas, atraentes e profissionais com este programa de apresentação. Este programa oferece ferramentas de texto, ferramentas de desenho, transições, arte 2-D e 3-D, e até mesmo animações para que você mostre o seu ponto de vista de uma maneira bonita e atraente. E o melhor de tudo, este programa é fácil de entender e usar, com passos simplificados para você criar exatamente o que você precisa."
 
-#: content/Default/apps/content.json.h:321
+#: content/Default/apps/content.json.h:330
 msgctxt "title"
 msgid "Writer"
 msgstr "Redator"
 
-#: content/Default/apps/content.json.h:322
+#: content/Default/apps/content.json.h:331
 msgctxt "subtitle"
 msgid "Free, similar to & compatible with Microsoft Word"
 msgstr "Ferramenta de processamento de texto e editorial"
 
-#: content/Default/apps/content.json.h:323
+#: content/Default/apps/content.json.h:332
 msgctxt "description"
 msgid ""
 "This app gives you all the features of the best word processing applications"
@@ -2204,17 +2224,17 @@ msgid ""
 "notes; either way, you’ll have simple yet powerful tools available."
 msgstr "Este programa oferece todas as características dos melhores programas de processamento de texto e ainda é compatível com o Microsoft Office. Criar e editar documentos com facilidade, criar notas curtas ou longas com anotações e diagramas. Tudo isso é possível com este programa. Seus documentos vão ficar profissionais o suficiente para você apresentar ao seu chefe, professor ou outras pessoas importantes. Use este programa para compor sua próxima obra-prima ou para tirar ótimas notas; de qualquer forma, você terá ferramentas simples, porém poderosas disponíveis."
 
-#: content/Default/apps/content.json.h:324
+#: content/Default/apps/content.json.h:333
 msgctxt "title"
 msgid "Maps"
 msgstr "Mapas"
 
-#: content/Default/apps/content.json.h:325
+#: content/Default/apps/content.json.h:334
 msgctxt "subtitle"
 msgid "Maps of the entire world"
 msgstr "Mapas de todo o mundo"
 
-#: content/Default/apps/content.json.h:326
+#: content/Default/apps/content.json.h:335
 msgctxt "description"
 msgid ""
 "Where do players from FC Barcelona or Real Madrid live? How far away are you"
@@ -2225,17 +2245,17 @@ msgid ""
 "has changed over time!"
 msgstr "Onde vivem os jogadores do Barcelona ou Real Madrid? Quão longe você está o país onde os elefantes e leões passeiam livremente? O quão perto é o vulcão mais próximo? Estas são as perguntas que os mapas certos podem ajudar a responder. Este programa vai lhe dar acesso à todos os tipos de mapas de todo o mundo, de diferentes idades, de modo que você pode até mesmo ver como o mundo mudou ao longo do tempo!"
 
-#: content/Default/apps/content.json.h:327
+#: content/Default/apps/content.json.h:336
 msgctxt "title"
 msgid "M.A.R.S."
 msgstr "M.A.R.S."
 
-#: content/Default/apps/content.json.h:328
+#: content/Default/apps/content.json.h:337
 msgctxt "subtitle"
 msgid "A shooting game in space"
 msgstr "Um jogo de tiros no espaço"
 
-#: content/Default/apps/content.json.h:329
+#: content/Default/apps/content.json.h:338
 msgctxt "description"
 msgid ""
 "In the year 3547, civilizations across the galaxy have settled their own "
@@ -2248,17 +2268,17 @@ msgid ""
 "keep playing until you succeed in returning peace to your planet!"
 msgstr "No ano de 3547, as civilizações de toda a galáxia estabeleceram seus próprios planetas. Seus povos vivem em paz e harmonia com o meio ambiente. Mas fora de seu planeta pacífico, uma grande guerra está sendo travada. Então você é um lutador famoso que é conhecido por sua honra e habilidade e tem que proteger o seu planeta de seus vizinhos invejosos que querem destruí-lo! Este jogo tem uma opção multiplayer, permite que você escolha a partir de uma variedade de armas para lutar, e permite ainda que você personalize sua própria nave espacial. Você vai querer continuar jogando até que você consiga devolver a paz ao seu planeta! "
 
-#: content/Default/apps/content.json.h:330
+#: content/Default/apps/content.json.h:339
 msgctxt "title"
 msgid "MegaGlest"
 msgstr "MegaGlest"
 
-#: content/Default/apps/content.json.h:331
+#: content/Default/apps/content.json.h:340
 msgctxt "subtitle"
 msgid "A fantasy world with kings, queens and magic"
 msgstr "Um mundo de fantasia com reis, rainhas e magia"
 
-#: content/Default/apps/content.json.h:332
+#: content/Default/apps/content.json.h:341
 msgctxt "description"
 msgid ""
 "Kings, castles, and dragons all unite in this awesome strategy game that "
@@ -2268,17 +2288,17 @@ msgid ""
 "you desire!"
 msgstr "Reis, castelos e dragões juntos neste jogo de estratégia incrível, que vai fazer você querer governar a sua própria civilização. Jogue contra seus amigos para ver quem tem o que é preciso para governar este mundo de fantasia selvagem, onde a magia te faz ainda mais poderoso e você pode conquistar qualquer parte do reino que você desejar!"
 
-#: content/Default/apps/content.json.h:333
+#: content/Default/apps/content.json.h:342
 msgctxt "title"
 msgid "Minetest"
 msgstr "Minetest"
 
-#: content/Default/apps/content.json.h:334
+#: content/Default/apps/content.json.h:343
 msgctxt "subtitle"
 msgid "Create your dream world"
 msgstr "Crie o mundo dos seus sonhos"
 
-#: content/Default/apps/content.json.h:335
+#: content/Default/apps/content.json.h:344
 msgctxt "description"
 msgid ""
 "What kind of a world would you build? Start with just land and water, and "
@@ -2290,17 +2310,17 @@ msgid ""
 " your city!"
 msgstr "Que tipo de mundo você construiria? Comece com apenas terra e água e, à partir daí, preencha cada detalhe que você imaginar. Seja criativo e construa um castelo incrível, um arranha-céu, uma enorme mansão e não se esqueça te colocar muros em sua cidade para protegê-la. Explore o mundo e construa o que quiser durante o dia, mas tenha certeza de estar preparado para a noite.  Você descobrirá que aranhas, esqueletos e zumbis podem tentar atacar sua cidade! "
 
-#: content/Default/apps/content.json.h:336
+#: content/Default/apps/content.json.h:345
 msgctxt "title"
 msgid "Numpty Physics"
 msgstr "Fisica Legal"
 
-#: content/Default/apps/content.json.h:337
+#: content/Default/apps/content.json.h:346
 msgctxt "subtitle"
 msgid "Fun physics puzzle games"
 msgstr "Jogos nos quais a física é necessária para resolver quebra-cabeças"
 
-#: content/Default/apps/content.json.h:338
+#: content/Default/apps/content.json.h:347
 msgctxt "description"
 msgid ""
 "Who knew the laws of physics could be so much fun? With this app, you can "
@@ -2311,17 +2331,17 @@ msgid ""
 "learning."
 msgstr "Quem diria que as leis da física poderiam ser tão divertidas? Com este programa você pode resolver quebra-cabeças ao desenhando objetos como alavancas e rampas. Se suas criações derem certo você realizará a tarefa do nível em que você estiver e avançar para o próximo nível. Este jogo desafiador também vai te ensinar um pouco de física básica, mas você vai estar se divertindo tanto que dificilmente você vai saber que você já está aprendendo."
 
-#: content/Default/apps/content.json.h:339
+#: content/Default/apps/content.json.h:348
 msgctxt "title"
 msgid "OpenSCAD"
 msgstr ""
 
-#: content/Default/apps/content.json.h:340
+#: content/Default/apps/content.json.h:349
 msgctxt "subtitle"
 msgid "Solid 3D CAD modeller"
 msgstr ""
 
-#: content/Default/apps/content.json.h:341
+#: content/Default/apps/content.json.h:350
 msgctxt "description"
 msgid ""
 "OpenSCAD is software for creating solid 3D CAD models. It reads in a script "
@@ -2329,17 +2349,17 @@ msgid ""
 "file. The resulting model can be sent to a 3D printer."
 msgstr ""
 
-#: content/Default/apps/content.json.h:342
+#: content/Default/apps/content.json.h:351
 msgctxt "title"
 msgid "Palapeli"
 msgstr "Palapeli"
 
-#: content/Default/apps/content.json.h:343
+#: content/Default/apps/content.json.h:352
 msgctxt "subtitle"
 msgid "A fun jigsaw puzzle game"
 msgstr "Um divertido jogo de quebra-cabeça"
 
-#: content/Default/apps/content.json.h:344
+#: content/Default/apps/content.json.h:353
 msgctxt "description"
 msgid ""
 "If you’re a big fan of jigsaw puzzles, you’ll love this game. Unlike other "
@@ -2349,17 +2369,17 @@ msgid ""
 "rewarding, and as true to life as can be."
 msgstr "Se você é um grande fã de quebra-cabeça, você vai adorar este jogo. Ao contrário de outros jogos desse tipo, não é necessário alinhar peças em uma grade. Em vez disso, Palapeli tem uma sensação mais real, com peças que são livremente móveis. Escolha o seu quebra-cabeça e começe a montar as peças. Este jogo é divertido, gratificante e tão verdadeiro como na vida como real."
 
-#: content/Default/apps/content.json.h:345
+#: content/Default/apps/content.json.h:354
 msgctxt "title"
 msgid "Pingus"
 msgstr "Pingus"
 
-#: content/Default/apps/content.json.h:346
+#: content/Default/apps/content.json.h:355
 msgctxt "subtitle"
 msgid "Save your penguin friends from falling into the water"
 msgstr "Jogo divertido em vários níveis protagonizado por pinguins"
 
-#: content/Default/apps/content.json.h:347
+#: content/Default/apps/content.json.h:356
 msgctxt "description"
 msgid ""
 "Penguins are among the cutest animals, so who wouldn’t want to play a fun "
@@ -2369,17 +2389,17 @@ msgid ""
 " them in order to avoid an untimely end."
 msgstr "Os pinguins são uma fofura, quem não iria querer participar de um jogo divertido onde você deve protegê-los para que não caiam de penhascos em águas congelantes? Com inúmeros níveis e personagens adoráveis, este com certeza se tornará o seu jogo favorito. Observe os pinguins usarem as ferramentas que você deu à eles para evitar um final inesperado."
 
-#: content/Default/apps/content.json.h:348
+#: content/Default/apps/content.json.h:357
 msgctxt "title"
 msgid "Video Editor"
 msgstr "Editor de Video"
 
-#: content/Default/apps/content.json.h:349
+#: content/Default/apps/content.json.h:358
 msgctxt "subtitle"
 msgid "Hundreds of transitions, effects, and filters to edit your videos"
 msgstr "Centenas de transições, efeitos e filtros para editar seus vídeos"
 
-#: content/Default/apps/content.json.h:350
+#: content/Default/apps/content.json.h:359
 msgctxt "description"
 msgid ""
 "Create videos for projects, friends, family, or just for fun! Look through "
@@ -2389,17 +2409,17 @@ msgid ""
 "yourself, this video editor will help you do it!"
 msgstr "Crie vídeos para projetos, amigos, família, ou simplesmente para se divertir! Explore através de centenas de transições, efeitos de vídeo, efeitos de áudio e filtros para fazer o seu vídeo ficar incrível. Se você quiser contar uma história, produzir um presente para um amigo, criar um vídeo com aparência profissional, ou apenas quer se expressar, este editor de vídeo vai te ajudar a fazer isso!"
 
-#: content/Default/apps/content.json.h:351
+#: content/Default/apps/content.json.h:360
 msgctxt "title"
 msgid "Quadrapassel"
 msgstr "Quadrapassel"
 
-#: content/Default/apps/content.json.h:352
+#: content/Default/apps/content.json.h:361
 msgctxt "subtitle"
 msgid "A tetris-like puzzle game"
 msgstr "Um jogo no estilo Tetris que vai ficando mais difícil de acordo com a sua evolução"
 
-#: content/Default/apps/content.json.h:353
+#: content/Default/apps/content.json.h:362
 msgctxt "description"
 msgid ""
 "You'll need to be quick if you want to win this game! Change the shape of "
@@ -2410,17 +2430,17 @@ msgid ""
 "challenge!"
 msgstr "Você vai precisar ser rápido se quiser ganhar esse jogo! Mude o formato das peças que estão caindo para combinar as cores e fazê-las desaparecer. Se você não desaparecer com a quantidade suficiente de blocos da mesma cor, logo sua tela ficará cheia e você vai precisar começar de novo. E quando você pensar que está sendo rápido o bastante o jogo começará a acelerar!  Está pronto pra esse desafio?"
 
-#: content/Default/apps/content.json.h:354
+#: content/Default/apps/content.json.h:363
 msgctxt "title"
 msgid "Music"
 msgstr "Música"
 
-#: content/Default/apps/content.json.h:355
+#: content/Default/apps/content.json.h:364
 msgctxt "subtitle"
 msgid "Listen to all your music, and to the radio"
 msgstr "Reprodutor de áudio e rádio que reproduz e ajuda a organizar música digital"
 
-#: content/Default/apps/content.json.h:356
+#: content/Default/apps/content.json.h:365
 msgctxt "description"
 msgid ""
 "In addition to listening to your favorite music, this app lets you search "
@@ -2430,17 +2450,17 @@ msgid ""
 "in one convenient app."
 msgstr "Além de ouvir suas músicas preferidas, este programa permite que você pesquise em sua biblioteca, crie listas de reprodução, reproduza e grave CDs, e exiba as capas dos álbuns e as letras das músicas. Este programa também é compatível com transmissão de rádio pela internet e visualizações de áudio. Curta suas músicas favoritas, guardadas e organizadas neste programa super prático."
 
-#: content/Default/apps/content.json.h:357
+#: content/Default/apps/content.json.h:366
 msgctxt "title"
 msgid "Toy Train"
 msgstr "Trenzinho"
 
-#: content/Default/apps/content.json.h:358
+#: content/Default/apps/content.json.h:367
 msgctxt "subtitle"
 msgid "A fun train game for kids of all ages"
 msgstr "Um jogo de trem divertido para crianças de todas as idades"
 
-#: content/Default/apps/content.json.h:359
+#: content/Default/apps/content.json.h:368
 msgctxt "description"
 msgid ""
 "Sure to be an instant hit with the whole family, this is a game featuring a "
@@ -2448,17 +2468,17 @@ msgid ""
 "coaches as you go. Collect all the coaches to win the game!"
 msgstr "Esse será sucesso instantâneo com toda a família. Use a locomotiva para recolher a maior quantidade de vagões possível e ganhe o jogo. "
 
-#: content/Default/apps/content.json.h:360
+#: content/Default/apps/content.json.h:369
 msgctxt "title"
 msgid "Scorched 3D"
 msgstr "Scorched 3D"
 
-#: content/Default/apps/content.json.h:361
+#: content/Default/apps/content.json.h:370
 msgctxt "subtitle"
 msgid "A battle adventure multi-player game"
 msgstr "Jogo de artilharia"
 
-#: content/Default/apps/content.json.h:362
+#: content/Default/apps/content.json.h:371
 msgctxt "description"
 msgid ""
 "Do you love games with jets, naval vessels, and all sorts of weapons? If so,"
@@ -2470,17 +2490,17 @@ msgid ""
 "shake things up!"
 msgstr "Você gosta de jogos com aviões a jatos, navios de guerra e inúmeras armas? Então o Scorched 3D é para você. Neste jogo você poderá visitar diversos terrenos nos quais irá entrar em batalhas. Você precisa criar uma boa estratégia para vencer o seu adversário. Podes jogar sozinho, com os teus amigos, ou em modo de batalha com outros membros da comunidade online. Este jogo vai fazer você se sacudir!"
 
-#: content/Default/apps/content.json.h:363
+#: content/Default/apps/content.json.h:372
 msgctxt "title"
 msgid "Scratch"
 msgstr "Scratch"
 
-#: content/Default/apps/content.json.h:364
+#: content/Default/apps/content.json.h:373
 msgctxt "subtitle"
 msgid "Learn basic computer programming"
 msgstr "Aprenda sobre programação de computadores básica"
 
-#: content/Default/apps/content.json.h:365
+#: content/Default/apps/content.json.h:374
 msgctxt "description"
 msgid ""
 "Do you love computer games and applications? Why not learn how to make your "
@@ -2492,17 +2512,17 @@ msgid ""
 "will you someday make? "
 msgstr "Você gosta de jogos e programas? Por que não aprender a fazer o seu próprio? Este programa ensina conceitos básicos de programação de computadores de uma forma divertida e fácil de aprender.  Você pode escolher personagens e objetos que você goste e, em seguida, adicionar as instruções para que façam o que você quer. À medida em que você for avançando vai ver que pode dar vida a praticamente qualquer coisa na tela, desde que dê as instruções corretas. Qual jogo maneiro você vai fazer?"
 
-#: content/Default/apps/content.json.h:366
+#: content/Default/apps/content.json.h:375
 msgctxt "title"
 msgid "Photos"
 msgstr "Fotos"
 
-#: content/Default/apps/content.json.h:367
+#: content/Default/apps/content.json.h:376
 msgctxt "subtitle"
 msgid "Easily edit, organize, and share photos."
 msgstr "Facilita a edição, organização e compartilhamento de fotos."
 
-#: content/Default/apps/content.json.h:368
+#: content/Default/apps/content.json.h:377
 msgctxt "description"
 msgid ""
 "We all love to take pictures in our everyday lives – and we especially love "
@@ -2513,17 +2533,17 @@ msgid ""
 "networks, like Facebook."
 msgstr "Todos nós adoramos tirar fotos em nossa vida diária - especialmente baixá-las para os nossos computadores para editar e compartilhar em mídias sociais. Este programa permite importar fotos de uma câmera digital ou telefone perfeitamente. Você pode organizá-las em álbuns, editá-las para obter o máximo de beleza e efeito e, claro, exibi-las em suas redes sociais preferidas, como o Facebook. Este programa de foto também permite que você crie álbuns para compartilhar na internet, se você preferir assim. O que quer que seja, seus amigos podem ver todas as fotos que você quiser mostrar!"
 
-#: content/Default/apps/content.json.h:369
+#: content/Default/apps/content.json.h:378
 msgctxt "title"
 msgid "Simple Scan"
 msgstr "Scanner Simples"
 
-#: content/Default/apps/content.json.h:370
+#: content/Default/apps/content.json.h:379
 msgctxt "subtitle"
 msgid "Make a digital copy of your photos and documents"
 msgstr "Faça cópias digitais de suas fotos e documentos"
 
-#: content/Default/apps/content.json.h:371
+#: content/Default/apps/content.json.h:380
 msgctxt "description"
 msgid ""
 "Preserving your photos and important documents by making digital copies has "
@@ -2534,17 +2554,17 @@ msgid ""
 "sure the things you scan are clear, straight, and in any format you need!"
 msgstr "Preservar suas fotos e documentos importantes criando cópias digitais nunca foi tão fácil! Tenha seu scanner conectado ao seu computador , abra este programa e comece à digitalizar. Quando uma foto ou documento é digitalizado, é super fácil compartilhá-la por e-mail, enviá-la para sua rede social favorita ou colocá-la em um pen-drive. Este programa certamente te ajudará a realizar digitalizações com precisão, clareza e no formato de arquivo que você precisa!"
 
-#: content/Default/apps/content.json.h:372
+#: content/Default/apps/content.json.h:381
 msgctxt "title"
 msgid "Skype"
 msgstr "Skype"
 
-#: content/Default/apps/content.json.h:373
+#: content/Default/apps/content.json.h:382
 msgctxt "subtitle"
 msgid "Free internet calls with cheap rates to phones"
 msgstr "Faça chamadas gratuitas pela internet e ligações baratas para telefones e celulares."
 
-#: content/Default/apps/content.json.h:374
+#: content/Default/apps/content.json.h:383
 msgctxt "description"
 msgid ""
 "Skype makes staying in touch incredibly easy and fun! If you have a webcam "
@@ -2553,17 +2573,17 @@ msgid ""
 "you can stay in touch with people anywhere in world!  **Requires Internet"
 msgstr "Skype faz você ficar em contato facilmente e de forma divertida! Se você tiver uma webcam e um microfone, você pode facilmente fazer chamadas de vídeo e chamadas de voz para qualquer pessoa no mundo que também tem Skype. As ferramentas deste programa são simples de usar e você pode ficar em contato com pessoas em qualquer lugar no mundo!"
 
-#: content/Default/apps/content.json.h:375
+#: content/Default/apps/content.json.h:384
 msgctxt "title"
 msgid "Slingshot"
 msgstr "Estilingue"
 
-#: content/Default/apps/content.json.h:376
+#: content/Default/apps/content.json.h:385
 msgctxt "subtitle"
 msgid "A shooting strategy game set in space"
 msgstr "Um jogo de estratégia de tiro no espaço"
 
-#: content/Default/apps/content.json.h:377
+#: content/Default/apps/content.json.h:386
 msgctxt "description"
 msgid ""
 "Gravity is your best friend in this fun shooting game set in outer space. "
@@ -2572,17 +2592,17 @@ msgid ""
 "in this fun and addictive game!"
 msgstr "A gravidade é o seu melhor amigo neste divertido jogo de tiro no espaço sideral. Use a gravidade de planetas diferentes para a sua vantagem e use seu estilingue fiel para destruir a nave inimiga. Nenhuma das rodadas são iguais neste jogo divertido e viciante!"
 
-#: content/Default/apps/content.json.h:378
+#: content/Default/apps/content.json.h:387
 msgctxt "title"
 msgid "Freecell"
 msgstr "Freecell"
 
-#: content/Default/apps/content.json.h:379
+#: content/Default/apps/content.json.h:388
 msgctxt "subtitle"
 msgid "Solitare based single player card game"
 msgstr "Jogo de cartas de um jogador, estilo Paciência"
 
-#: content/Default/apps/content.json.h:380
+#: content/Default/apps/content.json.h:389
 msgctxt "description"
 msgid ""
 "This application lets you play a new type of solitaire that will keep you "
@@ -2592,17 +2612,17 @@ msgid ""
 "to enjoy."
 msgstr "Este programa permite que você jogue um novo tipo de paciência que irá mantê-lo ocupado por horas! Freecell Paciência é um pouco diferente da Paciência tradicional, mas as regras são fáceis de entender. Como a Paciência tradicional, a ideia geral é colocar cartas do mesmo naipe para baixo, em ordem numérica, mas é um pouco mais complicado do que isso. Este jogo de cartas desafia a mente e proporciona muita diversão para você aproveitar."
 
-#: content/Default/apps/content.json.h:381
+#: content/Default/apps/content.json.h:390
 msgctxt "title"
 msgid "Solitaire"
 msgstr "Paciência"
 
-#: content/Default/apps/content.json.h:382
+#: content/Default/apps/content.json.h:391
 msgctxt "subtitle"
 msgid "The classic single player card game"
 msgstr "O clássico jogo de cartas para um jogador"
 
-#: content/Default/apps/content.json.h:383
+#: content/Default/apps/content.json.h:392
 msgctxt "description"
 msgid ""
 "Solitaire is a classic card game that is fun for people of all ages. It’s "
@@ -2612,17 +2632,17 @@ msgid ""
 "entertain you, hour after hour."
 msgstr "Paciência é um jogo clássico de cartas que é divertido para pessoas de todas as idades. É fácil aprender as regras, mas leva um tempo para dominar o jogo. Com sorte você irá dedicar um tempo para realmente aprender a jogar porque vai ser muito divertido. Este jogo cativante e estimulante com certeza irá entreter você, hora após hora."
 
-#: content/Default/apps/content.json.h:384
+#: content/Default/apps/content.json.h:393
 msgctxt "title"
 msgid "Steam"
 msgstr "Steam"
 
-#: content/Default/apps/content.json.h:385
+#: content/Default/apps/content.json.h:394
 msgctxt "subtitle"
 msgid "Browse hundreds of the most popular games online"
 msgstr "Navegue centenas dos mais populares jogos on-line"
 
-#: content/Default/apps/content.json.h:386
+#: content/Default/apps/content.json.h:395
 msgctxt "description"
 msgid ""
 "If you like playing video games, you're going to have a great time exploring"
@@ -2633,18 +2653,18 @@ msgid ""
 " a time!"
 msgstr "Se você gosta de jogar videogame, você vai gastar um tempo explorando todos os jogos divertidos Linux, no portal Steam, da Valve! Você vai precisar de uma conexão com a internet para ver e comprar jogos na loja Steam. Prepare-se para encontrar o que há de mais popular no mundo dos jogos. É a certeza de que você estará entretido por horas e horas!"
 
-#: content/Default/apps/content.json.h:387
+#: content/Default/apps/content.json.h:396
 msgctxt "title"
 msgid "Stellarium"
 msgstr "Constelação"
 
-#: content/Default/apps/content.json.h:388
+#: content/Default/apps/content.json.h:397
 msgctxt "subtitle"
 msgid ""
 "Planetarium software that shows what you see when you look at the stars"
 msgstr "Software planetário que mostra o que você vê ao olhar para as estrelas"
 
-#: content/Default/apps/content.json.h:389
+#: content/Default/apps/content.json.h:398
 msgctxt "description"
 msgid ""
 "Discover the night sky with this application. With a catalogue of more than "
@@ -2655,17 +2675,17 @@ msgid ""
 "coordinates and learn about the stars above you!"
 msgstr "Descubra o céu noturno com este programa. Com um catálogo de mais de 600 mil estrelas, constelações de mais de uma dúzia de culturas e muitos outros recursos, este programa permite ver e conhecer as estrelas bem aí na sua área de trabalho. Ele mostra o céu noturno tão real quanto o que você vê quando olha para cima. Defina as coordenadas de sua localização e saiba mais sobre as estrelas!"
 
-#: content/Default/apps/content.json.h:390
+#: content/Default/apps/content.json.h:399
 msgctxt "title"
 msgid "Super Tux"
 msgstr "Super Tux"
 
-#: content/Default/apps/content.json.h:391
+#: content/Default/apps/content.json.h:400
 msgctxt "subtitle"
 msgid "Jump your way through different levels to win"
 msgstr "Clássico jogo corre e pula em estilo arcade"
 
-#: content/Default/apps/content.json.h:392
+#: content/Default/apps/content.json.h:401
 msgctxt "description"
 msgid ""
 "This game is similar to the original Super Mario Brothers games where you "
@@ -2674,17 +2694,17 @@ msgid ""
 " can follow along with as you play."
 msgstr "Este jogo é semelhante aos jogos originais do Super Mario Bros. O seu personagem tem que correr e saltar de para passar de nível. Este jogo tem 26 níveis com diferentes adversários para combater, uma divertida trilha sonora e uma história que se desenrola a cada nível que você passa."
 
-#: content/Default/apps/content.json.h:393
+#: content/Default/apps/content.json.h:402
 msgctxt "title"
 msgid "Tux Kart"
 msgstr "Tux Kart"
 
-#: content/Default/apps/content.json.h:394
+#: content/Default/apps/content.json.h:403
 msgctxt "subtitle"
 msgid "Race alone or against your friends and family"
 msgstr "Jogo de corridas com personagens coloridos e pistas originais"
 
-#: content/Default/apps/content.json.h:395
+#: content/Default/apps/content.json.h:404
 msgctxt "description"
 msgid ""
 "Do you love racing games? Then this is the app for you! Race down easy, "
@@ -2695,17 +2715,17 @@ msgid ""
 "is sure to entertain you and your friends for hours!"
 msgstr "Tux Kart é um jogo de corridas protagonizado pelo adorável Pinguim Tux. Este jogo tem vários tipos de pistas de variadas dificuldades para testar as suas habilidades de condução. Não importa a pista em que você corre, o importante é chegar o mais rápido possível ao final, antes dos seus adversários, colecionar os itens vermelhos (que te darão capacidades especiais) e evitar os verdes (que te irão atrasar). Este jogo oferece a você e aos seus amigos horas de entretenimento!"
 
-#: content/Default/apps/content.json.h:396
+#: content/Default/apps/content.json.h:405
 msgctxt "title"
 msgid "Teeworlds"
 msgstr "Teelândia"
 
-#: content/Default/apps/content.json.h:397
+#: content/Default/apps/content.json.h:406
 msgctxt "subtitle"
 msgid "Exciting multi-player shooting game"
 msgstr "Incrível jogo de tiros para vários jogadores"
 
-#: content/Default/apps/content.json.h:398
+#: content/Default/apps/content.json.h:407
 msgctxt "description"
 msgid ""
 "Shoot your way to victory in death matches and more! This game has an old-"
@@ -2717,17 +2737,17 @@ msgid ""
 "and go!"
 msgstr "Teelândia é um jogo de estilo retro, mas não deixe que esta nostalgia o engane. Teelândia é também um incrível jogo multiplayer, com batalhas épicas de 16 jogadores, e vários modos conhecidos, tais como Capture the Flag e Team Deathmatch. Tente sobreviver na mortífera arena enquanto destrói os adversários. O Teelândia possui um interessante modo que lhe permite criar os seus próprios níveis de jogo. Muita diversão espera por você no programa Teelândia."
 
-#: content/Default/apps/content.json.h:399
+#: content/Default/apps/content.json.h:408
 msgctxt "title"
 msgid "TORCS"
 msgstr "TORCS"
 
-#: content/Default/apps/content.json.h:400
+#: content/Default/apps/content.json.h:409
 msgctxt "subtitle"
 msgid "Race cool 3D cars in this realistic game"
 msgstr "Jogo de incríveis corridas 3D"
 
-#: content/Default/apps/content.json.h:401
+#: content/Default/apps/content.json.h:410
 msgctxt "description"
 msgid ""
 "Rip around turns and scream past other drivers in this exciting 3D car "
@@ -2738,17 +2758,17 @@ msgid ""
 "want to play too!"
 msgstr "Ultrapasse os outros pilotos neste emocionante jogo de corrida de carros em 3D. É tão realista que você vai jurar que está sentindo o cheiro de borracha queimada! Os usuários avançados também tem a oportunidade de personalizar seu jogo e ganhar ainda mais vantagem sobre seus adversários. Você vai adorar correr com seus carros velozes e, em breve, vai perceber que todos os seus amigos vão querer jogar também."
 
-#: content/Default/apps/content.json.h:402
+#: content/Default/apps/content.json.h:411
 msgctxt "title"
 msgid "Videos"
 msgstr "Vídeos"
 
-#: content/Default/apps/content.json.h:403
+#: content/Default/apps/content.json.h:412
 msgctxt "subtitle"
 msgid "Full function video and media player"
 msgstr "Leitor de vídeo e outros formatos de mídia."
 
-#: content/Default/apps/content.json.h:404
+#: content/Default/apps/content.json.h:413
 msgctxt "description"
 msgid ""
 "Do you love watching movies? Do it the right way with this video application"
@@ -2758,17 +2778,17 @@ msgid ""
 "your family and friends to join you in watching all of your favorite movies!"
 msgstr "Você gosta de assistir filmes? Faça isso do jeito certo com este programa de vídeo que permite assistir a filmes baixados em modo de tela cheia. Outros recursos básicos, como controle de volume e listas de reprodução tornam a sua experiência de assistir a vídeos fácil e divertida. Com este programa você vai querer convidar toda a sua família e amigos para assistir aos seus filmes preferidos!"
 
-#: content/Default/apps/content.json.h:405
+#: content/Default/apps/content.json.h:414
 msgctxt "title"
 msgid "Tux Football"
 msgstr "Tux Futebol"
 
-#: content/Default/apps/content.json.h:406
+#: content/Default/apps/content.json.h:415
 msgctxt "subtitle"
 msgid "A fun soccer game starring Tux the penguin"
 msgstr "Um divertido jogo de futebol - estrelando Tux, o pinguim"
 
-#: content/Default/apps/content.json.h:407
+#: content/Default/apps/content.json.h:416
 msgctxt "description"
 msgid ""
 "Do you love soccer? Now you can play all day with your favorite penguins! "
@@ -2777,17 +2797,17 @@ msgid ""
 "professionals!"
 msgstr "Você gosta de futebol? Agora você pode jogar o dia todo com seus pinguins favoritos! Mostre suas habilidades e estratégia enquanto controla os jogadores com a bola. Muito em breve, você vai sentir como se estivesse pronto para assumir um time!"
 
-#: content/Default/apps/content.json.h:408
+#: content/Default/apps/content.json.h:417
 msgctxt "title"
 msgid "Tux Math"
 msgstr "123 Tux"
 
-#: content/Default/apps/content.json.h:409
+#: content/Default/apps/content.json.h:418
 msgctxt "subtitle"
 msgid "Math games for kids"
 msgstr "Jogo de estilo Arcade que ajuda as crianças a estudarem matemática"
 
-#: content/Default/apps/content.json.h:410
+#: content/Default/apps/content.json.h:419
 msgctxt "description"
 msgid ""
 "Learn math by playing games! Starring kids’ favorite buddy, Tux the Penguin,"
@@ -2797,17 +2817,17 @@ msgid ""
 "both worlds and will help your child learn to love math!"
 msgstr "Apresentado pelo amiguinho favorito das crianças, Tux o Pinguim, este programa de jogo de matemática conduz as crianças pelos conceitos da matemática de forma divertida e envolvente. Você quer que seus filhos sejam bons em matemática e que brinquem com jogos - portanto encorajá-los a jogar é unir o melhor dos dois mundos e isso irá fazer com que eles aprendam a gostar de matemática!"
 
-#: content/Default/apps/content.json.h:411
+#: content/Default/apps/content.json.h:420
 msgctxt "title"
 msgid "Tux Paint"
 msgstr "Tux Paint"
 
-#: content/Default/apps/content.json.h:412
+#: content/Default/apps/content.json.h:421
 msgctxt "subtitle"
 msgid "A fun drawing app for kids"
 msgstr "Um programa de desenho divertido para crianças"
 
-#: content/Default/apps/content.json.h:413
+#: content/Default/apps/content.json.h:422
 msgctxt "description"
 msgid ""
 "Create beautiful artwork with this fun and easy to use app! Tux the penguin "
@@ -2818,17 +2838,17 @@ msgid ""
 "then download this app and get them started on their next masterpiece!"
 msgstr "'Pinte o sete' com este programa fácil e divertido! O pinguim Tux ajuda a orientar as crianças para que elas saibam como usar todas as ferramentas. A idade recomendada para usar este programa é de 3 a 12 anos, mas qualquer pessoa de coração jovem com certeza vai adorar! Use adesivos, brinque com as formas, ou desenhe à mão livre para criar algo especial. Se seu filho gosta de desenhar e criar arte, baixe este programa e faça ele começar sua próxima obra-prima!"
 
-#: content/Default/apps/content.json.h:414
+#: content/Default/apps/content.json.h:423
 msgctxt "title"
 msgid "Tux Puck"
 msgstr "Tux Puck"
 
-#: content/Default/apps/content.json.h:415
+#: content/Default/apps/content.json.h:424
 msgctxt "subtitle"
 msgid "Exciting air hockey game for you and your friends"
 msgstr "Emocionante jogo de hóquei aéreo para você e seus amigos"
 
-#: content/Default/apps/content.json.h:416
+#: content/Default/apps/content.json.h:425
 msgctxt "description"
 msgid ""
 "An air hockey game in which you try to knock the puck past your opponent's "
@@ -2837,17 +2857,17 @@ msgid ""
 " or F6 to adjust your paddle speed.)"
 msgstr "Um jogo de hóquei aéreo em que o objetivo é movimentar o disco, passando pela defesa do seu oponente para marcar ponto. Este é um grande jogo para toda a família! Teste sua habilidade e reflexos para vencer este jogo rápido!"
 
-#: content/Default/apps/content.json.h:417
+#: content/Default/apps/content.json.h:426
 msgctxt "title"
 msgid "Tux Typing"
 msgstr "Tecla Tux"
 
-#: content/Default/apps/content.json.h:418
+#: content/Default/apps/content.json.h:427
 msgctxt "subtitle"
 msgid "Learn to type by playing games"
 msgstr "Ferramenta para crianças aprenderem a digitar"
 
-#: content/Default/apps/content.json.h:419
+#: content/Default/apps/content.json.h:428
 msgctxt "description"
 msgid ""
 "This fun application is a great way for kids, and even adults, to learn how "
@@ -2859,17 +2879,17 @@ msgid ""
 "encouraging them to play!"
 msgstr "Este programa divertido é um ótimo meio para crianças e adultos aprenderem a digitar! Aprenda o básico ou aprimore suas habilidades com jogos que o ensinam como usar um teclado sem nem precisar olhar para ele. As crianças de hoje estão crescendo rodeadas de computadores e dispositivos móveis, e aprender como usar essas tecnologias adequadamente é muito importante para o seu futuro. Ajude-os a começar da forma correta, baixando este programa e incentivando-os a jogar!"
 
-#: content/Default/apps/content.json.h:420
+#: content/Default/apps/content.json.h:429
 msgctxt "title"
 msgid "Warmux"
 msgstr "WarMUX"
 
-#: content/Default/apps/content.json.h:421
+#: content/Default/apps/content.json.h:430
 msgctxt "subtitle"
 msgid "Make your computer a battle of wit and war"
 msgstr "Faça do seu computador uma batalha de guerra e inteligência"
 
-#: content/Default/apps/content.json.h:422
+#: content/Default/apps/content.json.h:431
 msgctxt "description"
 msgid ""
 "Exterminate your opponent in a cartoon word using dynamite, grenades, "
@@ -2878,17 +2898,17 @@ msgid ""
 " member of each team attempts to destroy his opponents."
 msgstr "Extermine seu oponente em um mundo de desenho animado usando dinamite, granadas, bazucas e até um taco de beisebol. Cada jogador controla seu próprio time e precisa destruir seu adversário usando seu arsenal e inteligência. "
 
-#: content/Default/apps/content.json.h:423
+#: content/Default/apps/content.json.h:432
 msgctxt "title"
 msgid "Warzone 2100"
 msgstr "Warzone 2100"
 
-#: content/Default/apps/content.json.h:424
+#: content/Default/apps/content.json.h:433
 msgctxt "subtitle"
 msgid "Lead your troops to rebuild the world"
 msgstr "Lidere suas tropas para reconstruir o mundo"
 
-#: content/Default/apps/content.json.h:425
+#: content/Default/apps/content.json.h:434
 msgctxt "description"
 msgid ""
 "In Warzone 2100 you command forces to rebuild the world after nuclear war "
@@ -2898,17 +2918,17 @@ msgid ""
 "of strategy, tactics, and wit."
 msgstr "No Warzone 2100 você comanda as forças para reconstruir o mundo após uma guerra nuclear. Jogue sozinho ou com amigos. De qualquer forma, você vai mergulhar de cabeça em outro mundo, onde estará vivendo e respirando estratégia militar. Pesquise tecnologias e planeje batalhas neste jogo de estratégia, tática e inteligência."
 
-#: content/Default/apps/content.json.h:426
+#: content/Default/apps/content.json.h:435
 msgctxt "title"
 msgid "Wesnoth"
 msgstr "Wesnoth"
 
-#: content/Default/apps/content.json.h:427
+#: content/Default/apps/content.json.h:436
 msgctxt "subtitle"
 msgid "Fantasy turn-based strategy game"
 msgstr "Jogo de estratégia baseado em Fantasia"
 
-#: content/Default/apps/content.json.h:428
+#: content/Default/apps/content.json.h:437
 msgctxt "description"
 msgid ""
 "Battle for control of the land, villages, and resources in this fantasy-"
@@ -2917,17 +2937,17 @@ msgid ""
 "strategy, this game is sure to reveal a great leader inside you."
 msgstr "Batalhe pelo controle de terras, aldeias e recursos neste jogo de estratégia temático. Cada jogador controla um exército criado por ele mesmo e o usa em busca do domínio. Uma emocionante mistura de história, fantasia e estratégia, este jogo é certo para revelar um grande líder dentro de você."
 
-#: content/Default/apps/content.json.h:429
+#: content/Default/apps/content.json.h:438
 msgctxt "title"
 msgid "X-Moto"
 msgstr "X-Moto"
 
-#: content/Default/apps/content.json.h:430
+#: content/Default/apps/content.json.h:439
 msgctxt "subtitle"
 msgid "A motorcycle racing game"
 msgstr "Jogo de corrida de motocicletas"
 
-#: content/Default/apps/content.json.h:431
+#: content/Default/apps/content.json.h:440
 msgctxt "description"
 msgid ""
 "Love motorcycles? Then you're going to love this racing game where physics "
@@ -2937,17 +2957,17 @@ msgid ""
 "time in this fast-paced, exciting test of speed!"
 msgstr "Ama motocicletas?  Então você vai adorar este jogo de corrida, onde a física desempenha um papel importante na conquista! Você deve controlar sua moto ao seu limite físico se quiser ter a chance de terminar os percursos difíceis. Saiba mais sobre ciência e pratique suas habilidades de corrida ao mesmo tempo neste teste de velocidade emocionante!"
 
-#: content/Default/apps/content.json.h:432
+#: content/Default/apps/content.json.h:441
 msgctxt "title"
 msgid "KBlocks"
 msgstr "KBlocks"
 
-#: content/Default/apps/content.json.h:433
+#: content/Default/apps/content.json.h:442
 msgctxt "subtitle"
 msgid "Match blocks to destroy them and win"
 msgstr "Agrupe os blocos para destruí-los e ganhar o jogo"
 
-#: content/Default/apps/content.json.h:434
+#: content/Default/apps/content.json.h:443
 msgctxt "description"
 msgid ""
 "This game is similar to Tetris, so if you love that game, you will love this"
@@ -2956,17 +2976,17 @@ msgid ""
 " lose, so pay attention and get ready for some very fast-actioned fun!"
 msgstr "Esse jogo é parecido com Tetris, se você gosta dele, vai adorar esse também. Agrupe os blocos por formato, afim de fazê-los desaparecer e evite que eles encham a tela. Você terá que ser muito rápido ou perderá. Então, preste atenção e prepare-se para se divertir em ritmo acelerado. "
 
-#: content/Default/apps/content.json.h:435
+#: content/Default/apps/content.json.h:444
 msgctxt "title"
 msgid "KBounce"
 msgstr "KBounce"
 
-#: content/Default/apps/content.json.h:436
+#: content/Default/apps/content.json.h:445
 msgctxt "subtitle"
 msgid "The ball-bouncing game sure to hook you"
 msgstr "Esse jogo com certeza vai fisgar você. "
 
-#: content/Default/apps/content.json.h:437
+#: content/Default/apps/content.json.h:446
 msgctxt "description"
 msgid ""
 "This is a fun game with a simple goal: you must build walls to decrease the "
@@ -2976,17 +2996,17 @@ msgid ""
 "It requires quick thinking and fast reflexes!"
 msgstr "Este é um jogo divertido, com um objetivo simples: você deve construir paredes para diminuir o espaço onde a bola pode quicar. Depois de preencher a maior parte da tela com essas paredes você passará de nível. Esse jogo tem um pouco de quebra-cabeças, é acelerado e divertido. Ele exige raciocínio e reflexos rápidos!  "
 
-#: content/Default/apps/content.json.h:438
+#: content/Default/apps/content.json.h:447
 msgctxt "title"
 msgid "KDiamond"
 msgstr "KDiamante"
 
-#: content/Default/apps/content.json.h:439
+#: content/Default/apps/content.json.h:448
 msgctxt "subtitle"
 msgid "Create lines of three diamonds"
 msgstr "Crie linhas de três diamantes"
 
-#: content/Default/apps/content.json.h:440
+#: content/Default/apps/content.json.h:449
 msgctxt "description"
 msgid ""
 "In this fast-paced game, your job is to build lines of three diamonds of the"
@@ -2997,17 +3017,17 @@ msgid ""
 "many age levels."
 msgstr "Neste jogo rápido, seu trabalho é construir linhas de três diamantes iguais. Basta trocar diamantes com seus vizinhos para fazer suas linhas. Faça isso com rapidez para construir o máximo de linhas possível antes do final da rodada! Este é um jogo fácil que você pode jogar por pouco tempo, ou por horas seguidas. É divertido, rápido e ótimo para todas as idades."
 
-#: content/Default/apps/content.json.h:441
+#: content/Default/apps/content.json.h:450
 msgctxt "title"
 msgid "KJumpingCube"
 msgstr "Cubo Saltador"
 
-#: content/Default/apps/content.json.h:442
+#: content/Default/apps/content.json.h:451
 msgctxt "subtitle"
 msgid "Develop a good strategy to conquer all the squares"
 msgstr "Desenvolva uma boa estratégia para conquistar todos os espaços"
 
-#: content/Default/apps/content.json.h:443
+#: content/Default/apps/content.json.h:452
 msgctxt "description"
 msgid ""
 "Practice your strategic thinking with this challenging dice-based game! You "
@@ -3022,17 +3042,17 @@ msgid ""
 " toes! "
 msgstr "Pratique seu pensamento estratégico com esse jogo desafiador. Se mova clicando nos espaços vazios ou que já sejam seus. Se você clicar em um quadrado vazio ele ganha a sua cor, mostrando que agora ele é seu. Cada vez que você clica no mesmo quadrado ele ganha mais um ponto. Uma vez que um quadrado tem mais pontos que os quadrados vizinhos, eles são distribuídos (os pontos pulam para os quadrados em volta). Se o quadrado vizinho for do adversário, você passa a ser o novo dono do espaço e dos pontos desse quadrado. Você precisa pensar cuidadosamente para controlar todos os quadrados pois os pontos mudam de mãos rapidamente e isso vai mantê-lo envolvido por um bom tempo! "
 
-#: content/Default/apps/content.json.h:444
+#: content/Default/apps/content.json.h:453
 msgctxt "title"
 msgid "KSame"
 msgstr "Cores Iguais"
 
-#: content/Default/apps/content.json.h:445
+#: content/Default/apps/content.json.h:454
 msgctxt "subtitle"
 msgid "Get rid of all the marbles to win"
 msgstr "Livre-se de todas as bolas para vencer"
 
-#: content/Default/apps/content.json.h:446
+#: content/Default/apps/content.json.h:455
 msgctxt "description"
 msgid ""
 "Show off your pattern-finding skills in this addicting game. Match all of "
@@ -3042,17 +3062,17 @@ msgid ""
 " challenge. A really fun challenge!"
 msgstr "Mostre toda a sua habilidade neste jogo viciante. Combine todas as bolinhas da mesma cor para limpar o tabuleiro e ganhar o jogo. Mas lembre-se: quanto mais bolinhas você eliminar ao mesmo tempo, mais pontos você ganha. Pense estrategicamente em todos os seus movimentos. Isso pode parecer fácil à primeira vista mas é um grande desafio. Um desafio muito divertido"
 
-#: content/Default/apps/content.json.h:447
+#: content/Default/apps/content.json.h:456
 msgctxt "title"
 msgid "Open Arena"
 msgstr "Open Arena"
 
-#: content/Default/apps/content.json.h:448
+#: content/Default/apps/content.json.h:457
 msgctxt "subtitle"
 msgid "Shoot your way out of trouble in this fun game"
 msgstr "Jogo de tiros em primeira pessoa baseado no jogo Quake III Arena"
 
-#: content/Default/apps/content.json.h:449
+#: content/Default/apps/content.json.h:458
 msgctxt "description"
 msgid ""
 "If arena battles are your idea of a good time, then you’ll love this "
@@ -3062,7 +3082,7 @@ msgid ""
 "of these modes offers its own form of excitement as you battle your enemies!"
 msgstr "Se você considera os jogos de batalhas um bom passa tempo, então você vai adorar este programa. Já estamos avisando: este é um jogo de muita habilidade, e derramamento de sangue. Use diferentes estilos de armas em batalhas como: Capture the Flag,  Deathmatch, Team Deathmatch, Last Man Standing, e Tournament. Cada um destes modos oferece a sua própria forma de emoção enquanto você luta contra seus inimigos!"
 
-#: content/Default/apps/content.json.h:159
+#: content/Default/apps/content.json.h:171
 msgctxt "description"
 msgid ""
 "Need to safely store all of your important documents, photos, songs, and "

--- a/renamed-apps.txt
+++ b/renamed-apps.txt
@@ -1,0 +1,3 @@
+com.endlessm.futbol com.endlessm.soccer
+gt-literature com.endlessm.world-literature
+gt-textbooks com.endlessm.textbooks

--- a/unzip_content.py
+++ b/unzip_content.py
@@ -56,6 +56,15 @@ APPS_TO_APPEND = [
     'openarena'
 ]
 
+# Hack: when we rename an app id, we add a duplicated entry with
+# the old app id and special subtitle and description
+# that identify the app as deprecated
+DEPRECATED_SUBTITLE = 'Deprecated version'
+DEPRECATED_DESCRIPTION = 'If you have internet access, there may be a newer ' \
+    'version of this application available to download and install. In the ' \
+    'meantime, you may continue to use this version that is already installed '\
+    'on your computer.'
+
 # Run the ImageMagick 'convert' application from the command line,
 # with specified JPEG quality and all metadata stripped
 def convert(source, target, command):
@@ -145,6 +154,27 @@ if __name__ == '__main__':
             continue;
         app_index += 1
     sorted_json.extend(apps_to_append)
+
+    # Read the list of apps that have had app ids renamed
+    with open('renamed-apps.txt') as renamed_file:
+        renamed_apps = renamed_file.read().strip().split('\n')
+
+    # Insert a duplicate entry for any renamed app ids
+    # that uses the same name and assets but with a special
+    # subtitle and description to identify it as deprecated
+    app_index = 0
+    while app_index < len(sorted_json):
+        for renamed_app in renamed_apps:
+            app_data = sorted_json[app_index]
+            [old_id, new_id] = renamed_app.split()
+            if app_data['application-id'] == new_id:
+                app_copy = app_data.copy()
+                app_copy['application-id'] = old_id
+                app_copy['subtitle'] = DEPRECATED_SUBTITLE
+                app_copy['description'] = DEPRECATED_DESCRIPTION
+                sorted_json.insert(app_index, app_copy)
+                app_index += 1
+        app_index += 1
 
     with open(target, 'w') as outfile:
         json.dump(sorted_json, outfile, indent=2, sort_keys=True)


### PR DESCRIPTION
The unzip_content.py script reads renamed-apps.txt to get the mapping
from old app ID to new app ID.  This is reflected in the content.json
as a duplicate entry using the name and assets for the new app ID
but with special text for the subtitle and description that identifies
this old app ID as deprecated.  The old entry is inserted right before
the new entry, to help cluster the two entries together in the app store.

For now, this is only relevant for a few applicaitons that have been
delivered on the Guatemala images, so no concern that other translations
are missing -- we will pick them up on the next milestone.

[endlessm/eos-shell#4588]
