### PR TITLE
tools: Match a language app to its base content app

### DIFF
--- a/tools/dh_eoscontent
+++ b/tools/dh_eoscontent
@@ -38,9 +38,18 @@ my $content = JSON->new->utf8->decode($json_text);
 sub app_content {
 	my $app_id=shift;
 	my $package=shift;
+	my $alt_id;
+
+	# If this app ID has a language suffix, also try with the suffix
+	# removed.
+	if ($app_id =~ /(.*)-([a-z][a-z](_[A-Z][A-Z])?)$/) {
+		$alt_id = $1;
+		verbose_print("Also trying alternate ID $alt_id");
+	}
 
 	for my $app (@$content) {
 		return $app if $app_id eq $app->{'application-id'};
+		return $app if $alt_id eq $app->{'application-id'};
 	}
 }
 
@@ -58,6 +67,7 @@ sub app_desktop_file {
 foreach my $package (@{$dh{DOPACKAGES}}) {
 	my $tmp=tmpdir($package);
 	my $app_id=package_eos_app_id($package);
+	my $content_id;
 	my $prefix='/usr';
 	my $app_data;
 	my $desktop;
@@ -66,7 +76,8 @@ foreach my $package (@{$dh{DOPACKAGES}}) {
 
 	$app_data = app_content($app_id, $package);
 	next if not $app_data;
-	verbose_print("Found content for app $app_id");
+	$content_id = $app->{'application-id'};
+	verbose_print("Found content for app $content_id");
 
 	if (get_buildprofile("eos-app")) {
 		# Get the app prefix.
@@ -77,7 +88,7 @@ foreach my $package (@{$dh{DOPACKAGES}}) {
 	next if not $desktop;
 
 	verbose_print("Updating desktop file $desktop");
-	doit("eos-content-merge -i $app_id $desktop");
+	doit("eos-content-merge -i $content_id $desktop");
 }
 
 =head1 SEE ALSO

--- a/tools/eos-content-merge
+++ b/tools/eos-content-merge
@@ -4,6 +4,7 @@
 from configparser import ConfigParser
 import json
 import os
+import re
 import shutil
 import sys
 
@@ -37,9 +38,24 @@ class App(object):
                            CONTENT_FILE)
         with open(CONTENT_FILE) as cf:
             content = json.load(cf)
+
+            # If this app ID has a language suffix, also try with the
+            # suffix removed
+            altid = None
+            langmatch = re.search('(.*)-([a-z][a-z](_[A-Z][A-Z])?)$',
+                                  self.appid)
+            if langmatch:
+                altid = langmatch.group(1)
+                self.verbose_print('Also trying alternate ID', altid)
+
             for app in content:
-                if app['application-id'] == self.appid:
+                content_id = app['application-id']
+                if content_id in [self.appid, altid]:
                     self.content = app
+                    if content_id == altid:
+                        self.appid = altid
+                        self.verbose_print('Using alternate app ID',
+                                           self.appid)
                     break
 
         if self.content is None:


### PR DESCRIPTION
Many Endless apps have a language specific app ID like
com.endlessm.foo-es. However, the CMS only has a base app ID like
com.endlessm.foo so that the content isn't duplicated across all
languages. If the specified app ID has a suffix that looks like a
language, also try with that suffix removed.

This is probably only required in eos-content-merge since no apps that
do this use the debian packaging, but manage it in dh_eoscontent as well
in case that happens at some point.

[endlessm/eos-shell#4464]
