### PR TITLE
Add Tank Warriors and Missile Math to icon grid

### DIFF
--- a/data/settings/icon-grid-C.json.in
+++ b/data/settings/icon-grid-C.json.in
@@ -55,7 +55,7 @@
     "com.endlessnetwork.dragonsapprentice.desktop",
     "com.endlessnetwork.frogsquash.desktop",
     "com.endlessnetwork.passage.desktop",
-    "com.endlessnetwork.tankwarrior.desktop",
+    "com.endlessnetwork.tankwarriors.desktop",
     "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],

--- a/data/settings/icon-grid-C.json.in
+++ b/data/settings/icon-grid-C.json.in
@@ -34,6 +34,7 @@
     "eos-link-duolingo.desktop"
   ],
   "eos-folder-games.directory": [
+    "com.endlessnetwork.missilemath.desktop",
     "org.gnome.Aisleriot.desktop",
     "org.gnome.Chess.desktop",
     "net.supertuxkart.SuperTuxKart.desktop",

--- a/data/settings/icon-grid-ar.json.in
+++ b/data/settings/icon-grid-ar.json.in
@@ -25,6 +25,7 @@
     "eos-link-duolingo.desktop"
   ],
   "eos-folder-games.directory": [
+    "com.endlessnetwork.missilemath.desktop",
     "org.gnome.Aisleriot.desktop",
     "org.gnome.Chess.desktop",
     "net.supertuxkart.SuperTuxKart.desktop",

--- a/data/settings/icon-grid-ar.json.in
+++ b/data/settings/icon-grid-ar.json.in
@@ -46,7 +46,7 @@
     "com.endlessnetwork.dragonsapprentice.desktop",
     "com.endlessnetwork.frogsquash.desktop",
     "com.endlessnetwork.passage.desktop",
-    "com.endlessnetwork.tankwarrior.desktop",
+    "com.endlessnetwork.tankwarriors.desktop",
     "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],

--- a/data/settings/icon-grid-bn.json.in
+++ b/data/settings/icon-grid-bn.json.in
@@ -32,6 +32,7 @@
     "eos-link-duolingo.desktop"
   ],
   "eos-folder-games.directory": [
+    "com.endlessnetwork.missilemath.desktop",
     "org.gnome.Aisleriot.desktop",
     "org.gnome.Chess.desktop",
     "net.supertuxkart.SuperTuxKart.desktop",

--- a/data/settings/icon-grid-bn.json.in
+++ b/data/settings/icon-grid-bn.json.in
@@ -53,7 +53,7 @@
     "com.endlessnetwork.dragonsapprentice.desktop",
     "com.endlessnetwork.frogsquash.desktop",
     "com.endlessnetwork.passage.desktop",
-    "com.endlessnetwork.tankwarrior.desktop",
+    "com.endlessnetwork.tankwarriors.desktop",
     "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],

--- a/data/settings/icon-grid-es.json.in
+++ b/data/settings/icon-grid-es.json.in
@@ -31,6 +31,7 @@
     "eos-link-duolingo.desktop"
   ],
   "eos-folder-games.directory": [
+    "com.endlessnetwork.missilemath.desktop",
     "org.gnome.Aisleriot.desktop",
     "org.gnome.Chess.desktop",
     "net.supertuxkart.SuperTuxKart.desktop",

--- a/data/settings/icon-grid-es.json.in
+++ b/data/settings/icon-grid-es.json.in
@@ -52,7 +52,7 @@
     "com.endlessnetwork.dragonsapprentice.desktop",
     "com.endlessnetwork.frogsquash.desktop",
     "com.endlessnetwork.passage.desktop",
-    "com.endlessnetwork.tankwarrior.desktop",
+    "com.endlessnetwork.tankwarriors.desktop",
     "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],

--- a/data/settings/icon-grid-es_GT.json.in
+++ b/data/settings/icon-grid-es_GT.json.in
@@ -32,6 +32,7 @@
     "eos-link-duolingo.desktop"
   ],
   "eos-folder-games.directory": [
+    "com.endlessnetwork.missilemath.desktop",
     "org.gnome.Aisleriot.desktop",
     "org.gnome.Chess.desktop",
     "net.supertuxkart.SuperTuxKart.desktop",

--- a/data/settings/icon-grid-es_GT.json.in
+++ b/data/settings/icon-grid-es_GT.json.in
@@ -53,7 +53,7 @@
     "com.endlessnetwork.dragonsapprentice.desktop",
     "com.endlessnetwork.frogsquash.desktop",
     "com.endlessnetwork.passage.desktop",
-    "com.endlessnetwork.tankwarrior.desktop",
+    "com.endlessnetwork.tankwarriors.desktop",
     "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],

--- a/data/settings/icon-grid-fr.json.in
+++ b/data/settings/icon-grid-fr.json.in
@@ -23,6 +23,7 @@
     "eos-link-duolingo.desktop"
   ],
   "eos-folder-games.directory": [
+    "com.endlessnetwork.missilemath.desktop",
     "org.gnome.Aisleriot.desktop",
     "org.gnome.Chess.desktop",
     "net.supertuxkart.SuperTuxKart.desktop",

--- a/data/settings/icon-grid-fr.json.in
+++ b/data/settings/icon-grid-fr.json.in
@@ -44,7 +44,7 @@
     "com.endlessnetwork.dragonsapprentice.desktop",
     "com.endlessnetwork.frogsquash.desktop",
     "com.endlessnetwork.passage.desktop",
-    "com.endlessnetwork.tankwarrior.desktop",
+    "com.endlessnetwork.tankwarriors.desktop",
     "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],

--- a/data/settings/icon-grid-id.json.in
+++ b/data/settings/icon-grid-id.json.in
@@ -68,7 +68,7 @@
     "com.endlessnetwork.dragonsapprentice.desktop",
     "com.endlessnetwork.frogsquash.desktop",
     "com.endlessnetwork.passage.desktop",
-    "com.endlessnetwork.tankwarrior.desktop",
+    "com.endlessnetwork.tankwarriors.desktop",
     "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],

--- a/data/settings/icon-grid-id.json.in
+++ b/data/settings/icon-grid-id.json.in
@@ -47,6 +47,7 @@
     "com.endlessm.video_animations.desktop"
   ],
   "eos-folder-games.directory": [
+    "com.endlessnetwork.missilemath.desktop",
     "org.gnome.Aisleriot.desktop",
     "org.gnome.Chess.desktop",
     "net.supertuxkart.SuperTuxKart.desktop",

--- a/data/settings/icon-grid-pt.json.in
+++ b/data/settings/icon-grid-pt.json.in
@@ -32,6 +32,7 @@
     "eos-link-duolingo.desktop"
   ],
   "eos-folder-games.directory": [
+    "com.endlessnetwork.missilemath.desktop",
     "org.gnome.Aisleriot.desktop",
     "org.gnome.Chess.desktop",
     "net.supertuxkart.SuperTuxKart.desktop",

--- a/data/settings/icon-grid-pt.json.in
+++ b/data/settings/icon-grid-pt.json.in
@@ -53,7 +53,7 @@
     "com.endlessnetwork.dragonsapprentice.desktop",
     "com.endlessnetwork.frogsquash.desktop",
     "com.endlessnetwork.passage.desktop",
-    "com.endlessnetwork.tankwarrior.desktop",
+    "com.endlessnetwork.tankwarriors.desktop",
     "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],

--- a/data/settings/icon-grid-th.json.in
+++ b/data/settings/icon-grid-th.json.in
@@ -31,6 +31,7 @@
     "eos-link-duolingo.desktop"
   ],
   "eos-folder-games.directory": [
+    "com.endlessnetwork.missilemath.desktop",
     "org.gnome.Aisleriot.desktop",
     "org.gnome.Chess.desktop",
     "net.supertuxkart.SuperTuxKart.desktop",

--- a/data/settings/icon-grid-th.json.in
+++ b/data/settings/icon-grid-th.json.in
@@ -52,7 +52,7 @@
     "com.endlessnetwork.dragonsapprentice.desktop",
     "com.endlessnetwork.frogsquash.desktop",
     "com.endlessnetwork.passage.desktop",
-    "com.endlessnetwork.tankwarrior.desktop",
+    "com.endlessnetwork.tankwarriors.desktop",
     "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],

--- a/data/settings/icon-grid-vi.json.in
+++ b/data/settings/icon-grid-vi.json.in
@@ -32,6 +32,7 @@
     "eos-link-duolingo.desktop"
   ],
   "eos-folder-games.directory": [
+    "com.endlessnetwork.missilemath.desktop",
     "org.gnome.Aisleriot.desktop",
     "org.gnome.Chess.desktop",
     "net.supertuxkart.SuperTuxKart.desktop",

--- a/data/settings/icon-grid-vi.json.in
+++ b/data/settings/icon-grid-vi.json.in
@@ -53,7 +53,7 @@
     "com.endlessnetwork.dragonsapprentice.desktop",
     "com.endlessnetwork.frogsquash.desktop",
     "com.endlessnetwork.passage.desktop",
-    "com.endlessnetwork.tankwarrior.desktop",
+    "com.endlessnetwork.tankwarriors.desktop",
     "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],

--- a/data/settings/icon-grid-zh_CN.json.in
+++ b/data/settings/icon-grid-zh_CN.json.in
@@ -18,6 +18,7 @@
     "com.endlessm.chinese_curriculum_english.zh_CN.desktop"
   ],
   "eos-folder-games.directory": [
+    "com.endlessnetwork.missilemath.desktop",
     "org.gnome.Aisleriot.desktop",
     "org.gnome.Chess.desktop",
     "net.supertuxkart.SuperTuxKart.desktop",

--- a/data/settings/icon-grid-zh_CN.json.in
+++ b/data/settings/icon-grid-zh_CN.json.in
@@ -40,7 +40,7 @@
     "com.endlessnetwork.dragonsapprentice.desktop",
     "com.endlessnetwork.frogsquash.desktop",
     "com.endlessnetwork.passage.desktop",
-    "com.endlessnetwork.tankwarrior.desktop",
+    "com.endlessnetwork.tankwarriors.desktop",
     "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],


### PR DESCRIPTION
Tested by installing all apps, copying `icon-grid-C.json.in` to `/var/lib/eos-image-defaults/icon-grid/icon-grid-C.json`, and running `eos-reset-desktop`.

![Screenshot from 2019-04-12 11-44-26](https://user-images.githubusercontent.com/86760/56031820-69f87680-5d18-11e9-9b61-fcfe696704b2.png)
![Screenshot from 2019-04-12 11-44-05](https://user-images.githubusercontent.com/86760/56031821-6a910d00-5d18-11e9-92a6-9edde7323365.png)



https://phabricator.endlessm.com/T25938