### PR TITLE
eos-content-merge: Sort keys in rewritten desktop file

### DIFF
--- a/tools/eos-content-merge
+++ b/tools/eos-content-merge
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 # -*- Mode: Python; indent-tabs-mode: nil -*-
 
+from collections import OrderedDict
 from configparser import ConfigParser
 import json
 import os
@@ -98,6 +99,24 @@ class App(object):
 
         # Add the X-Endless-Merged field
         outentry['X-Endless-Merged'] = 'true'
+
+        # Reorder the fields such that all translated "Name[..]" keys
+        # are sorted and immediately follow the original "Name" key,
+        # but maintain the original order for all other keys.
+        names = OrderedDict()
+        others = OrderedDict()
+        for item in outentry.items():
+            if item[0].startswith('Name['):
+                names.update([item])
+            else:
+                others.update([item])
+        names = OrderedDict(sorted(names.items(), key=lambda t: t[0]))
+        outentry = OrderedDict()
+        for item in others.items():
+            outentry.update([item])
+            if item[0] == 'Name':
+                outentry.update(names)
+        outdesktop['Desktop Entry'] = outentry
 
         # Output the desktop file
         if inplace:


### PR DESCRIPTION
ConfigParser uses OrderedDict for each section, which maintains the
order that keys were added to it. That means that newly added keys will
always show up at the end of the "Desktop Entry" section.

For most fields this is the desired behavior, but the translated
"Name[..]" keys should be sorted alphabetically and immediately
follow the original "Name" key.  Though this has no impact to the
user experience, it helps when manually reviewing desktop files.

[endlessm/eos-shell#5336]
