### PR TITLE
Pull translation info in content.json from CMS

### DIFF
--- a/bundle/translations.json
+++ b/bundle/translations.json
@@ -1,0 +1,82 @@
+{
+    "com.endlessm.animals.bn_BD": {
+        "translation_id": "eos-subscriptions-apps",
+        "translation_type": "gettext"
+    },
+    "com.endlessm.bengali_curriculum.bn_BD": {
+        "translation_id": "eos-subscriptions-apps",
+        "translation_type": "gettext"
+    },
+    "com.endlessm.celebrities.bn_BD": {
+        "translation_id": "eos-subscriptions-apps",
+        "translation_type": "gettext"
+    },
+    "com.endlessm.textbooks": {
+        "translation_id": "eos-subscriptions-apps",
+        "translation_type": "gettext"
+    },
+    "com.endlessm.translation": {
+        "translation_id": "eos-translation",
+        "translation_type": "gettext"
+    },
+    "com.endlessm.travel": {
+        "translation_id": "eos-subscriptions-apps",
+        "translation_type": "gettext"
+    },
+    "com.endlessm.videonet": {
+        "translation_id": "eos-videonet",
+        "translation_type": "gettext"
+    },
+    "com.endlessm.weather": {
+        "translation_id": "eos-weather",
+        "translation_type": "gettext"
+    },
+    "com.endlessm.your_health": {
+        "translation_id": "eos-subscriptions-apps",
+        "translation_type": "gettext"
+    },
+    "net.sourceforge.Tuxfootball": {
+        "translation_id": "tuxfootball",
+        "translation_type": "gettext"
+    },
+    "net.sourceforge.Warmux": {
+        "translation_id": "warmux",
+        "translation_type": "gettext"
+    },
+    "net.wz2100.Warzone2100": {
+        "translation_id": "warzone2100",
+        "translation_type": "gettext"
+    },
+    "org.debian.alioth.tux4kids.Tuxmath": {
+        "translation_id": "tuxmath",
+        "translation_type": "gettext"
+    },
+    "org.debian.alioth.tux4kids.Tuxtype": {
+        "translation_id": "tuxtype",
+        "translation_type": "gettext"
+    },
+    "org.gnome.Terminal": {
+        "translation_id": "gnome-terminal",
+        "translation_type": "gettext"
+    },
+    "org.gnome.Tetravex": {
+        "translation_id": "gnome-tetravex",
+        "translation_type": "gettext"
+    },
+    "org.gnome.Totem": {
+        "translation_id": "totem",
+        "translation_type": "gettext"
+    },
+    "org.pitivi.Pitivi": {
+        "translation_id": "pitivi",
+        "translation_type": "gettext"
+    },
+    "org.sugarlabs.Turtleblocks": {
+        "translation_id": "org.laptop.TurtleArtActivity",
+        "translation_type": "gettext"
+    },
+    "org.tuxfamily.Xmoto": {
+        "translation_id": "xmoto",
+        "translation_type": "gettext"
+    }
+}

--- a/content/Default/apps/content.json
+++ b/content/Default/apps/content.json
@@ -29,6 +29,8 @@
     "square_img": "brasero-thumb.jpg",
     "subtitle": "Burn your own CDs and DVDs",
     "title": "Brasero",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -67,6 +69,8 @@
     "square_img": "cheese-thumb.jpg",
     "subtitle": "Take funny pictures of yourself and your friends",
     "title": "Cheese",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -100,6 +104,8 @@
     "square_img": "chromium-browser-thumb.jpg",
     "subtitle": "Browse the Web",
     "title": "Internet",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -135,6 +141,8 @@
     "square_img": "com.dropbox.client-thumb.jpg",
     "subtitle": "Access your files from any computer",
     "title": "Dropbox",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -163,6 +171,8 @@
     "square_img": "com.endlessm.animals.bn_bd-thumb.jpg",
     "subtitle": "\u09aa\u09c3\u09a5\u09bf\u09ac\u09c0\u09b0 \u09aa\u09b6\u09c1\u09aa\u09be\u0996\u09bf \u09b8\u09ae\u09cd\u09aa\u09b0\u09cd\u0995\u09c7 \u099c\u09be\u09a8\u09c1\u09a8",
     "title": "\u09aa\u09b6\u09c1\u09aa\u09be\u0996\u09bf",
