### PR TITLE
icon-grid-*: change to LibreOffice flatpak

### DIFF
--- a/data/settings/icon-grid-C.json.in
+++ b/data/settings/icon-grid-C.json.in
@@ -2,9 +2,9 @@
   "desktop" : [
     "chromium-browser.desktop",
     "org.gnome.Nautilus.desktop",
-    "libreoffice-writer.desktop",
-    "libreoffice-calc.desktop",
-    "libreoffice-impress.desktop",
+    "org.libreoffice.LibreOffice-writer.desktop",
+    "org.libreoffice.LibreOffice-calc.desktop",
+    "org.libreoffice.LibreOffice-impress.desktop",
     "com.endlessm.encyclopedia.en.desktop",
     "eos-vlc.desktop",
     "eos-link-facebook.desktop",

--- a/data/settings/icon-grid-ar.json.in
+++ b/data/settings/icon-grid-ar.json.in
@@ -2,9 +2,9 @@
   "desktop" : [
     "chromium-browser.desktop",
     "org.gnome.Nautilus.desktop",
-    "libreoffice-writer.desktop",
-    "libreoffice-calc.desktop",
-    "libreoffice-impress.desktop",
+    "org.libreoffice.LibreOffice-writer.desktop",
+    "org.libreoffice.LibreOffice-calc.desktop",
+    "org.libreoffice.LibreOffice-impress.desktop",
     "com.endlessm.encyclopedia.ar.desktop",
     "eos-vlc.desktop",
     "eos-link-facebook.desktop",

--- a/data/settings/icon-grid-bn.json.in
+++ b/data/settings/icon-grid-bn.json.in
@@ -2,9 +2,9 @@
   "desktop" : [
     "chromium-browser.desktop",
     "org.gnome.Nautilus.desktop",
-    "libreoffice-writer.desktop",
-    "libreoffice-calc.desktop",
-    "libreoffice-impress.desktop",
+    "org.libreoffice.LibreOffice-writer.desktop",
+    "org.libreoffice.LibreOffice-calc.desktop",
+    "org.libreoffice.LibreOffice-impress.desktop",
     "com.endlessm.bengali_curriculum.bn_BD.desktop",
     "eos-vlc.desktop",
     "eos-link-facebook.desktop",

--- a/data/settings/icon-grid-es.json.in
+++ b/data/settings/icon-grid-es.json.in
@@ -2,9 +2,9 @@
   "desktop" : [
     "chromium-browser.desktop",
     "org.gnome.Nautilus.desktop",
-    "libreoffice-writer.desktop",
-    "libreoffice-calc.desktop",
-    "libreoffice-impress.desktop",
+    "org.libreoffice.LibreOffice-writer.desktop",
+    "org.libreoffice.LibreOffice-calc.desktop",
+    "org.libreoffice.LibreOffice-impress.desktop",
     "com.endlessm.encyclopedia.es.desktop",
     "eos-vlc.desktop",
     "eos-link-facebook.desktop",

--- a/data/settings/icon-grid-es_GT.json.in
+++ b/data/settings/icon-grid-es_GT.json.in
@@ -2,9 +2,9 @@
   "desktop" : [
     "chromium-browser.desktop",
     "org.gnome.Nautilus.desktop",
-    "libreoffice-writer.desktop",
-    "libreoffice-calc.desktop",
-    "libreoffice-impress.desktop",
+    "org.libreoffice.LibreOffice-writer.desktop",
+    "org.libreoffice.LibreOffice-calc.desktop",
+    "org.libreoffice.LibreOffice-impress.desktop",
     "com.endlessm.encyclopedia.es.desktop",
     "eos-link-facebook.desktop",
     "eos-link-whatsapp.desktop",

--- a/data/settings/icon-grid-fr.json.in
+++ b/data/settings/icon-grid-fr.json.in
@@ -2,9 +2,9 @@
   "desktop" : [
     "chromium-browser.desktop",
     "org.gnome.Nautilus.desktop",
-    "libreoffice-writer.desktop",
-    "libreoffice-calc.desktop",
-    "libreoffice-impress.desktop",
+    "org.libreoffice.LibreOffice-writer.desktop",
+    "org.libreoffice.LibreOffice-calc.desktop",
+    "org.libreoffice.LibreOffice-impress.desktop",
     "com.endlessm.encyclopedia.fr.desktop",
     "eos-vlc.desktop",
     "eos-link-facebook.desktop",

--- a/data/settings/icon-grid-id.json.in
+++ b/data/settings/icon-grid-id.json.in
@@ -2,9 +2,9 @@
   "desktop" : [
     "chromium-browser.desktop",
     "org.gnome.Nautilus.desktop",
-    "libreoffice-writer.desktop",
-    "libreoffice-calc.desktop",
-    "libreoffice-impress.desktop",
+    "org.libreoffice.LibreOffice-writer.desktop",
+    "org.libreoffice.LibreOffice-calc.desktop",
+    "org.libreoffice.LibreOffice-impress.desktop",
     "com.endlessm.encyclopedia.id.desktop",
     "eos-vlc.desktop",
     "eos-link-facebook.desktop",

--- a/data/settings/icon-grid-pt.json.in
+++ b/data/settings/icon-grid-pt.json.in
@@ -2,9 +2,9 @@
   "desktop" : [
     "chromium-browser.desktop",
     "org.gnome.Nautilus.desktop",
-    "libreoffice-writer.desktop",
-    "libreoffice-calc.desktop",
-    "libreoffice-impress.desktop",
+    "org.libreoffice.LibreOffice-writer.desktop",
+    "org.libreoffice.LibreOffice-calc.desktop",
+    "org.libreoffice.LibreOffice-impress.desktop",
     "com.endlessm.encyclopedia.pt.desktop",
     "eos-vlc.desktop",
     "eos-link-facebook.desktop",

--- a/data/settings/icon-grid-th.json.in
+++ b/data/settings/icon-grid-th.json.in
@@ -2,9 +2,9 @@
   "desktop" : [
     "chromium-browser.desktop",
     "org.gnome.Nautilus.desktop",
-    "libreoffice-writer.desktop",
-    "libreoffice-calc.desktop",
-    "libreoffice-impress.desktop",
+    "org.libreoffice.LibreOffice-writer.desktop",
+    "org.libreoffice.LibreOffice-calc.desktop",
+    "org.libreoffice.LibreOffice-impress.desktop",
     "com.endlessm.encyclopedia.th.desktop",
     "eos-vlc.desktop",
     "eos-link-facebook.desktop",

--- a/data/settings/icon-grid-vi.json.in
+++ b/data/settings/icon-grid-vi.json.in
@@ -2,9 +2,9 @@
   "desktop" : [
     "chromium-browser.desktop",
     "org.gnome.Nautilus.desktop",
-    "libreoffice-writer.desktop",
-    "libreoffice-calc.desktop",
-    "libreoffice-impress.desktop",
+    "org.libreoffice.LibreOffice-writer.desktop",
+    "org.libreoffice.LibreOffice-calc.desktop",
+    "org.libreoffice.LibreOffice-impress.desktop",
     "com.endlessm.encyclopedia.vi.desktop",
     "eos-vlc.desktop",
     "eos-link-facebook.desktop",

--- a/data/settings/icon-grid-zh_CN.json.in
+++ b/data/settings/icon-grid-zh_CN.json.in
@@ -17,9 +17,9 @@
     "com.endlessm.chinese_curriculum_english.zh_CN.desktop"
   ],
   "eos-folder-work.directory" : [
-    "libreoffice-writer.desktop",
-    "libreoffice-calc.desktop",
-    "libreoffice-impress.desktop"
+    "org.libreoffice.LibreOffice-writer.desktop",
+    "org.libreoffice.LibreOffice-calc.desktop",
+    "org.libreoffice.LibreOffice-impress.desktop"
   ],
   "eos-folder-tools.directory" : [
     "rhythmbox.desktop",


### PR DESCRIPTION
Update .desktop links to use the Flatpak version of LibreOffice.

https://phabricator.endlessm.com/T22113