### PR TITLE
Revert "extra-categories: Add the 'Blacklisted' category for Google C…

### DIFF
--- a/extra_categories.py
+++ b/extra_categories.py
@@ -43,6 +43,5 @@ EXTRA_CATEGORIES = {
     'com.endlessm.videonet': ['Education', 'Family'],
     'com.endlessm.water_and_sanitation': ['Family'],
     'com.endlessm.weather': ['Utility', 'Family'],
-    'com.endlessm.your_health': ['Family'],
-    'com.google.Chrome': ['Blacklisted']
+    'com.endlessm.your_health': ['Family']
 }


### PR DESCRIPTION
…hrome"

This reverts commit 1d65ebeb671dfec3203c57e4e6a03f7392de3df1 and is
necessary because GNOME Software is not showing Google Chrome in the
installed view. The original intention was to keep it blacklisted only
for a couple of releases to give time for users to update to >=3.0.7 and
so far there have been 5 releases.

https://phabricator.endlessm.com/T15076