### PR TITLE
tools: Adjust the debhelper sequence order for dh_eoscontent

### DIFF
--- a/tools/eoscontent.pm
+++ b/tools/eoscontent.pm
@@ -3,8 +3,8 @@ use warnings;
 use strict;
 use Debian::Debhelper::Dh_Lib;
 
-# Run after dh_eosapp so that files are definitely migrated to the
-# proper location.
-insert_after("dh_eosapp", "dh_eoscontent");
+# Run before dh_fixperms so that installed files are
+# completely settled before fixing permissions.
+insert_before("dh_fixperms", "dh_eoscontent");
 
 1;


### PR DESCRIPTION
dh_eosapp got recently deprecated and removed from the install sequence in
our debhelper, so we can't use it as reference anymore. Otherwise packages
relying on --with=eoscontent won't have dh_eoscontent executed, resulting
in broken .desktop files, with unmerged values (e.g. wrong icons).

Use dh_installdeb as reference to fix this, as all we care is about having
the content merged before that step (and it's probably cleared than using
dh_fixperms instead).

[endlessm/eos-shell#6361]
