### PR TITLE
add first indonesian apps to the grid

### DIFF
--- a/data/settings/icon-grid-id.json.in
+++ b/data/settings/icon-grid-id.json.in
@@ -9,6 +9,8 @@
     "eos-link-facebook.desktop",
     "eos-link-whatsapp.desktop",
     "eos-link-youtube.desktop",
+    "com.endlessm.okezone.id.desktop",
+    "com.endlessm.kapan_lagi.id.desktop",
     "eos-folder-media.directory",
     "eos-folder-games.directory",
     "eos-folder-social.directory",


### PR DESCRIPTION
We have fixed this in the image builder with an -append for 3.2.2, but the correct
fix is to patch it into the ostree and then drop it from the image builder.

https://phabricator.endlessm.com/T18139