### PR TITLE
Fix kde desktop IDs on icon grid

### DIFF
--- a/data/settings/icon-grid-C.json.in
+++ b/data/settings/icon-grid-C.json.in
@@ -29,7 +29,7 @@
     "org.debian.alioth.tux4kids.Tuxmath.desktop",
     "net.gcompris.Gcompris.desktop",
     "org.debian.alioth.tux4kids.Tuxtype.desktop",
-    "org.kde.Ktuberling.desktop",
+    "kde4-org.kde.Ktuberling.desktop",
     "org.maemo.Numptyphysics.desktop",
     "org.debian.Tuxpuck.desktop",
     "net.sourceforge.Rili.desktop",
@@ -53,7 +53,7 @@
     "com.endlessm.howto.en.desktop",
     "com.endlessm.travel.en.desktop",
     "com.endlessm.health.en.desktop",
-    "org.kde.Marble.desktop",
+    "kde4-org.kde.Marble.desktop",
     "eos-link-duolingo.desktop"
   ],
   "eos-folder-social.directory" : [

--- a/data/settings/icon-grid-ar.json.in
+++ b/data/settings/icon-grid-ar.json.in
@@ -29,7 +29,7 @@
     "org.debian.alioth.tux4kids.Tuxmath.desktop",
     "net.gcompris.Gcompris.desktop",
     "org.debian.alioth.tux4kids.Tuxtype.desktop",
-    "org.kde.Ktuberling.desktop",
+    "kde4-org.kde.Ktuberling.desktop",
     "org.maemo.Numptyphysics.desktop",
     "org.debian.Tuxpuck.desktop",
     "net.sourceforge.Rili.desktop",
@@ -48,7 +48,7 @@
   "eos-folder-curiosity.directory" : [
     "com.endlessm.cooking.ar.desktop",
     "com.endlessm.health.ar.desktop",
-    "org.kde.Marble.desktop",
+    "kde4-org.kde.Marble.desktop",
     "eos-link-duolingo.desktop"
   ],
   "eos-folder-social.directory" : [

--- a/data/settings/icon-grid-bn.json.in
+++ b/data/settings/icon-grid-bn.json.in
@@ -29,7 +29,7 @@
     "org.debian.alioth.tux4kids.Tuxmath.desktop",
     "net.gcompris.Gcompris.desktop",
     "org.debian.alioth.tux4kids.Tuxtype.desktop",
-    "org.kde.Ktuberling.desktop",
+    "kde4-org.kde.Ktuberling.desktop",
     "org.maemo.Numptyphysics.desktop",
     "org.debian.Tuxpuck.desktop",
     "net.sourceforge.Rili.desktop",
@@ -46,7 +46,7 @@
     "com.endlessm.translation.desktop"
   ],
   "eos-folder-curiosity.directory" : [
-    "org.kde.Marble.desktop",
+    "kde4-org.kde.Marble.desktop",
     "eos-link-duolingo.desktop"
   ],
   "eos-folder-social.directory" : [

--- a/data/settings/icon-grid-es.json.in
+++ b/data/settings/icon-grid-es.json.in
@@ -29,7 +29,7 @@
     "org.debian.alioth.tux4kids.Tuxmath.desktop",
     "net.gcompris.Gcompris.desktop",
     "org.debian.alioth.tux4kids.Tuxtype.desktop",
-    "org.kde.Ktuberling.desktop",
+    "kde4-org.kde.Ktuberling.desktop",
     "org.maemo.Numptyphysics.desktop",
     "org.debian.Tuxpuck.desktop",
     "net.sourceforge.Rili.desktop",
@@ -51,7 +51,7 @@
     "com.endlessm.howto.es.desktop",
     "com.endlessm.travel.es.desktop",
     "com.endlessm.health.es.desktop",
-    "org.kde.Marble.desktop",
+    "kde4-org.kde.Marble.desktop",
     "eos-link-duolingo.desktop",
     "com.endlessm.maternity.es.desktop",
     "com.endlessm.world_literature.es.desktop"

--- a/data/settings/icon-grid-es_GT.json.in
+++ b/data/settings/icon-grid-es_GT.json.in
@@ -31,7 +31,7 @@
     "org.debian.alioth.tux4kids.Tuxmath.desktop",
     "net.gcompris.Gcompris.desktop",
     "org.debian.alioth.tux4kids.Tuxtype.desktop",
-    "org.kde.Ktuberling.desktop",
+    "kde4-org.kde.Ktuberling.desktop",
     "org.maemo.Numptyphysics.desktop",
     "org.debian.Tuxpuck.desktop",
     "net.sourceforge.Rili.desktop",
@@ -56,7 +56,7 @@
     "com.endlessm.howto.es.desktop",
     "com.endlessm.travel.es_GT.desktop",
     "com.endlessm.health.es.desktop",
-    "org.kde.Marble.desktop",
+    "kde4-org.kde.Marble.desktop",
     "eos-link-duolingo.desktop"
   ],
   "eos-folder-social.directory" : [

--- a/data/settings/icon-grid-fr.json.in
+++ b/data/settings/icon-grid-fr.json.in
@@ -29,7 +29,7 @@
     "org.debian.alioth.tux4kids.Tuxmath.desktop",
     "net.gcompris.Gcompris.desktop",
     "org.debian.alioth.tux4kids.Tuxtype.desktop",
-    "org.kde.Ktuberling.desktop",
+    "kde4-org.kde.Ktuberling.desktop",
     "org.maemo.Numptyphysics.desktop",
     "org.debian.Tuxpuck.desktop",
     "net.sourceforge.Rili.desktop",
@@ -46,7 +46,7 @@
     "com.endlessm.translation.desktop"
   ],
   "eos-folder-curiosity.directory" : [
-    "org.kde.Marble.desktop",
+    "kde4-org.kde.Marble.desktop",
     "eos-link-duolingo.desktop"
   ],
   "eos-folder-social.directory" : [

--- a/data/settings/icon-grid-pt.json.in
+++ b/data/settings/icon-grid-pt.json.in
@@ -29,7 +29,7 @@
     "org.debian.alioth.tux4kids.Tuxmath.desktop",
     "net.gcompris.Gcompris.desktop",
     "org.debian.alioth.tux4kids.Tuxtype.desktop",
-    "org.kde.Ktuberling.desktop",
+    "kde4-org.kde.Ktuberling.desktop",
     "org.maemo.Numptyphysics.desktop",
     "org.debian.Tuxpuck.desktop",
     "net.sourceforge.Rili.desktop",
@@ -51,7 +51,7 @@
     "com.endlessm.howto.pt.desktop",
     "com.endlessm.travel.pt.desktop",
     "com.endlessm.health.pt.desktop",
-    "org.kde.Marble.desktop",
+    "kde4-org.kde.Marble.desktop",
     "eos-link-duolingo.desktop",
     "com.endlessm.maternity.pt.desktop"
   ],

--- a/data/settings/icon-grid-zh_CN.json.in
+++ b/data/settings/icon-grid-zh_CN.json.in
@@ -8,8 +8,8 @@
     "eos-folder-games.directory",
     "eos-folder-social.directory",
     "eos-link-duolingo.desktop",
-    "org.kde.Kwordquiz.desktop",
-    "org.kde.Kbruch.desktop",
+    "kde4-org.kde.Kwordquiz.desktop",
+    "kde4-org.kde.Kbruch.desktop",
     "gnome-control-center.desktop"
   ],
   "eos-folder-curiosity.directory" : [
@@ -40,7 +40,7 @@
     "org.debian.alioth.tux4kids.Tuxmath.desktop",
     "net.gcompris.Gcompris.desktop",
     "org.debian.alioth.tux4kids.Tuxtype.desktop",
-    "org.kde.Ktuberling.desktop",
+    "kde4-org.kde.Ktuberling.desktop",
     "org.maemo.Numptyphysics.desktop",
     "org.debian.Tuxpuck.desktop",
     "net.sourceforge.Rili.desktop",


### PR DESCRIPTION
Due to the way the flatpak directory structure is organized,
the dekstop IDs have a "kde4-" prefix before the app ID.

https://phabricator.endlessm.com/T12968