### PR TITLE
icon-grid: add eos-installer icon (when image-booted)

### DIFF
--- a/data/settings/icon-grid-C.json.in
+++ b/data/settings/icon-grid-C.json.in
@@ -12,7 +12,8 @@
     "eos-folder-games.directory",
     "eos-folder-work.directory",
     "eos-folder-curiosity.directory",
-    "eos-folder-social.directory"
+    "eos-folder-social.directory",
+    "eos-installer.desktop"
   ],
   "eos-folder-media.directory" : [
     "shotwell.desktop",

--- a/data/settings/icon-grid-ar.json.in
+++ b/data/settings/icon-grid-ar.json.in
@@ -12,7 +12,8 @@
     "eos-folder-games.directory",
     "eos-folder-work.directory",
     "eos-folder-curiosity.directory",
-    "eos-folder-social.directory"
+    "eos-folder-social.directory",
+    "eos-installer.desktop"
   ],
   "eos-folder-media.directory" : [
     "shotwell.desktop",

--- a/data/settings/icon-grid-bn.json.in
+++ b/data/settings/icon-grid-bn.json.in
@@ -12,7 +12,8 @@
     "eos-folder-games.directory",
     "eos-folder-work.directory",
     "eos-folder-curiosity.directory",
-    "eos-folder-social.directory"
+    "eos-folder-social.directory",
+    "eos-installer.desktop"
   ],
   "eos-folder-media.directory" : [
     "shotwell.desktop",

--- a/data/settings/icon-grid-es.json.in
+++ b/data/settings/icon-grid-es.json.in
@@ -12,7 +12,8 @@
     "eos-folder-games.directory",
     "eos-folder-work.directory",
     "eos-folder-curiosity.directory",
-    "eos-folder-social.directory"
+    "eos-folder-social.directory",
+    "eos-installer.desktop"
   ],
   "eos-folder-media.directory" : [
     "shotwell.desktop",

--- a/data/settings/icon-grid-es_GT.json.in
+++ b/data/settings/icon-grid-es_GT.json.in
@@ -12,7 +12,8 @@
     "eos-folder-games.directory",
     "eos-folder-work.directory",
     "eos-folder-curiosity.directory",
-    "eos-folder-social.directory"
+    "eos-folder-social.directory",
+    "eos-installer.desktop"
   ],
   "eos-folder-media.directory" : [
     "shotwell.desktop",

--- a/data/settings/icon-grid-fr.json.in
+++ b/data/settings/icon-grid-fr.json.in
@@ -12,7 +12,8 @@
     "eos-folder-games.directory",
     "eos-folder-work.directory",
     "eos-folder-curiosity.directory",
-    "eos-folder-social.directory"
+    "eos-folder-social.directory",
+    "eos-installer.desktop"
   ],
   "eos-folder-media.directory" : [
     "shotwell.desktop",

--- a/data/settings/icon-grid-pt.json.in
+++ b/data/settings/icon-grid-pt.json.in
@@ -12,7 +12,8 @@
     "eos-folder-games.directory",
     "eos-folder-work.directory",
     "eos-folder-curiosity.directory",
-    "eos-folder-social.directory"
+    "eos-folder-social.directory",
+    "eos-installer.desktop"
   ],
   "eos-folder-media.directory" : [
     "shotwell.desktop",

--- a/data/settings/icon-grid-zh_CN.json.in
+++ b/data/settings/icon-grid-zh_CN.json.in
@@ -10,7 +10,8 @@
     "eos-link-duolingo.desktop",
     "kde4-org.kde.Kwordquiz.desktop",
     "kde4-org.kde.Kbruch.desktop",
-    "gnome-control-center.desktop"
+    "gnome-control-center.desktop",
+    "eos-installer.desktop"
   ],
   "eos-folder-curiosity.directory" : [
     "com.endlessm.chinese_curriculum_math.zh_CN.desktop",


### PR DESCRIPTION
In general, this will actually have no effect: the grid ignores desktop
files that don't exist, and the eos-installer.desktop file generally
does not exist.

But when we are booted from an installable image, eos-installer.desktop
will be magicked into place. This way, if the user opts to "Try Endless"
during the FBE, they can still run eos-installer without rebooting.

https://phabricator.endlessm.com/T12548