### PR TITLE
Update desktop layouts to reflect new apps available for SEA

### DIFF
--- a/data/settings/icon-grid-C.json.in
+++ b/data/settings/icon-grid-C.json.in
@@ -16,6 +16,7 @@
     "eos-folder-social.directory",
     "net.minetest.Minetest.desktop",
     "com.endlessm.cooking.en.desktop",
+    "com.endlessm.times_of_india.en_IN",
     "rhythmbox.desktop"
   ],
   "eos-folder-media.directory" : [
@@ -36,6 +37,7 @@
     "com.endlessm.travel.en.desktop",
     "com.endlessm.health.en.desktop",
     "com.endlessm.dinosaurs.en.desktop",
+    "com.endlessm.animals.en.desktop",
     "com.endlessm.translation.desktop",
     "eos-link-duolingo.desktop"
   ],

--- a/data/settings/icon-grid-th.json.in
+++ b/data/settings/icon-grid-th.json.in
@@ -12,6 +12,7 @@
     "eos-link-youtube.desktop",
     "com.endlessm.duet_diary.th.desktop",
     "eos-folder-media.directory",
+    "eos-folder-curiosity.directory",
     "eos-folder-games.directory",
     "eos-folder-social.directory",
     "net.minetest.Minetest.desktop",
@@ -24,6 +25,17 @@
     "org.tuxpaint.Tuxpaint.desktop",
     "net.sourceforge.Audacity.desktop",
     "org.gimp.Gimp.desktop"
+  ],
+  "eos-folder-curiosity.directory" : [
+    "com.endlessm.celebrities.th.desktop",
+    "com.endlessm.animals.th.desktop",
+    "com.endlessm.biology.th.desktop",
+    "com.endlessm.geography.th.desktop",
+    "com.endlessm.history.th.desktop",
+    "com.endlessm.soccer.th.desktop",
+    "com.endlessm.socialsciences.th.desktop",
+    "com.endlessm.translation.desktop",
+    "eos-link-duolingo.desktop"
   ],
   "eos-folder-games.directory" : [
     "net.sourceforge.Supertuxkart.desktop",

--- a/data/settings/icon-grid-vi.json.in
+++ b/data/settings/icon-grid-vi.json.in
@@ -11,10 +11,10 @@
     "eos-link-whatsapp.desktop",
     "eos-link-youtube.desktop",
     "eos-folder-media.directory",
+    "eos-folder-curiosity.directory",
     "eos-folder-games.directory",
     "eos-folder-social.directory",
     "net.minetest.Minetest.desktop",
-    "com.endlessm.cooking.en.desktop",
     "rhythmbox.desktop"
   ],
   "eos-folder-media.directory" : [
@@ -24,6 +24,19 @@
     "org.tuxpaint.Tuxpaint.desktop",
     "net.sourceforge.Audacity.desktop",
     "org.gimp.Gimp.desktop"
+  ],
+  "eos-folder-curiosity.directory" : [
+    "com.endlessm.celebrities.vi.desktop",
+    "com.endlessm.animals.vi.desktop",
+    "com.endlessm.astronomy.vi.desktop",
+    "com.endlessm.biology.vi.desktop",
+    "com.endlessm.geography.vi.desktop",
+    "com.endlessm.history.vi.desktop",
+    "com.endlessm.physics.vi.desktop",
+    "com.endlessm.soccer.vi.desktop",
+    "com.endlessm.socialsciences.vi.desktop",
+    "com.endlessm.translation.desktop",
+    "eos-link-duolingo.desktop"
   ],
   "eos-folder-games.directory" : [
     "net.sourceforge.Supertuxkart.desktop",


### PR DESCRIPTION
Create curiosity folders for th and vi now that we have wiki apps to populate them.

Add extra options for the C locale to make sure that all the apps we ship in SEA images are visible to the user on the desktop.