+    "translation_id": "eos-subscriptions-apps",
+    "translation_type": "gettext",
     "tryexec": ""
   },
   {
@@ -191,6 +201,8 @@
     "square_img": "com.endlessm.animals.en-thumb.jpg",
     "subtitle": "Learn about all of Earth's creatures",
     "title": "Animals",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -220,6 +232,8 @@
     "square_img": "com.endlessm.animals.es-thumb.jpg",
     "subtitle": "Aprende acerca de las criaturas de la Tierra",
     "title": "Animales",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -248,6 +262,8 @@
     "square_img": "com.endlessm.animals.es_gt-thumb.jpg",
     "subtitle": "Aprende acerca de las criaturas de la Tierra",
     "title": "Animales",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -276,6 +292,8 @@
     "square_img": "com.endlessm.animals.pt-thumb.jpg",
     "subtitle": "Aprenda mais sobre todas as criaturas da Terra.",
     "title": "Animais",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -304,6 +322,8 @@
     "square_img": "com.endlessm.astronomy.en-thumb.jpg",
     "subtitle": "Learn about the universe and all it contains",
     "title": "Astronomy",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -332,6 +352,8 @@
     "square_img": "com.endlessm.astronomy.es-thumb.jpg",
     "subtitle": "Explora el universo y todo lo que contiene",
     "title": "Astronom\u00eda",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -360,6 +382,8 @@
     "square_img": "com.endlessm.astronomy.pt-thumb.jpg",
     "subtitle": "Aprenda sobre o universo e tudo que cont\u00e9m nele",
     "title": "Astronomia",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -388,6 +412,8 @@
     "square_img": "com.endlessm.bengali_curriculum.bn_bd-thumb.jpg",
     "subtitle": "\u09b8\u09ac \u09ac\u09bf\u09b7\u09af\u09bc\u09c7 \u099c\u09be\u09a4\u09c0\u09af\u09bc \u09aa\u09be\u09a0\u09cd\u09af\u09aa\u09c1\u09b8\u09cd\u09a4\u0995",
     "title": "\u099c\u09be\u09a4\u09c0\u09df \u09aa\u09be\u09a0\u09cd\u09af\u09aa\u09c1\u09b8\u09cd\u09a4\u0995",
+    "translation_id": "eos-subscriptions-apps",
+    "translation_type": "gettext",
     "tryexec": ""
   },
   {
@@ -416,6 +442,8 @@
     "square_img": "com.endlessm.biology.en-thumb.jpg",
     "subtitle": "Learn all about the living world around you",
     "title": "Biology",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -444,6 +472,8 @@
     "square_img": "com.endlessm.biology.es-thumb.jpg",
     "subtitle": "Aprende sobre la vida en el mundo que te rodea",
     "title": "Biolog\u00eda",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -472,6 +502,8 @@
     "square_img": "com.endlessm.biology.pt-thumb.jpg",
     "subtitle": "Aprenda tudo sobre o mundo vivo ao seu redor",
     "title": "Biologia",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -505,6 +537,8 @@
     "square_img": "com.endlessm.capacitate_services-thumb.jpg",
     "subtitle": "Learn the necessary skills for a job in Servicio al Cliente",
     "title": "Client Services Courses",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -538,6 +572,8 @@
     "square_img": "com.endlessm.capacitate_technology-thumb.jpg",
     "subtitle": "Learn the necessary skills for a career in tecnolog\u00eda.",
     "title": "Technology courses",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -566,6 +602,8 @@
     "square_img": "com.endlessm.celebrities.bn_bd-thumb.jpg",
     "subtitle": "\u0986\u09aa\u09a8\u09be\u09b0 \u09aa\u09cd\u09b0\u09bf\u09df \u0995\u09c0\u09b0\u09cd\u09a4\u09bf\u09ae\u09be\u09a8 \u09ac\u09cd\u09af\u0995\u09cd\u09a4\u09bf\u09a6\u09c7\u09b0 \u09b8\u09ae\u09cd\u09aa\u09b0\u09cd\u0995\u09c7 \u0986\u09b0\u09cb \u099c\u09be\u09a8\u09c1\u09a8",
     "title": "\u0995\u09c0\u09b0\u09cd\u09a4\u09bf\u09ae\u09be\u09a8 \u09ac\u09cd\u09af\u0995\u09cd\u09a4\u09bf\u09a4\u09cd\u09ac",
+    "translation_id": "eos-subscriptions-apps",
+    "translation_type": "gettext",
     "tryexec": ""
   },
   {
@@ -594,6 +632,8 @@
     "square_img": "com.endlessm.celebrities.en-thumb.jpg",
     "subtitle": "Learn more about your favorite celebrities",
     "title": "Celebrities",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -622,6 +662,8 @@
     "square_img": "com.endlessm.celebrities.es-thumb.jpg",
     "subtitle": "Informaci\u00f3n y chisme sobre los m\u00e1s famosos",
     "title": "Celebridades",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -650,6 +692,8 @@
     "square_img": "com.endlessm.celebrities.es_gt-thumb.jpg",
     "subtitle": "Informaci\u00f3n y chisme sobre los m\u00e1s famosos",
     "title": "Celebridades",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -678,6 +722,8 @@
     "square_img": "com.endlessm.celebrities.pt-thumb.jpg",
     "subtitle": "Saiba mais sobre suas celebridades favoritas",
     "title": "Celebridades",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -711,6 +757,8 @@
     "square_img": "com.endlessm.childrens_collection-thumb.jpg",
     "subtitle": "Short stories that will delight the whole family",
     "title": "Children's Collection",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -744,6 +792,8 @@
     "square_img": "com.endlessm.chinese_curriculum_english-thumb.jpg",
     "subtitle": "Primary English curriculum practice",
     "title": "Learn English Curriculum",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -777,6 +827,8 @@
     "square_img": "com.endlessm.chinese_curriculum_math-thumb.jpg",
     "subtitle": "Primary mathematics curriculum practice",
     "title": "Math Curriculum",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -820,6 +872,8 @@
     "square_img": "com.endlessm.cooking-thumb.jpg",
     "subtitle": "Delicious recipes and tips for cooking",
     "title": "Cooking",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -853,6 +907,8 @@
     "square_img": "com.endlessm.creativity_center-thumb.jpg",
     "subtitle": "Drawing, painting, music, and so much more",
     "title": "Creativity Center",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -891,6 +947,8 @@
     "square_img": "com.endlessm.dinosaurs-thumb.jpg",
     "subtitle": "Bringing prehistory back to life for you to discover anew",
     "title": "Dinosaurs",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -924,6 +982,8 @@
     "square_img": "com.endlessm.disabilities-thumb.jpg",
     "subtitle": "Learn how to provide the best care",
     "title": "Disabilities",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -958,6 +1018,8 @@
     "square_img": "com.endlessm.diy-thumb.jpg",
     "subtitle": "Guidelines to create a wide variety of items",
     "title": "DIY",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -986,6 +1048,8 @@
     "square_img": "com.endlessm.edu_collections.es_gt-thumb.jpg",
     "subtitle": "Todo tipo de informaci\u00f3n a tu dispocisi\u00f3n con un cl",
     "title": "EduColecciones",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -1024,6 +1088,8 @@
     "square_img": "com.endlessm.encyclopedia-thumb.jpg",
     "subtitle": "The free encyclopedia that anyone can contribute to",
     "title": "Encyclopedia",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -1058,6 +1124,8 @@
     "square_img": "com.endlessm.entrepreneurship-thumb.jpg",
     "subtitle": "Business advice for your inner entrepreneur",
     "title": "Entrepreneurship",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -1085,6 +1153,8 @@
     "square_img": "com.endlessm.extra-thumb.jpg",
     "subtitle": "News that affects your day to day",
     "title": "Extra",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -1123,6 +1193,8 @@
     "square_img": "com.endlessm.farming-thumb.jpg",
     "subtitle": "Learn about crops and raising animals",
     "title": "Farming",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -1161,6 +1233,8 @@
     "square_img": "com.endlessm.finance-thumb.jpg",
     "subtitle": "Learn how to create your own budget and save",
     "title": "My Budget",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -1194,6 +1268,8 @@
     "square_img": "com.endlessm.fitness-thumb.jpg",
     "subtitle": "Tips for excercise and healthy living",
     "title": "Fitness",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -1222,6 +1298,8 @@
     "square_img": "com.endlessm.fnde_foreign_library.pt_br-thumb.jpg",
     "subtitle": "MEC - Biblioteca com mais de 500 cl\u00e1ssicos populares em l\u00edngua estrangeira",
     "title": "MEC Library",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -1250,6 +1328,8 @@
     "square_img": "com.endlessm.fnde_library.pt_br-thumb.jpg",
     "subtitle": "MEC - Biblioteca com aproximadamente 1000 livros cl\u00e1ssicos em portug\u00eas para crian\u00e7as, jovens e adult",
     "title": "MEC Biblioteca",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -1278,6 +1358,8 @@
     "square_img": "com.endlessm.fnde_mec_culture_studies.pt_br-thumb.jpg",
     "subtitle": "TV Escola - MEC: Depoimentos de \u00edndios brasileiros e estrangeiros que vivem no Brasil",
     "title": "Pluralidade Cultural",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -1306,6 +1388,8 @@
     "square_img": "com.endlessm.fnde_mec_education.pt_br-thumb.jpg",
     "subtitle": "TV Escola - MEC: A organiza\u00e7\u00e3o e o planejamento escolar em uma s\u00e9rie de v\u00eddeos para educadores",
     "title": "Escola Educa\u00e7\u00e3o",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -1334,6 +1418,8 @@
     "square_img": "com.endlessm.fnde_mec_ethics.pt_br-thumb.jpg",
     "subtitle": "TV Escola - MEC: S\u00e9rie discute problemas causados por viol\u00eancia, armas e drogas",
     "title": "Direitos Humanos",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -1362,6 +1448,8 @@
     "square_img": "com.endlessm.fnde_mec_future_education.pt_br-thumb.jpg",
     "subtitle": "TV Escola - MEC: Principais temas relacionados \u00e0 Educa\u00e7\u00e3o em debate",
     "title": "Salto para o Futuro Educa\u00e7\u00e3o",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -1390,6 +1478,8 @@
     "square_img": "com.endlessm.fnde_mec_geography.pt_br-thumb.jpg",
     "subtitle": "TV Escola - MEC: Viaje pelas mais belas paisagens do Brasil",
     "title": "Momento Brasil",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -1418,6 +1508,8 @@
     "square_img": "com.endlessm.fnde_mec_health.pt_br-thumb.jpg",
     "subtitle": "TV Escola - MEC: Entenda e aprenda a prevenir acne, manchas de sol e outras doen\u00e7as de pele",
     "title": "Gera\u00e7\u00e3o Sa\u00fade",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -1446,6 +1538,8 @@
     "square_img": "com.endlessm.fnde_mec_high_school.pt_br-thumb.jpg",
     "subtitle": "TV Escola - MEC: Experi\u00eancias escolare para aprimorar o Ensino M\u00e9dio",
     "title": "Ensino M\u00e9dio",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -1474,6 +1568,8 @@
     "square_img": "com.endlessm.fnde_mec_history.pt_br-thumb.jpg",
     "subtitle": "TV Escola - MEC: Document\u00e1rios sobre diferentes per\u00edodos da Hist\u00f3ria do Brasil",
     "title": "Hist\u00f3ria do Brasil",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -1502,6 +1598,8 @@
     "square_img": "com.endlessm.fnde_mec_literature.pt_br-thumb.jpg",
     "subtitle": "TV Escola - MEC: Conta\u00e7\u00e3o de hist\u00f3rias para crian\u00e7as e as hist\u00f3rias dos grandes mestres da Literatur",
     "title": "Literatura",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -1530,6 +1628,8 @@
     "square_img": "com.endlessm.fnde_mec_mathematics.pt_br-thumb.jpg",
     "subtitle": "TV Escola - MEC: A matem\u00e1tica e suas aplica\u00e7\u00f5es na vida e nas artes",
     "title": "Matem\u00e1tica",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -1558,6 +1658,8 @@
     "square_img": "com.endlessm.fnde_mec_physical_education.pt_br-thumb.jpg",
     "subtitle": "TV Escola - MEC: Programa voltado para professores para enriquecer as aulas de Educa\u00e7\u00e3o F\u00edsica",
     "title": "Esporte na Escola",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -1586,6 +1688,8 @@
     "square_img": "com.endlessm.fnde_mec_portuguese.pt_br-thumb.jpg",
     "subtitle": "TV Escola - MEC: A import\u00e2ncia da escrita e da leitura da sociedade",
     "title": "Lingua Portuguesa",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -1614,6 +1718,8 @@
     "square_img": "com.endlessm.fnde_mec_science.pt_br-thumb.jpg",
     "subtitle": "TV Escola - MEC: Curiosidades sobre o mundo com a personagem infantil Kika",
     "title": "De onde vem?",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -1642,6 +1748,8 @@
     "square_img": "com.endlessm.fnde_mec_special_education.pt_br-thumb.jpg",
     "subtitle": "TV Escola - MEC: Desafios e oportuidades para pessoas com defici\u00eancia f\u00edsica e intelectual",
     "title": "Educa\u00e7\u00e3o Especial",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -1680,6 +1788,8 @@
     "square_img": "com.endlessm.geography-thumb.jpg",
     "subtitle": "Learn about all the countries in the world",
     "title": "Geography",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -1714,6 +1824,8 @@
     "square_img": "com.endlessm.guatemala-thumb.jpg",
     "subtitle": "Learn more about this beautiful country",
     "title": "Guatemala",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -1747,6 +1859,8 @@
     "square_img": "com.endlessm.guatemalan_curriculum-thumb.jpg",
     "subtitle": "From the Guatemalan Ministry of Education",
     "title": "Curriculum",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -1781,6 +1895,8 @@
     "square_img": "com.endlessm.handicrafts-thumb.jpg",
     "subtitle": "Learn how to make the most beautiful handicrafts",
     "title": "Handicrafts",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -1819,6 +1935,8 @@
     "square_img": "com.endlessm.health-thumb.jpg",
     "subtitle": "Keep yourself and loved ones healthy",
     "title": "Health",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -1852,6 +1970,8 @@
     "square_img": "com.endlessm.healthy_living-thumb.jpg",
     "subtitle": "Discover what it takes to stay healthy",
     "title": "Healthy Living",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -1885,6 +2005,8 @@
     "square_img": "com.endlessm.healthy_teeth-thumb.jpg",
     "subtitle": "Learn to take care of your teeth",
     "title": "Healthy Teeth",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -1923,6 +2045,8 @@
     "square_img": "com.endlessm.history-thumb.jpg",
     "subtitle": "Learn about the world's events and civilizations",
     "title": "History",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -1961,6 +2085,8 @@
     "square_img": "com.endlessm.howto-thumb.jpg",
     "subtitle": "How-to do just about anything by yourself",
     "title": "How To",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -1994,6 +2120,8 @@
     "square_img": "com.endlessm.library-thumb.jpg",
     "subtitle": "Literary classics for all ages",
     "title": "Library",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -2027,6 +2155,8 @@
     "square_img": "com.endlessm.maternity-thumb.jpg",
     "subtitle": "Valuable information for new mothers",
     "title": "Maternity",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -2065,6 +2195,8 @@
     "square_img": "com.endlessm.math-thumb.jpg",
     "subtitle": "High school math made simple and accessible",
     "title": "Math",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -2094,6 +2226,8 @@
     "square_img": "com.endlessm.mayan_languages-thumb.jpg",
     "subtitle": "Stories and dictionaries in Mayan languages",
     "title": "Mayan Languages",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -2128,6 +2262,8 @@
     "square_img": "com.endlessm.mental_health-thumb.jpg",
     "subtitle": "Tips and tricks for living a healthier, happier life",
     "title": "Mental Health",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -2161,6 +2297,8 @@
     "square_img": "com.endlessm.microenterprises-thumb.jpg",
     "subtitle": "Learn to run your own company",
     "title": "Microenterprises",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -2199,6 +2337,8 @@
     "square_img": "com.endlessm.myths-thumb.jpg",
     "subtitle": "Myths and legends from around the world",
     "title": "Myths & Legends",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -2232,6 +2372,8 @@
     "square_img": "com.endlessm.paraguayan_constitution-thumb.jpg",
     "subtitle": "La entera Constituci\u00f3n de la Rep\u00fablica del Paraguay",
     "title": "La Constituci\u00f3n",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -2270,6 +2412,8 @@
     "square_img": "com.endlessm.photos-thumb.jpg",
     "subtitle": "Easily edit and share all of your favorite photos",
     "title": "Photo Editor",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -2308,6 +2452,8 @@
     "square_img": "com.endlessm.physics-thumb.jpg",
     "subtitle": "Learn about the physical world's mysteries",
     "title": "Physics",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -2336,6 +2482,8 @@
     "square_img": "com.endlessm.prensa_libre-thumb.jpg",
     "subtitle": "All the news about Guatemala and the world",
     "title": "Prensa Libre",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -2374,6 +2522,8 @@
     "square_img": "com.endlessm.programming-thumb.jpg",
     "subtitle": "Learn to create your own video games",
     "title": "Coding Fun",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -2412,6 +2562,8 @@
     "square_img": "com.endlessm.programming_guide-thumb.jpg",
     "subtitle": "Learn the basics of front-end web development with this app",
     "title": "Programming",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -2439,6 +2591,8 @@
     "square_img": "com.endlessm.publimetro-thumb.jpg",
     "subtitle": "The global newspaper about breaking news in Mexico and the world",
     "title": "Publimetro",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -2477,6 +2631,8 @@
     "square_img": "com.endlessm.resume-thumb.jpg",
     "subtitle": "Write a great resume and prepare for interviews",
     "title": "R\u00e9sum\u00e9",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -2499,6 +2655,8 @@
     "square_img": "com.endlessm.sinadep_curso3.es-thumb.jpg",
     "subtitle": "Este curso de SINADEP demuestra c\u00f3mo usar una aplicaci\u00f3n m\u00f3vil para digitalizar el aprendizaje",
     "title": "Expediente de Evidencias",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -2521,6 +2679,8 @@
     "square_img": "com.endlessm.sinadep_curso4.es-thumb.jpg",
     "subtitle": "Este curso de SINADEP discute el ejercicio cotidiano de la pr\u00e1ctica profesional docente",
     "title": "Planeaci\u00f3n did\u00e1ctica",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -2543,6 +2703,8 @@
     "square_img": "com.endlessm.sinadep_curso5_educacionpaz.es-thumb.jpg",
     "subtitle": "Este curso de SINADEP explora el concepto de educaci\u00f3n para la paz",
     "title": "Educaci\u00f3n para la Paz",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -2565,6 +2727,8 @@
     "square_img": "com.endlessm.sinadep_curso6_usodelexcel.es-thumb.jpg",
     "subtitle": "Este curso de SINADEP discute los conocimientos b\u00e1sicos de Excel",
     "title": "El uso del excel",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -2603,6 +2767,8 @@
     "square_img": "com.endlessm.soccer-thumb.jpg",
     "subtitle": "Learn about your favorite team and players",
     "title": "Football",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -2636,6 +2802,8 @@
     "square_img": "com.endlessm.social_enterprises-thumb.jpg",
     "subtitle": "All about non-profit organizations",
     "title": "Social Enterprises",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -2674,6 +2842,8 @@
     "square_img": "com.endlessm.socialsciences-thumb.jpg",
     "subtitle": "Subjects that explore the individual and society",
     "title": "Social Sciences",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -2707,6 +2877,8 @@
     "square_img": "com.endlessm.spanish_guarani_dictionary-thumb.jpg",
     "subtitle": "Diccionario biling\u00fce de Castellano-Guaran\u00ed y Guaran\u00ed-Castellano",
     "title": "Diccionario Guaran\u00ed",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -2735,6 +2907,8 @@
     "square_img": "com.endlessm.teachers_portal_fundamental_final.pt_br-thumb.jpg",
     "subtitle": "Sugest\u00f5es de aulas para o Ensino fundamental final retiradas do Portal do Professor - MEC",
     "title": "Fundamental 2",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -2763,6 +2937,8 @@
     "square_img": "com.endlessm.teachers_portal_fundamental_initial.pt_br-thumb.jpg",
     "subtitle": "Sugest\u00f5es de aulas para o Ensino fundamental inicial retiradas do Portal do Professor - MEC",
     "title": "Fundamental 1",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -2791,6 +2967,8 @@
     "square_img": "com.endlessm.teachers_portal_high_school.pt_br-thumb.jpg",
     "subtitle": "Sugest\u00f5es de aulas para as disciplinas do Ensino M\u00e9dio retiradas do Portal do Professor - MEC",
     "title": "Ensino M\u00e9dio",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -2819,6 +2997,8 @@
     "square_img": "com.endlessm.teachers_portal_kindergarten.pt_br-thumb.jpg",
     "subtitle": "Sugest\u00f5es de aulas para professores de Educa\u00e7\u00e3o Infantil retiradas do Portal do Professor - MEC ",
     "title": "Educa\u00e7\u00e3o Infantil",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -2847,6 +3027,8 @@
     "square_img": "com.endlessm.teachers_portal_professional.pt_br-thumb.jpg",
     "subtitle": "Sugest\u00f5es de aulas para cursos de Educa\u00e7\u00e3o Profissional retiradas do Portal do Professor - MEC",
     "title": "Educa\u00e7\u00e3o Profissional",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -2880,6 +3062,8 @@
     "square_img": "com.endlessm.textbooks-thumb.jpg",
     "subtitle": "Math and science textbooks",
     "title": "Textbooks",
+    "translation_id": "eos-subscriptions-apps",
+    "translation_type": "gettext",
     "tryexec": ""
   },
   {
@@ -2912,6 +3096,8 @@
     "square_img": "com.endlessm.translation-thumb.jpg",
     "subtitle": "Translate text between many languages instantly",
     "title": "Translate",
+    "translation_id": "eos-translation",
+    "translation_type": "gettext",
     "tryexec": ""
   },
   {
@@ -2950,6 +3136,8 @@
     "square_img": "com.endlessm.travel-thumb.jpg",
     "subtitle": "Travel around the world from your living room",
     "title": "Travel",
+    "translation_id": "eos-subscriptions-apps",
+    "translation_type": "gettext",
     "tryexec": ""
   },
   {
@@ -2988,6 +3176,8 @@
     "square_img": "com.endlessm.videonet-thumb.jpg",
     "subtitle": "Discover and share great videos online",
     "title": "VideoNet",
+    "translation_id": "eos-videonet",
+    "translation_type": "gettext",
     "tryexec": ""
   },
   {
@@ -3021,6 +3211,8 @@
     "square_img": "com.endlessm.water_and_sanitation-thumb.jpg",
     "subtitle": "All about clean water and sanitation",
     "title": "Sanitation",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -3055,6 +3247,8 @@
     "square_img": "com.endlessm.weather-thumb.jpg",
     "subtitle": "Get daily local forecasts from trusted sources",
     "title": "Weather",
+    "translation_id": "eos-weather",
+    "translation_type": "gettext",
     "tryexec": ""
   },
   {
@@ -3090,6 +3284,8 @@
     "square_img": "com.endlessm.world_literature-thumb.jpg",
     "subtitle": "Read all of the world's great literature",
     "title": "World Literature",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -3123,6 +3319,8 @@
     "square_img": "com.endlessm.your_health-thumb.jpg",
     "subtitle": "Health, nutrition, and well-being in one click",
     "title": "Your Health",
+    "translation_id": "eos-subscriptions-apps",
+    "translation_type": "gettext",
     "tryexec": ""
   },
   {
@@ -3149,6 +3347,8 @@
     "square_img": "com.github.slingshot-thumb.jpg",
     "subtitle": "A shooting strategy game set in space",
     "title": "Slingshot",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -3181,6 +3381,8 @@
     "square_img": "com.google.chrome-thumb.jpg",
     "subtitle": "Google's popular web browser",
     "title": "Google Chrome",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -3208,6 +3410,8 @@
     "square_img": "com.microsoft.skype-thumb.jpg",
     "subtitle": "Free internet calls with cheap rates to phones",
     "title": "Skype",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -3234,6 +3438,8 @@
     "square_img": "com.mojang.minecraft-thumb.jpg",
     "subtitle": "Create your own world in one of the most popular video games",
     "title": "Minecraft",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -3260,6 +3466,8 @@
     "square_img": "com.spotify.client-thumb.jpg",
     "subtitle": "Listen to music using Spotify",
     "title": "Spotify",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -3282,6 +3490,8 @@
     "square_img": "com.sublimetext.three-thumb.jpg",
     "subtitle": "Sophisticated text editor for code, markup, and prose",
     "title": "Sublime Text",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -3310,6 +3520,8 @@
     "square_img": "com.teeworlds.teeworlds-thumb.jpg",
     "subtitle": "Exciting multi-player shooting game",
     "title": "Teeworlds",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": "teeworlds"
   },
   {
@@ -3345,6 +3557,8 @@
     "square_img": "com.valvesoftware.steam-thumb.jpg",
     "subtitle": "Online store with popular video games",
     "title": "Steam",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -3373,6 +3587,8 @@
     "square_img": "de.billardgl.billardgl-thumb.jpg",
     "subtitle": "Fun 3D billiards game",
     "title": "Billiards",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -3406,6 +3622,8 @@
     "square_img": "evolution-thumb.jpg",
     "subtitle": "Your e-mail, address book and calendar in one place",
     "title": "E-mail",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -3438,6 +3656,8 @@
     "square_img": "gnome-calculator-thumb.jpg",
     "subtitle": "A scientific calculator with many bonus tools",
     "title": "Calculator",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -3476,6 +3696,8 @@
     "square_img": "gnome-control-center-thumb.jpg",
     "subtitle": "Easily change your computer's settings",
     "title": "Settings",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -3504,6 +3726,8 @@
     "square_img": "io.github.supertux-thumb.jpg",
     "subtitle": "Jump your way through different levels to win",
     "title": "Super Tux",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": "supertux2"
   },
   {
@@ -3536,6 +3760,8 @@
     "square_img": "libreoffice-calc-thumb.jpg",
     "subtitle": "A spreadsheet program with many functions",
     "title": "Spreadsheet",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -3570,6 +3796,8 @@
     "square_img": "libreoffice-impress-thumb.jpg",
     "subtitle": "Create great presentations with this easy-to-use app",
     "title": "Presentation",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -3607,6 +3835,8 @@
     "square_img": "libreoffice-writer-thumb.jpg",
     "subtitle": "Free, similar to & compatible with Microsoft Word",
     "title": "Writer",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -3633,6 +3863,8 @@
     "square_img": "net.blockout.blockout2-thumb.jpg",
     "subtitle": "3D Tetris-style game",
     "title": "BlockOut 2",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -3671,6 +3903,8 @@
     "square_img": "net.gcompris.gcompris-thumb.jpg",
     "subtitle": "Puzzles, memory games, and more for kids",
     "title": "EduGames",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -3703,6 +3937,8 @@
     "square_img": "net.gcompris.gcompris.admin-thumb.jpg",
     "subtitle": "For teachers to help their students learn",
     "title": "EduGames Admin",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -3729,6 +3965,8 @@
     "square_img": "net.minetest.minetest-thumb.jpg",
     "subtitle": "Create your dream world",
     "title": "Minetest",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -3757,6 +3995,8 @@
     "square_img": "net.olofson.kobodeluxe-thumb.jpg",
     "subtitle": "Destroy enemy bases in space",
     "title": "Kobo Deluxe",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": "kobodl"
   },
   {
@@ -3783,6 +4023,8 @@
     "square_img": "net.sourceforge.atanks-thumb.jpg",
     "subtitle": "Bring friends and families together in the pursuit of world domination",
     "title": "Atomic Tanks",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -3809,6 +4051,8 @@
     "square_img": "net.sourceforge.audacity-thumb.jpg",
     "subtitle": "Audio editor for recording, slicing, and mixing audio",
     "title": "Audio Editor",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -3835,6 +4079,8 @@
     "square_img": "net.sourceforge.btanks-thumb.jpg",
     "subtitle": "A fast-paced battle game to play with friends",
     "title": "Battle Tanks",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -3862,6 +4108,8 @@
     "square_img": "net.sourceforge.chromiumbsu-thumb.jpg",
     "subtitle": "Command your spaceship and battle with robots",
     "title": "Chromium BSU",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": "chromium-bsu"
   },
   {
@@ -3888,6 +4136,8 @@
     "square_img": "net.sourceforge.extremetuxracer-thumb.jpg",
     "subtitle": "Race down icy mountains",
     "title": "Tux Racer",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -3926,6 +4176,8 @@
     "square_img": "net.sourceforge.frostwire-thumb.jpg",
     "subtitle": "Download nearly anything or share your own files",
     "title": "FrostTorrent",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -3952,6 +4204,8 @@
     "square_img": "net.sourceforge.rili-thumb.jpg",
     "subtitle": "A fun train game for kids of all ages",
     "title": "Toy Train",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -3980,6 +4234,8 @@
     "square_img": "net.sourceforge.supertuxkart-thumb.jpg",
     "subtitle": "Race alone or against your friends and family",
     "title": "Tux Kart",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": "supertuxkart"
   },
   {
@@ -4006,6 +4262,8 @@
     "square_img": "net.sourceforge.torcs-thumb.jpg",
     "subtitle": "Race cool 3D cars in this realistic game",
     "title": "TORCS",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -4032,6 +4290,8 @@
     "square_img": "net.sourceforge.tuxfootball-thumb.jpg",
     "subtitle": "A fun soccer game starring Tux the penguin",
     "title": "Tux Football",
+    "translation_id": "tuxfootball",
+    "translation_type": "gettext",
     "tryexec": ""
   },
   {
@@ -4058,6 +4318,8 @@
     "square_img": "net.sourceforge.warmux-thumb.jpg",
     "subtitle": "Make your computer a battle of wit and war",
     "title": "Warmux",
+    "translation_id": "warmux",
+    "translation_type": "gettext",
     "tryexec": ""
   },
   {
@@ -4084,6 +4346,8 @@
     "square_img": "net.wz2100.warzone2100-thumb.jpg",
     "subtitle": "Lead your troops to rebuild the world",
     "title": "Warzone 2100",
+    "translation_id": "warzone2100",
+    "translation_type": "gettext",
     "tryexec": ""
   },
   {
@@ -4112,6 +4376,8 @@
     "square_img": "org.armagetronad.armagetronad-thumb.jpg",
     "subtitle": "Race 3D light motorcycles like in the movie Tron",
     "title": "Armagetron",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -4138,6 +4404,8 @@
     "square_img": "org.debian.tuxpuck-thumb.jpg",
     "subtitle": "Exciting air hockey game for you and your friends",
     "title": "Tux Puck",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": "tuxpuck"
   },
   {
@@ -4176,6 +4444,8 @@
     "square_img": "org.debian.alioth.tux4kids.tuxmath-thumb.jpg",
     "subtitle": "Math games for kids",
     "title": "Tux Math",
+    "translation_id": "tuxmath",
+    "translation_type": "gettext",
     "tryexec": ""
   },
   {
@@ -4214,6 +4484,8 @@
     "square_img": "org.debian.alioth.tux4kids.tuxtype-thumb.jpg",
     "subtitle": "Learn to type by playing games",
     "title": "Tux Typing",
+    "translation_id": "tuxtype",
+    "translation_type": "gettext",
     "tryexec": "tuxtype"
   },
   {
@@ -4247,6 +4519,8 @@
     "square_img": "org.freeciv.freeciv-thumb.jpg",
     "subtitle": "Guide your own civilization to greatness",
     "title": "FreeCiv",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -4275,6 +4549,8 @@
     "square_img": "org.freecol.freecol-thumb.jpg",
     "subtitle": "Create your own country and conquer the world",
     "title": "FreeCol",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -4303,6 +4579,8 @@
     "square_img": "org.frozenbubble.frozenbubble-thumb.jpg",
     "subtitle": "Pop bubbles before they all come crashing down",
     "title": "Frozen Bubbles",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -4339,6 +4617,8 @@
     "square_img": "org.gimp.gimp-thumb.jpg",
     "subtitle": "Advanced image editing tool similar to Photoshop",
     "title": "GIMP",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -4375,6 +4655,8 @@
     "square_img": "org.gnome.freecell-thumb.jpg",
     "subtitle": "Solitare based single player card game",
     "title": "Freecell",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -4403,6 +4685,8 @@
     "square_img": "org.gnome.genius-thumb.jpg",
     "subtitle": "Interactive computation and data visualization tool",
     "title": "Math Plotting",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -4436,6 +4720,8 @@
     "square_img": "org.gnome.gnote-thumb.jpg",
     "subtitle": "Never lose a note again",
     "title": "Notes",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -4463,6 +4749,8 @@
     "square_img": "org.gnome.iagno-thumb.jpg",
     "subtitle": "A fun puzzle game that involves lots of thought",
     "title": "Iagno",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -4492,6 +4780,8 @@
     "square_img": "org.gnome.nautilus-thumb.jpg",
     "subtitle": "Access all of your documents and files",
     "title": "Documents",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -4519,6 +4809,8 @@
     "square_img": "org.gnome.quadrapassel-thumb.jpg",
     "subtitle": "A tetris-like puzzle game",
     "title": "Quadrapassel",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -4551,6 +4843,8 @@
     "square_img": "org.gnome.screenshot-thumb.jpg",
     "subtitle": "Take a picture of your screen to save",
     "title": "Screenshot",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -4589,6 +4883,8 @@
     "square_img": "org.gnome.solitaire-thumb.jpg",
     "subtitle": "The classic single player card game",
     "title": "Solitaire",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -4615,6 +4911,8 @@
     "square_img": "org.gnome.terminal-thumb.jpg",
     "subtitle": "Use the command line",
     "title": "Terminal",
+    "translation_id": "gnome-terminal",
+    "translation_type": "gettext",
     "tryexec": ""
   },
   {
@@ -4642,6 +4940,8 @@
     "square_img": "org.gnome.tetravex-thumb.jpg",
     "subtitle": "Race the clock in a numerical puzzle game",
     "title": "Tetravex",
+    "translation_id": "gnome-tetravex",
+    "translation_type": "gettext",
     "tryexec": ""
   },
   {
@@ -4678,6 +4978,8 @@
     "square_img": "org.gnome.totem-thumb.jpg",
     "subtitle": "Full function video and media player",
     "title": "Videos",
+    "translation_id": "totem",
+    "translation_type": "gettext",
     "tryexec": "totem"
   },
   {
@@ -4716,6 +5018,8 @@
     "square_img": "org.gnome.gedit-thumb.jpg",
     "subtitle": "A simple text editor for all of your text editing needs",
     "title": "Gedit",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -4743,6 +5047,8 @@
     "square_img": "org.gnome.people.dscorgie.labyrinth-thumb.jpg",
     "subtitle": "Create mind maps with text, images, and drawings",
     "title": "Mind Maps",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -4777,6 +5083,8 @@
     "square_img": "org.inkscape.inkscape-thumb.jpg",
     "subtitle": "An advanced graphic design tool",
     "title": "Inkscape",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -4812,6 +5120,8 @@
     "square_img": "org.kde.kalzium-thumb.jpg",
     "subtitle": "A fun interactive periodic table of elements",
     "title": "Kalzium",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -4847,6 +5157,8 @@
     "square_img": "org.kde.kapman-thumb.jpg",
     "subtitle": "The classic game of ghosts and mazes",
     "title": "Kapman",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -4879,6 +5191,8 @@
     "square_img": "org.kde.katomic-thumb.jpg",
     "subtitle": "A fun way to learn chemistry",
     "title": "KAtomic",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -4914,6 +5228,8 @@
     "square_img": "org.kde.kblocks-thumb.jpg",
     "subtitle": "Match blocks to destroy them and win",
     "title": "KBlocks",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -4946,6 +5262,8 @@
     "square_img": "org.kde.kbounce-thumb.jpg",
     "subtitle": "The ball-bouncing game sure to hook you",
     "title": "KBounce",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -4978,6 +5296,8 @@
     "square_img": "org.kde.kbruch-thumb.jpg",
     "subtitle": "Learn about fractions, percentages and more",
     "title": "KBruch",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -5010,6 +5330,8 @@
     "square_img": "org.kde.kdiamond-thumb.jpg",
     "subtitle": "Create lines of three diamonds",
     "title": "KDiamond",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -5048,6 +5370,8 @@
     "square_img": "org.kde.kgeography-thumb.jpg",
     "subtitle": "Become a geography genius while having fun",
     "title": "KGeography",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -5080,6 +5404,8 @@
     "square_img": "org.kde.kgoldrunner-thumb.jpg",
     "subtitle": "Look for treasure and hide from enemies",
     "title": "KGoldrunner",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -5112,6 +5438,8 @@
     "square_img": "org.kde.khangman-thumb.jpg",
     "subtitle": "One of the most fun word games on earth",
     "title": "KHangMan",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -5144,6 +5472,8 @@
     "square_img": "org.kde.kigo-thumb.jpg",
     "subtitle": "The ancient game of skill, updated for modern play",
     "title": "Kigo",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -5176,6 +5506,8 @@
     "square_img": "org.kde.killbots-thumb.jpg",
     "subtitle": "Outsmart the killer robots to win",
     "title": "Killbots",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -5208,6 +5540,8 @@
     "square_img": "org.kde.kjumpingcube-thumb.jpg",
     "subtitle": "Develop a good strategy to conquer all the squares",
     "title": "KJumpingCube",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -5240,6 +5574,8 @@
     "square_img": "org.kde.klines-thumb.jpg",
     "subtitle": "Line up balls of the same color to win",
     "title": "Kolor Lines",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -5272,6 +5608,8 @@
     "square_img": "org.kde.knavalbattle-thumb.jpg",
     "subtitle": "Blow your opponents out of the water",
     "title": "Battleships",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -5304,6 +5642,8 @@
     "square_img": "org.kde.knetwalk-thumb.jpg",
     "subtitle": "Make the right cable connections and win",
     "title": "KNetwalk",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -5336,6 +5676,8 @@
     "square_img": "org.kde.ksame-thumb.jpg",
     "subtitle": "Get rid of all the marbles to win",
     "title": "KSame",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -5368,6 +5710,8 @@
     "square_img": "org.kde.ksquares-thumb.jpg",
     "subtitle": "Connect the dots in this challenging strategy game",
     "title": "KSquares",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -5403,6 +5747,8 @@
     "square_img": "org.kde.ksudoku-thumb.jpg",
     "subtitle": "A challenging numerical puzzle game",
     "title": "Sudoku",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -5438,6 +5784,8 @@
     "square_img": "org.kde.ktuberling-thumb.jpg",
     "subtitle": "Give your potato a funny face",
     "title": "Potato Guy",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -5470,6 +5818,8 @@
     "square_img": "org.kde.kubrick-thumb.jpg",
     "subtitle": "Like Rubik's Cube - create solid color sides to win",
     "title": "Kubrick",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -5502,6 +5852,8 @@
     "square_img": "org.kde.kwordquiz-thumb.jpg",
     "subtitle": "Grow your vocabulary and test your learning",
     "title": "KWordQuiz",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -5530,6 +5882,8 @@
     "square_img": "org.kde.marble-thumb.jpg",
     "subtitle": "Maps of the entire world",
     "title": "Maps",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -5562,6 +5916,8 @@
     "square_img": "org.kde.palapeli-thumb.jpg",
     "subtitle": "A fun jigsaw puzzle game",
     "title": "Palapeli",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -5590,6 +5946,8 @@
     "square_img": "org.learningequality.kalite-thumb.jpg",
     "subtitle": "Free educational videos on almost any subject",
     "title": "Virtual School",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -5618,6 +5976,8 @@
     "square_img": "org.maemo.numptyphysics-thumb.jpg",
     "subtitle": "Fun physics puzzle games",
     "title": "Numpty Physics",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -5644,6 +6004,8 @@
     "square_img": "org.marsshooter.marsshooter-thumb.jpg",
     "subtitle": "A shooting game in space",
     "title": "M.A.R.S.",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -5679,6 +6041,8 @@
     "square_img": "org.megaglest.megaglest-thumb.jpg",
     "subtitle": "A fantasy world with kings, queens and magic",
     "title": "MegaGlest",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -5705,6 +6069,8 @@
     "square_img": "org.mozilla.firefox-thumb.jpg",
     "subtitle": "Mozilla's popular web browser",
     "title": "Firefox",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": "firefox"
   },
   {
@@ -5731,6 +6097,8 @@
     "square_img": "org.openarena.openarena-thumb.jpg",
     "subtitle": "Shoot your way out of trouble in this fun game",
     "title": "Open Arena",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": "openarena"
   },
   {
@@ -5758,6 +6126,8 @@
     "square_img": "org.openscad.openscad-thumb.jpg",
     "subtitle": "Create 3D CAD models",
     "title": "3D CAD",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -5790,6 +6160,8 @@
     "square_img": "org.pitivi.pitivi-thumb.jpg",
     "subtitle": "Hundreds of transitions, effects, and filters to edit your videos",
     "title": "Video Editor",
+    "translation_id": "pitivi",
+    "translation_type": "gettext",
     "tryexec": ""
   },
   {
@@ -5823,6 +6195,8 @@
     "square_img": "org.seul.pingus-thumb.jpg",
     "subtitle": "Save your penguin friends from falling into the water",
     "title": "Pingus",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": "pingus"
   },
   {
@@ -5861,6 +6235,8 @@
     "square_img": "org.squeakland.etoys-thumb.jpg",
     "subtitle": "Learn with visual programming",
     "title": "Etoys",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -5893,6 +6269,8 @@
     "square_img": "org.squeakland.scratch-thumb.jpg",
     "subtitle": "Learn basic computer programming",
     "title": "Scratch",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -5921,6 +6299,8 @@
     "square_img": "org.stellarium.stellarium-thumb.jpg",
     "subtitle": "Planetarium software that shows what you see when you look at the stars",
     "title": "Stellarium",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -5959,6 +6339,8 @@
     "square_img": "org.sugarlabs.turtleblocks-thumb.jpg",
     "subtitle": "Visually program with turtle art",
     "title": "Turtle Blocks",
+    "translation_id": "org.laptop.TurtleArtActivity",
+    "translation_type": "gettext",
     "tryexec": ""
   },
   {
@@ -5985,6 +6367,8 @@
     "square_img": "org.tuxfamily.xmoto-thumb.jpg",
     "subtitle": "A motorcycle racing game",
     "title": "X-Moto",
+    "translation_id": "xmoto",
+    "translation_type": "gettext",
     "tryexec": ""
   },
   {
@@ -6023,6 +6407,8 @@
     "square_img": "org.tuxpaint.tuxpaint-thumb.jpg",
     "subtitle": "A fun drawing app for kids",
     "title": "Tux Paint",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -6049,6 +6435,8 @@
     "square_img": "org.videolan.vlc-thumb.jpg",
     "subtitle": "Play videos with this popular media player",
     "title": "VLC",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -6075,6 +6463,8 @@
     "square_img": "org.wesnoth.wesnoth-thumb.jpg",
     "subtitle": "Fantasy turn-based strategy game",
     "title": "Wesnoth",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": "wesnoth-1.11"
   },
   {
@@ -6110,6 +6500,8 @@
     "square_img": "rhythmbox-thumb.jpg",
     "subtitle": "Listen to all your music, and to the radio",
     "title": "Music",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -6145,6 +6537,8 @@
     "square_img": "shotwell-thumb.jpg",
     "subtitle": "Easily edit, organize, and share photos.",
     "title": "Photos",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -6177,6 +6571,8 @@
     "square_img": "simple-scan-thumb.jpg",
     "subtitle": "Make a digital copy of your photos and documents",
     "title": "Simple Scan",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -6199,6 +6595,8 @@
     "square_img": "vinagre-thumb.jpg",
     "subtitle": "Manage your desktop from afar",
     "title": "Remote Desktop",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   },
   {
@@ -6232,6 +6630,8 @@
     "square_img": "yelp-thumb.jpg",
     "subtitle": "Learn how to use Endless",
     "title": "Help Center",
+    "translation_id": null,
+    "translation_type": null,
     "tryexec": ""
   }
 ]


### PR DESCRIPTION
Update to the latest content.json from the CMS. This includes the new
translation_type and translation_id fields which will be used to add
<translation> tags to the AppData XML files. Only a few of the apps
currently have correct settings, but the keys are needed for the AppData
work to proceed.

I left out some screenshots that were also updated in appstore.zip since they were unrelated to this work.

https://phabricator.endlessm.com/T16227