### PR TITLE
tools: Ignore MimeType when merging from content

### DIFF
--- a/tools/eos-content-merge
+++ b/tools/eos-content-merge
@@ -25,7 +25,7 @@ class NoDesktopException(Exception):
 
 class App(object):
     # Fields that are present in CMS, but preferred from upstream
-    IGNORED_FIELDS = ['Exec', 'TryExec', 'Categories']
+    IGNORED_FIELDS = ['Exec', 'TryExec', 'MimeType', 'Categories']
 
     def __init__(self, appid, verbose=False):
         self.appid = appid


### PR DESCRIPTION
The upstream desktop file is the appropriate place to set the MimeType
information. After all the apps have been converted, we can drop the
hardcoded lists in desktop_object.py.

[endlessm/eos-shell#4464]
