### PR TITLE
eos-content-merge: Ignore localized icons

### DIFF
--- a/tools/eos-content-merge
+++ b/tools/eos-content-merge
@@ -116,6 +116,10 @@ class App(object):
                 # will fall back to our preferred English name instead
                 if item[1].lower() != origname.lower():
                     names.update([item])
+            elif item[0].startswith('Icon['):
+                # Exclude any localized icons so as not to
+                # override the Endless-provided icon
+                pass
             else:
                 others.update([item])
         names = OrderedDict(sorted(names.items(), key=lambda t: t[0]))


### PR DESCRIPTION
Upstream GNOME apps have started to provide localization
of the icon specification in desktop files as part of
the migration from intltool to gettext, even though
in practice they specify the same icon for all locales.
Let's filter these localized icons out so that the
Endless provided icon is used for all locales.

https://phabricator.endlessm.com/T17971