### PR TITLE
Automake 1.15 fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,5 @@ stamp-h1
 /po/remove-potcdate.sed
 /po/stamp-po
 /po/*.gmo
+/py-compile
 /unzipped

--- a/Makefile.am
+++ b/Makefile.am
@@ -15,6 +15,7 @@ install-data-local:
 	cp -r $(srcdir)/bundle $(DESTDIR)$(pkgdatadir)
 	chmod -R +w $(DESTDIR)$(pkgdatadir)/bundle
 	cp -r $(srcdir)/acknowledgements $(DESTDIR)$(datadir)/eos-acknowledgements
+	chmod -R +w $(DESTDIR)$(datadir)/eos-acknowledgements
 
 uninstall-local:
 	rm -rf $(DESTDIR)$(pkgdatadir)/bundle

--- a/content/Makefile.am
+++ b/content/Makefile.am
@@ -32,7 +32,7 @@ EXTRA_DIST += $(default_links_images)
 # directory since the po rules expect to find POTFILES there.
 content_files = $(default_app_json) $(default_links_json) $(default_folders_json)
 content_headers = $(content_files:.json=.json.h)
-%.json.h: %.json $(top_builddir)/tools/extract-content-strings$(BUILD_EXEEXT)
+%.json.h: %.json
 	$(top_builddir)/tools/extract-content-strings$(BUILD_EXEEXT) $< $(srcdir)/$@
 
 # Distribute the json.h files so they don't need to be regenerated at

--- a/content/Makefile.am
+++ b/content/Makefile.am
@@ -2,6 +2,7 @@ NULL =
 EXTRA_DIST =
 CLEANFILES =
 DISTCLEANFILES =
+MAINTAINERCLEANFILES =
 
 default_app_json = \
 	Default/apps/content.json \
@@ -26,17 +27,18 @@ default_links_images := $(shell cd $(srcdir); for file in `find Default/links/im
 
 EXTRA_DIST += $(default_links_images)
 
-# we need to generate the json.h header because gettext does not know how
-# to extract strings from custom JSON.
+# we need to generate the json.h header because gettext does not know
+# how to extract strings from custom JSON. Generate them in the source
+# directory since the po rules expect to find POTFILES there.
 content_files = $(default_app_json) $(default_links_json) $(default_folders_json)
 content_headers = $(content_files:.json=.json.h)
 %.json.h: %.json $(top_builddir)/tools/extract-content-strings$(BUILD_EXEEXT)
-	$(AM_V_GEN) $(MKDIR_P) $(@D) && \
-	$(top_builddir)/tools/extract-content-strings$(BUILD_EXEEXT) $< $@
+	$(top_builddir)/tools/extract-content-strings$(BUILD_EXEEXT) $< $(srcdir)/$@
 
-all-local: $(content_headers)
-
-CLEANFILES += $(content_headers)
+# Distribute the json.h files so they don't need to be regenerated at
+# build time
+EXTRA_DIST += $(content_headers)
+MAINTAINERCLEANFILES += $(content_headers)
 
 eos-app-store-link-content.gresource.xml: Makefile $(default_links_json) $(default_links_images)
 	$(AM_V_GEN) ( echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" ; \

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -17,6 +17,11 @@ extract_content_strings_LDADD = \
 	$(EOS_SHELL_CONTENT_LIBS) \
 	$(NULL)
 
+# extract-content-strings needs to be run during dist but not actually
+# distributed. This allows "make dist" to succeed without previously
+# running "make".
+dist-hook: extract-content-strings$(EXEEXT)
+
 dist_bin_SCRIPTS = \
 	eos-content-merge \
 	dh_eoscontent \


### PR DESCRIPTION
Various fixes for compatibility with automake 1.15. The primary change is to generate the json.h files in the source directory.

https://phabricator.endlessm.com/T18550