### PR TITLE
Add "Games to Hack" and "Learn to Code" to desktop

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -13,8 +13,9 @@ settings_in_files = $(wildcard settings/icon-grid-*.json.in)
 settings_DATA = $(settings_in_files:.in=)
 dist_noinst_SCRIPTS = settings/write-grid-json.py
 
-%.json: %.json.in settings/arch-blacklist.json
-	$(AM_V_GEN)$(srcdir)/settings/write-grid-json.py -o $@ $^ $(host_cpu)
+%.json: %.json.in settings/arch-blacklist.json settings/write-grid-json.py
+	$(AM_V_GEN)$(srcdir)/settings/write-grid-json.py -o $@ \
+		$< $(srcdir)/settings/arch-blacklist.json $(host_cpu)
 
 do_subst = sed \
 	-e 's|@PKG_DATA_DIR[@]|$(pkgdatadir)|g' \

--- a/data/settings/icon-grid-C.json.in
+++ b/data/settings/icon-grid-C.json.in
@@ -13,6 +13,8 @@
     "eos-folder-media.directory",
     "eos-folder-curiosity.directory",
     "eos-folder-games.directory",
+    "eos-folder-games-to-hack.directory",
+    "eos-folder-learn-to-code.directory",
     "eos-folder-social.directory",
     "net.minetest.Minetest.desktop",
     "com.endlessm.cooking.en.desktop",

--- a/data/settings/icon-grid-C.json.in
+++ b/data/settings/icon-grid-C.json.in
@@ -56,7 +56,7 @@
     "com.endlessnetwork.frogsquash.desktop",
     "com.endlessnetwork.passage.desktop",
     "com.endlessnetwork.tankwarrior.desktop",
