### PR TITLE
Add get_ game launchers to icon-grid

### DIFF
--- a/data/settings/arch-blacklist.json
+++ b/data/settings/arch-blacklist.json
@@ -1,9 +1,16 @@
 {
   "arm" : [
+      "eos-aqueducts.desktop",
+      "eos-dragons-apprentice.desktop",
       "eos-folder-games-to-hack.directory",
+      "eos-frog-squash.desktop",
+      "eos-midnightmare-teddy.desktop",
+      "eos-missile-math.desktop",
+      "eos-passage.desktop",
       "eos-skype.desktop",
       "eos-spotify.desktop",
-      "eos-vlc.desktop",
-      "eos-unity.desktop"
+      "eos-tank-warriors.desktop",
+      "eos-unity.desktop",
+      "eos-vlc.desktop"
   ]
 }

--- a/data/settings/icon-grid-C.json.in
+++ b/data/settings/icon-grid-C.json.in
@@ -35,6 +35,7 @@
   ],
   "eos-folder-games.directory": [
     "com.endlessnetwork.missilemath.desktop",
+    "eos-missile-math.desktop",
     "org.gnome.Aisleriot.desktop",
     "org.gnome.Chess.desktop",
     "net.supertuxkart.SuperTuxKart.desktop",
@@ -53,11 +54,17 @@
   ],
   "eos-folder-games-to-hack.directory": [
     "com.endlessnetwork.aqueducts.desktop",
+    "eos-aqueducts.desktop",
     "com.endlessnetwork.dragonsapprentice.desktop",
+    "eos-dragons-apprentice.desktop",
     "com.endlessnetwork.frogsquash.desktop",
+    "eos-frog-squash.desktop",
     "com.endlessnetwork.passage.desktop",
+    "eos-passage.desktop",
     "com.endlessnetwork.tankwarriors.desktop",
+    "eos-tank-warriors.desktop",
     "com.endlessnetwork.MidnightmareTeddy.desktop",
+    "eos-midnightmare-teddy.desktop",
     "eos-unity.desktop"
   ],
   "eos-folder-learn-to-code.directory": [

--- a/data/settings/icon-grid-ar.json.in
+++ b/data/settings/icon-grid-ar.json.in
@@ -26,6 +26,7 @@
   ],
   "eos-folder-games.directory": [
     "com.endlessnetwork.missilemath.desktop",
+    "eos-missile-math.desktop",
     "org.gnome.Aisleriot.desktop",
     "org.gnome.Chess.desktop",
     "net.supertuxkart.SuperTuxKart.desktop",
@@ -44,11 +45,17 @@
   ],
   "eos-folder-games-to-hack.directory": [
     "com.endlessnetwork.aqueducts.desktop",
+    "eos-aqueducts.desktop",
     "com.endlessnetwork.dragonsapprentice.desktop",
+    "eos-dragons-apprentice.desktop",
     "com.endlessnetwork.frogsquash.desktop",
+    "eos-frog-squash.desktop",
     "com.endlessnetwork.passage.desktop",
+    "eos-passage.desktop",
     "com.endlessnetwork.tankwarriors.desktop",
+    "eos-tank-warriors.desktop",
     "com.endlessnetwork.MidnightmareTeddy.desktop",
+    "eos-midnightmare-teddy.desktop",
     "eos-unity.desktop"
   ],
   "eos-folder-media.directory": [

--- a/data/settings/icon-grid-bn.json.in
+++ b/data/settings/icon-grid-bn.json.in
@@ -33,6 +33,7 @@
   ],
   "eos-folder-games.directory": [
     "com.endlessnetwork.missilemath.desktop",
+    "eos-missile-math.desktop",
     "org.gnome.Aisleriot.desktop",
     "org.gnome.Chess.desktop",
     "net.supertuxkart.SuperTuxKart.desktop",
@@ -51,11 +52,17 @@
   ],
   "eos-folder-games-to-hack.directory": [
     "com.endlessnetwork.aqueducts.desktop",
+    "eos-aqueducts.desktop",
     "com.endlessnetwork.dragonsapprentice.desktop",
+    "eos-dragons-apprentice.desktop",
     "com.endlessnetwork.frogsquash.desktop",
+    "eos-frog-squash.desktop",
     "com.endlessnetwork.passage.desktop",
+    "eos-passage.desktop",
     "com.endlessnetwork.tankwarriors.desktop",
+    "eos-tank-warriors.desktop",
     "com.endlessnetwork.MidnightmareTeddy.desktop",
+    "eos-midnightmare-teddy.desktop",
     "eos-unity.desktop"
   ],
   "eos-folder-media.directory": [

--- a/data/settings/icon-grid-es.json.in
+++ b/data/settings/icon-grid-es.json.in
@@ -32,6 +32,7 @@
   ],
   "eos-folder-games.directory": [
     "com.endlessnetwork.missilemath.desktop",
+    "eos-missile-math.desktop",
     "org.gnome.Aisleriot.desktop",
     "org.gnome.Chess.desktop",
     "net.supertuxkart.SuperTuxKart.desktop",
@@ -50,11 +51,17 @@
   ],
   "eos-folder-games-to-hack.directory": [
     "com.endlessnetwork.aqueducts.desktop",
+    "eos-aqueducts.desktop",
     "com.endlessnetwork.dragonsapprentice.desktop",
+    "eos-dragons-apprentice.desktop",
     "com.endlessnetwork.frogsquash.desktop",
+    "eos-frog-squash.desktop",
     "com.endlessnetwork.passage.desktop",
+    "eos-passage.desktop",
     "com.endlessnetwork.tankwarriors.desktop",
+    "eos-tank-warriors.desktop",
     "com.endlessnetwork.MidnightmareTeddy.desktop",
+    "eos-midnightmare-teddy.desktop",
     "eos-unity.desktop"
   ],
   "eos-folder-media.directory": [

--- a/data/settings/icon-grid-es_GT.json.in
+++ b/data/settings/icon-grid-es_GT.json.in
@@ -33,6 +33,7 @@
   ],
   "eos-folder-games.directory": [
     "com.endlessnetwork.missilemath.desktop",
+    "eos-missile-math.desktop",
     "org.gnome.Aisleriot.desktop",
     "org.gnome.Chess.desktop",
     "net.supertuxkart.SuperTuxKart.desktop",
@@ -51,11 +52,17 @@
   ],
   "eos-folder-games-to-hack.directory": [
     "com.endlessnetwork.aqueducts.desktop",
+    "eos-aqueducts.desktop",
     "com.endlessnetwork.dragonsapprentice.desktop",
+    "eos-dragons-apprentice.desktop",
     "com.endlessnetwork.frogsquash.desktop",
+    "eos-frog-squash.desktop",
     "com.endlessnetwork.passage.desktop",
+    "eos-passage.desktop",
     "com.endlessnetwork.tankwarriors.desktop",
+    "eos-tank-warriors.desktop",
     "com.endlessnetwork.MidnightmareTeddy.desktop",
+    "eos-midnightmare-teddy.desktop",
     "eos-unity.desktop"
   ],
   "eos-folder-media.directory": [

--- a/data/settings/icon-grid-fr.json.in
+++ b/data/settings/icon-grid-fr.json.in
@@ -24,6 +24,7 @@
   ],
   "eos-folder-games.directory": [
     "com.endlessnetwork.missilemath.desktop",
+    "eos-missile-math.desktop",
     "org.gnome.Aisleriot.desktop",
     "org.gnome.Chess.desktop",
     "net.supertuxkart.SuperTuxKart.desktop",
@@ -42,11 +43,17 @@
   ],
   "eos-folder-games-to-hack.directory": [
     "com.endlessnetwork.aqueducts.desktop",
+    "eos-aqueducts.desktop",
     "com.endlessnetwork.dragonsapprentice.desktop",
+    "eos-dragons-apprentice.desktop",
     "com.endlessnetwork.frogsquash.desktop",
+    "eos-frog-squash.desktop",
     "com.endlessnetwork.passage.desktop",
+    "eos-passage.desktop",
     "com.endlessnetwork.tankwarriors.desktop",
+    "eos-tank-warriors.desktop",
     "com.endlessnetwork.MidnightmareTeddy.desktop",
+    "eos-midnightmare-teddy.desktop",
     "eos-unity.desktop"
   ],
   "eos-folder-media.directory": [

--- a/data/settings/icon-grid-id.json.in
+++ b/data/settings/icon-grid-id.json.in
@@ -48,6 +48,7 @@
   ],
   "eos-folder-games.directory": [
     "com.endlessnetwork.missilemath.desktop",
+    "eos-missile-math.desktop",
     "org.gnome.Aisleriot.desktop",
     "org.gnome.Chess.desktop",
     "net.supertuxkart.SuperTuxKart.desktop",
@@ -66,11 +67,17 @@
   ],
   "eos-folder-games-to-hack.directory": [
     "com.endlessnetwork.aqueducts.desktop",
+    "eos-aqueducts.desktop",
     "com.endlessnetwork.dragonsapprentice.desktop",
+    "eos-dragons-apprentice.desktop",
     "com.endlessnetwork.frogsquash.desktop",
+    "eos-frog-squash.desktop",
     "com.endlessnetwork.passage.desktop",
+    "eos-passage.desktop",
     "com.endlessnetwork.tankwarriors.desktop",
+    "eos-tank-warriors.desktop",
     "com.endlessnetwork.MidnightmareTeddy.desktop",
+    "eos-midnightmare-teddy.desktop",
     "eos-unity.desktop"
   ],
   "eos-folder-media.directory": [

--- a/data/settings/icon-grid-pt.json.in
+++ b/data/settings/icon-grid-pt.json.in
@@ -33,6 +33,7 @@
   ],
   "eos-folder-games.directory": [
     "com.endlessnetwork.missilemath.desktop",
+    "eos-missile-math.desktop",
     "org.gnome.Aisleriot.desktop",
     "org.gnome.Chess.desktop",
     "net.supertuxkart.SuperTuxKart.desktop",
@@ -51,11 +52,17 @@
   ],
   "eos-folder-games-to-hack.directory": [
     "com.endlessnetwork.aqueducts.desktop",
+    "eos-aqueducts.desktop",
     "com.endlessnetwork.dragonsapprentice.desktop",
+    "eos-dragons-apprentice.desktop",
     "com.endlessnetwork.frogsquash.desktop",
+    "eos-frog-squash.desktop",
     "com.endlessnetwork.passage.desktop",
+    "eos-passage.desktop",
     "com.endlessnetwork.tankwarriors.desktop",
+    "eos-tank-warriors.desktop",
     "com.endlessnetwork.MidnightmareTeddy.desktop",
+    "eos-midnightmare-teddy.desktop",
     "eos-unity.desktop"
   ],
   "eos-folder-media.directory": [

--- a/data/settings/icon-grid-th.json.in
+++ b/data/settings/icon-grid-th.json.in
@@ -32,6 +32,7 @@
   ],
   "eos-folder-games.directory": [
     "com.endlessnetwork.missilemath.desktop",
+    "eos-missile-math.desktop",
     "org.gnome.Aisleriot.desktop",
     "org.gnome.Chess.desktop",
     "net.supertuxkart.SuperTuxKart.desktop",
@@ -50,11 +51,17 @@
   ],
   "eos-folder-games-to-hack.directory": [
     "com.endlessnetwork.aqueducts.desktop",
+    "eos-aqueducts.desktop",
     "com.endlessnetwork.dragonsapprentice.desktop",
+    "eos-dragons-apprentice.desktop",
     "com.endlessnetwork.frogsquash.desktop",
+    "eos-frog-squash.desktop",
     "com.endlessnetwork.passage.desktop",
+    "eos-passage.desktop",
     "com.endlessnetwork.tankwarriors.desktop",
+    "eos-tank-warriors.desktop",
     "com.endlessnetwork.MidnightmareTeddy.desktop",
+    "eos-midnightmare-teddy.desktop",
     "eos-unity.desktop"
   ],
   "eos-folder-media.directory": [

--- a/data/settings/icon-grid-vi.json.in
+++ b/data/settings/icon-grid-vi.json.in
@@ -33,6 +33,7 @@
   ],
   "eos-folder-games.directory": [
     "com.endlessnetwork.missilemath.desktop",
+    "eos-missile-math.desktop",
     "org.gnome.Aisleriot.desktop",
     "org.gnome.Chess.desktop",
     "net.supertuxkart.SuperTuxKart.desktop",
@@ -51,11 +52,17 @@
   ],
   "eos-folder-games-to-hack.directory": [
     "com.endlessnetwork.aqueducts.desktop",
+    "eos-aqueducts.desktop",
     "com.endlessnetwork.dragonsapprentice.desktop",
+    "eos-dragons-apprentice.desktop",
     "com.endlessnetwork.frogsquash.desktop",
+    "eos-frog-squash.desktop",
     "com.endlessnetwork.passage.desktop",
+    "eos-passage.desktop",
     "com.endlessnetwork.tankwarriors.desktop",
+    "eos-tank-warriors.desktop",
     "com.endlessnetwork.MidnightmareTeddy.desktop",
+    "eos-midnightmare-teddy.desktop",
     "eos-unity.desktop"
   ],
   "eos-folder-media.directory": [

--- a/data/settings/icon-grid-zh_CN.json.in
+++ b/data/settings/icon-grid-zh_CN.json.in
@@ -19,6 +19,7 @@
   ],
   "eos-folder-games.directory": [
     "com.endlessnetwork.missilemath.desktop",
+    "eos-missile-math.desktop",
     "org.gnome.Aisleriot.desktop",
     "org.gnome.Chess.desktop",
     "net.supertuxkart.SuperTuxKart.desktop",
@@ -38,11 +39,17 @@
   ],
   "eos-folder-games-to-hack.directory": [
     "com.endlessnetwork.aqueducts.desktop",
+    "eos-aqueducts.desktop",
     "com.endlessnetwork.dragonsapprentice.desktop",
+    "eos-dragons-apprentice.desktop",
     "com.endlessnetwork.frogsquash.desktop",
+    "eos-frog-squash.desktop",
     "com.endlessnetwork.passage.desktop",
+    "eos-passage.desktop",
     "com.endlessnetwork.tankwarriors.desktop",
+    "eos-tank-warriors.desktop",
     "com.endlessnetwork.MidnightmareTeddy.desktop",
+    "eos-midnightmare-teddy.desktop",
     "eos-unity.desktop"
   ],
   "eos-folder-social.directory": [


### PR DESCRIPTION
Add the endlessnetwork games get_ launchers to the default icon-grid.

https://phabricator.endlessm.com/T26080