### PR TITLE
Install content.json in dev package

### DIFF
--- a/content/Makefile.am
+++ b/content/Makefile.am
@@ -9,6 +9,9 @@ default_app_json = \
 
 EXTRA_DIST += $(default_app_json)
 
+app_jsondir = $(pkgdatadir)
+app_json_DATA = $(default_app_json)
+
 default_links_json := $(shell cd $(srcdir); for file in `find Default/links -name "*.json"`; do printf "$$file "; done)
 
 EXTRA_DIST += $(default_links_json)

--- a/debian/eos-shell-content-dev.install
+++ b/debian/eos-shell-content-dev.install
@@ -2,5 +2,6 @@ usr/bin/dh_eoscontent
 usr/bin/eos-content-merge
 usr/share/cdbs
 usr/share/eos-shell-content/bundle
+usr/share/eos-shell-content/content.json
 usr/share/man
 usr/share/perl5

--- a/tools/dh_eoscontent
+++ b/tools/dh_eoscontent
@@ -27,7 +27,7 @@ only to desktop files.
 init();
 
 # Parse out content.json
-my $filename = '/usr/share/application-store/Default/apps/content.json';
+my $filename = '/usr/share/eos-shell-content/content.json';
 my $json_text = do {
 	open(CONTENT, "<:encoding(UTF-8)", $filename) ||
 	    error("cannot read $filename: $!\n");

--- a/tools/eos-content-merge
+++ b/tools/eos-content-merge
@@ -9,7 +9,7 @@ import re
 import shutil
 import sys
 
-CONTENT_FILE = '/usr/share/application-store/Default/apps/content.json'
+CONTENT_FILE = '/usr/share/eos-shell-content/content.json'
 
 class NoAppException(Exception):
     def __init__(self, appid):


### PR DESCRIPTION
This is still needed for dh_eoscontent.

[endlessm/eos-shell#5872]