-    "com.endlessnetwork.midnightmareteddy.desktop",
+    "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],
   "eos-folder-learn-to-code.directory": [

--- a/data/settings/icon-grid-ar.json.in
+++ b/data/settings/icon-grid-ar.json.in
@@ -47,7 +47,7 @@
     "com.endlessnetwork.frogsquash.desktop",
     "com.endlessnetwork.passage.desktop",
     "com.endlessnetwork.tankwarrior.desktop",
-    "com.endlessnetwork.midnightmareteddy.desktop",
+    "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],
   "eos-folder-media.directory": [

--- a/data/settings/icon-grid-ar.json.in
+++ b/data/settings/icon-grid-ar.json.in
@@ -13,6 +13,7 @@
     "eos-folder-media.directory",
     "eos-folder-curiosity.directory",
     "eos-folder-games.directory",
+    "eos-folder-games-to-hack.directory",
     "eos-folder-social.directory",
     "net.minetest.Minetest.desktop",
     "com.endlessm.cooking.ar.desktop",

--- a/data/settings/icon-grid-bn.json.in
+++ b/data/settings/icon-grid-bn.json.in
@@ -13,6 +13,7 @@
     "eos-folder-media.directory",
     "eos-folder-curiosity.directory",
     "eos-folder-games.directory",
+    "eos-folder-games-to-hack.directory",
     "eos-folder-social.directory",
     "net.minetest.Minetest.desktop",
     "com.endlessm.cooking.bn_BD.desktop",

--- a/data/settings/icon-grid-bn.json.in
+++ b/data/settings/icon-grid-bn.json.in
@@ -54,7 +54,7 @@
     "com.endlessnetwork.frogsquash.desktop",
     "com.endlessnetwork.passage.desktop",
     "com.endlessnetwork.tankwarrior.desktop",
-    "com.endlessnetwork.midnightmareteddy.desktop",
+    "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],
   "eos-folder-media.directory": [

--- a/data/settings/icon-grid-es.json.in
+++ b/data/settings/icon-grid-es.json.in
@@ -13,6 +13,7 @@
     "eos-folder-media.directory",
     "eos-folder-curiosity.directory",
     "eos-folder-games.directory",
+    "eos-folder-games-to-hack.directory",
     "eos-folder-social.directory",
     "net.minetest.Minetest.desktop",
     "com.endlessm.cooking.es.desktop",

--- a/data/settings/icon-grid-es.json.in
+++ b/data/settings/icon-grid-es.json.in
@@ -53,7 +53,7 @@
     "com.endlessnetwork.frogsquash.desktop",
     "com.endlessnetwork.passage.desktop",
     "com.endlessnetwork.tankwarrior.desktop",
-    "com.endlessnetwork.midnightmareteddy.desktop",
+    "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],
   "eos-folder-media.directory": [

--- a/data/settings/icon-grid-es_GT.json.in
+++ b/data/settings/icon-grid-es_GT.json.in
@@ -54,7 +54,7 @@
     "com.endlessnetwork.frogsquash.desktop",
     "com.endlessnetwork.passage.desktop",
     "com.endlessnetwork.tankwarrior.desktop",
-    "com.endlessnetwork.midnightmareteddy.desktop",
+    "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],
   "eos-folder-media.directory": [

--- a/data/settings/icon-grid-es_GT.json.in
+++ b/data/settings/icon-grid-es_GT.json.in
@@ -11,6 +11,7 @@
     "eos-folder-media.directory",
     "eos-folder-curiosity.directory",
     "eos-folder-games.directory",
+    "eos-folder-games-to-hack.directory",
     "eos-folder-social.directory",
     "net.minetest.Minetest.desktop",
     "com.endlessm.cooking.es.desktop",

--- a/data/settings/icon-grid-fr.json.in
+++ b/data/settings/icon-grid-fr.json.in
@@ -45,7 +45,7 @@
     "com.endlessnetwork.frogsquash.desktop",
     "com.endlessnetwork.passage.desktop",
     "com.endlessnetwork.tankwarrior.desktop",
-    "com.endlessnetwork.midnightmareteddy.desktop",
+    "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],
   "eos-folder-media.directory": [

--- a/data/settings/icon-grid-fr.json.in
+++ b/data/settings/icon-grid-fr.json.in
@@ -13,6 +13,7 @@
     "eos-folder-media.directory",
     "eos-folder-curiosity.directory",
     "eos-folder-games.directory",
+    "eos-folder-games-to-hack.directory",
     "eos-folder-social.directory",
     "net.minetest.Minetest.desktop",
     "rhythmbox.desktop"

--- a/data/settings/icon-grid-id.json.in
+++ b/data/settings/icon-grid-id.json.in
@@ -20,6 +20,7 @@
     "eos-folder-news.directory",
     "eos-folder-curiosity.directory",
     "eos-folder-games.directory",
+    "eos-folder-games-to-hack.directory",
     "eos-folder-social.directory",
     "com.endlessm.video_animal_kingdom.desktop",
     "net.minetest.Minetest.desktop"

--- a/data/settings/icon-grid-id.json.in
+++ b/data/settings/icon-grid-id.json.in
@@ -69,7 +69,7 @@
     "com.endlessnetwork.frogsquash.desktop",
     "com.endlessnetwork.passage.desktop",
     "com.endlessnetwork.tankwarrior.desktop",
-    "com.endlessnetwork.midnightmareteddy.desktop",
+    "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],
   "eos-folder-media.directory": [

--- a/data/settings/icon-grid-pt.json.in
+++ b/data/settings/icon-grid-pt.json.in
@@ -54,7 +54,7 @@
     "com.endlessnetwork.frogsquash.desktop",
     "com.endlessnetwork.passage.desktop",
     "com.endlessnetwork.tankwarrior.desktop",
-    "com.endlessnetwork.midnightmareteddy.desktop",
+    "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],
   "eos-folder-media.directory": [

--- a/data/settings/icon-grid-pt.json.in
+++ b/data/settings/icon-grid-pt.json.in
@@ -13,6 +13,7 @@
     "eos-folder-media.directory",
     "eos-folder-curiosity.directory",
     "eos-folder-games.directory",
+    "eos-folder-games-to-hack.directory",
     "eos-folder-social.directory",
     "net.minetest.Minetest.desktop",
     "com.endlessm.cooking.pt.desktop",

--- a/data/settings/icon-grid-th.json.in
+++ b/data/settings/icon-grid-th.json.in
@@ -14,6 +14,7 @@
     "eos-folder-media.directory",
     "eos-folder-curiosity.directory",
     "eos-folder-games.directory",
+    "eos-folder-games-to-hack.directory",
     "eos-folder-social.directory",
     "net.minetest.Minetest.desktop",
     "rhythmbox.desktop"

--- a/data/settings/icon-grid-th.json.in
+++ b/data/settings/icon-grid-th.json.in
@@ -53,7 +53,7 @@
     "com.endlessnetwork.frogsquash.desktop",
     "com.endlessnetwork.passage.desktop",
     "com.endlessnetwork.tankwarrior.desktop",
-    "com.endlessnetwork.midnightmareteddy.desktop",
+    "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],
   "eos-folder-media.directory": [

--- a/data/settings/icon-grid-vi.json.in
+++ b/data/settings/icon-grid-vi.json.in
@@ -54,7 +54,7 @@
     "com.endlessnetwork.frogsquash.desktop",
     "com.endlessnetwork.passage.desktop",
     "com.endlessnetwork.tankwarrior.desktop",
-    "com.endlessnetwork.midnightmareteddy.desktop",
+    "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],
   "eos-folder-media.directory": [

--- a/data/settings/icon-grid-vi.json.in
+++ b/data/settings/icon-grid-vi.json.in
@@ -13,6 +13,7 @@
     "eos-folder-media.directory",
     "eos-folder-curiosity.directory",
     "eos-folder-games.directory",
+    "eos-folder-games-to-hack.directory",
     "eos-folder-social.directory",
     "net.minetest.Minetest.desktop",
     "rhythmbox.desktop"

--- a/data/settings/icon-grid-zh_CN.json.in
+++ b/data/settings/icon-grid-zh_CN.json.in
@@ -6,6 +6,7 @@
     "eos-folder-work.directory",
     "eos-folder-tools.directory",
     "eos-folder-games.directory",
+    "eos-folder-games-to-hack.directory",
     "eos-folder-social.directory",
     "eos-link-duolingo.desktop",
     "org.kde.kwordquiz.desktop",

--- a/data/settings/icon-grid-zh_CN.json.in
+++ b/data/settings/icon-grid-zh_CN.json.in
@@ -41,7 +41,7 @@
     "com.endlessnetwork.frogsquash.desktop",
     "com.endlessnetwork.passage.desktop",
     "com.endlessnetwork.tankwarrior.desktop",
-    "com.endlessnetwork.midnightmareteddy.desktop",
+    "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],
   "eos-folder-social.directory": [

--- a/data/settings/write-grid-json.py
+++ b/data/settings/write-grid-json.py
@@ -44,6 +44,14 @@ for app in cpu_blacklist:
         if app in apps:
             grid[sect].remove(app)
 
+# Check that all directories are in the top-level "desktop" pseudo-directory
+desktop = grid["desktop"]
+for directory in grid:
+    if directory != "desktop" and directory not in desktop:
+        raise ValueError(
+            '"{}" defined but not in "desktop" directory'.format(directory)
+        )
+
 # Write out the new json, keeping the indentation, separators and
 # trailing newline from the original. If successful, rename the
 # temporary file to the final name.


### PR DESCRIPTION
It is not enough to define keys for directories at the top level of the file: they must also be listed in the "desktop" pseudo-directory. Add them there; add a check that would have caught this, and fix the app ID for com.endlessnetwork.MidnightmareTeddy, which has turned out to be CamelCase not lowercase.

https://phabricator.endlessm.com/T25938
https://phabricator.endlessm.com/T26087