### PR TITLE
Shell: Fixed build issues with missing application-store dir

### DIFF
--- a/debian/eos-shell-content.install
+++ b/debian/eos-shell-content.install
@@ -2,7 +2,6 @@ usr/bin/eos-exec-localized
 usr/bin/eos-save-icon-grid
 usr/bin/eos-select-personality
 usr/share/applications
-usr/share/application-store
 usr/share/desktop-directories
 usr/share/EndlessOS
 usr/share/eos-shell-content/*.gresource


### PR DESCRIPTION
We don't need this anymore since everything is now a gresource file.

[endlessm/eos-shell#5872]
