### PR TITLE
Include English apps in Arabic icon grid

### DIFF
--- a/data/settings/icon-grid-Arabic.json
+++ b/data/settings/icon-grid-Arabic.json
@@ -6,6 +6,7 @@
     "rhythmbox.desktop",
     "com.endlessm.photos.desktop",
     "com.endlessm.encyclopedia-ar.desktop",
+    "com.endlessm.virtual-school-en.desktop",
     "com.endlessm.youvideos.desktop",
     "eos-folder-media.directory",
     "eos-folder-games.directory",
@@ -41,9 +42,19 @@
     "libreoffice-calc.desktop",
     "libreoffice-impress.desktop",
     "gnome-calculator.desktop",
+    "com.endlessm.finance.desktop",
+    "com.endlessm.resume.desktop",
     "com.endlessm.translation.desktop"
   ],
   "eos-folder-curiosity.directory" : [
+    "com.endlessm.cooking-en.desktop",
+    "com.endlessm.celebrities-en.desktop",
+    "com.endlessm.myths-en.desktop",
+    "com.endlessm.typing.desktop",
+    "com.endlessm.math-en.desktop",
+    "com.endlessm.howto-en.desktop",
+    "com.endlessm.travel-en.desktop",
+    "com.endlessm.health-en.desktop",
     "marble.desktop",
     "eos-link-duolingo.desktop"
   ],


### PR DESCRIPTION
At the request of our investor in the middle east,
we are including English apps on the Arabic image
to demo what our full version looks like.
Let's do the same for the default icon grid layout,
which is now identical to the Global English version
except for the Arabic version of the encyclopedia.

[endlessm/eos-shell#4706]
