### PR TITLE
Temporarily remove YouVideos from ARM desktop

### DIFF
--- a/data/settings/arch-blacklist.json
+++ b/data/settings/arch-blacklist.json
@@ -1,5 +1,6 @@
 {
   "arm" : [
+      "com.endlessm.youvideos.desktop",
       "eos-link-spotify.desktop"
   ]
 }


### PR DESCRIPTION
Since the performance is not yet good enough at the default resolution,
let's not highlight this app on the default desktop.

[endlessm/eos-shell#6188]
