### PR TITLE
data/settings: apply migrations to kde4- prefixed apps too

### DIFF
--- a/data/settings/icon-grid-C.json.in
+++ b/data/settings/icon-grid-C.json.in
@@ -38,7 +38,7 @@
     "com.tux4kids.tuxmath.desktop",
     "org.kde.gcompris.desktop",
     "com.tux4kids.tuxtype.desktop",
-    "kde4-org.kde.Ktuberling.desktop",
+    "org.kde.ktuberling.desktop",
     "io.thp.numptyphysics.desktop",
     "org.debian.TuxPuck.desktop",
     "net.sourceforge.Ri-li.desktop",

--- a/data/settings/icon-grid-ar.json.in
+++ b/data/settings/icon-grid-ar.json.in
@@ -30,7 +30,7 @@
     "com.tux4kids.tuxmath.desktop",
     "org.kde.gcompris.desktop",
     "com.tux4kids.tuxtype.desktop",
-    "kde4-org.kde.Ktuberling.desktop",
+    "org.kde.ktuberling.desktop",
     "io.thp.numptyphysics.desktop",
     "org.debian.TuxPuck.desktop",
     "net.sourceforge.Ri-li.desktop",

--- a/data/settings/icon-grid-bn.json.in
+++ b/data/settings/icon-grid-bn.json.in
@@ -37,7 +37,7 @@
     "com.tux4kids.tuxmath.desktop",
     "org.kde.gcompris.desktop",
     "com.tux4kids.tuxtype.desktop",
-    "kde4-org.kde.Ktuberling.desktop",
+    "org.kde.ktuberling.desktop",
     "io.thp.numptyphysics.desktop",
     "org.debian.TuxPuck.desktop",
     "net.sourceforge.Ri-li.desktop",

--- a/data/settings/icon-grid-es.json.in
+++ b/data/settings/icon-grid-es.json.in
@@ -36,7 +36,7 @@
     "com.tux4kids.tuxmath.desktop",
     "org.kde.gcompris.desktop",
     "com.tux4kids.tuxtype.desktop",
-    "kde4-org.kde.Ktuberling.desktop",
+    "org.kde.ktuberling.desktop",
     "io.thp.numptyphysics.desktop",
     "org.debian.TuxPuck.desktop",
     "net.sourceforge.Ri-li.desktop",

--- a/data/settings/icon-grid-es_GT.json.in
+++ b/data/settings/icon-grid-es_GT.json.in
@@ -37,7 +37,7 @@
     "com.tux4kids.tuxmath.desktop",
     "org.kde.gcompris.desktop",
     "com.tux4kids.tuxtype.desktop",
-    "kde4-org.kde.Ktuberling.desktop",
+    "org.kde.ktuberling.desktop",
     "io.thp.numptyphysics.desktop",
     "org.debian.TuxPuck.desktop",
     "net.sourceforge.Ri-li.desktop",

--- a/data/settings/icon-grid-fr.json.in
+++ b/data/settings/icon-grid-fr.json.in
@@ -28,7 +28,7 @@
     "com.tux4kids.tuxmath.desktop",
     "org.kde.gcompris.desktop",
     "com.tux4kids.tuxtype.desktop",
-    "kde4-org.kde.Ktuberling.desktop",
+    "org.kde.ktuberling.desktop",
     "io.thp.numptyphysics.desktop",
     "org.debian.TuxPuck.desktop",
     "net.sourceforge.Ri-li.desktop",

--- a/data/settings/icon-grid-id.json.in
+++ b/data/settings/icon-grid-id.json.in
@@ -52,7 +52,7 @@
     "com.tux4kids.tuxmath.desktop",
     "org.kde.gcompris.desktop",
     "com.tux4kids.tuxtype.desktop",
-    "kde4-org.kde.Ktuberling.desktop",
+    "org.kde.ktuberling.desktop",
     "io.thp.numptyphysics.desktop",
     "org.debian.TuxPuck.desktop",
     "net.sourceforge.Ri-li.desktop",

--- a/data/settings/icon-grid-pt.json.in
+++ b/data/settings/icon-grid-pt.json.in
@@ -37,7 +37,7 @@
     "com.tux4kids.tuxmath.desktop",
     "org.kde.gcompris.desktop",
     "com.tux4kids.tuxtype.desktop",
-    "kde4-org.kde.Ktuberling.desktop",
+    "org.kde.ktuberling.desktop",
     "io.thp.numptyphysics.desktop",
     "org.debian.TuxPuck.desktop",
     "net.sourceforge.Ri-li.desktop",

--- a/data/settings/icon-grid-th.json.in
+++ b/data/settings/icon-grid-th.json.in
@@ -36,7 +36,7 @@
     "com.tux4kids.tuxmath.desktop",
     "org.kde.gcompris.desktop",
     "com.tux4kids.tuxtype.desktop",
-    "kde4-org.kde.Ktuberling.desktop",
+    "org.kde.ktuberling.desktop",
     "io.thp.numptyphysics.desktop",
     "org.debian.TuxPuck.desktop",
     "net.sourceforge.Ri-li.desktop",

--- a/data/settings/icon-grid-vi.json.in
+++ b/data/settings/icon-grid-vi.json.in
@@ -37,7 +37,7 @@
     "com.tux4kids.tuxmath.desktop",
     "org.kde.gcompris.desktop",
     "com.tux4kids.tuxtype.desktop",
-    "kde4-org.kde.Ktuberling.desktop",
+    "org.kde.ktuberling.desktop",
     "io.thp.numptyphysics.desktop",
     "org.debian.TuxPuck.desktop",
     "net.sourceforge.Ri-li.desktop",

--- a/data/settings/icon-grid-zh_CN.json.in
+++ b/data/settings/icon-grid-zh_CN.json.in
@@ -8,8 +8,8 @@
     "eos-folder-games.directory",
     "eos-folder-social.directory",
     "eos-link-duolingo.desktop",
-    "kde4-org.kde.Kwordquiz.desktop",
-    "kde4-org.kde.Kbruch.desktop",
+    "org.kde.kwordquiz.desktop",
+    "org.kde.kbruch.desktop",
     "gnome-control-center.desktop"
   ],
   "eos-folder-curiosity.directory": [
@@ -24,7 +24,7 @@
     "com.tux4kids.tuxmath.desktop",
     "org.kde.gcompris.desktop",
     "com.tux4kids.tuxtype.desktop",
-    "kde4-org.kde.Ktuberling.desktop",
+    "org.kde.ktuberling.desktop",
     "io.thp.numptyphysics.desktop",
     "org.debian.TuxPuck.desktop",
     "net.sourceforge.Ri-li.desktop",


### PR DESCRIPTION
Ensure that .desktop files stored in the kde4 subdirectory are also matched and
migrated too. This was done manually in the eos-image-builder PR but forgotten
here.

https://phabricator.endlessm.com/T23856