### PR TITLE
icon-grid: add missing Endless Network knowledge apps

### DIFF
--- a/data/settings/icon-grid-C.json.in
+++ b/data/settings/icon-grid-C.json.in
@@ -64,10 +64,12 @@
     "com.endlessnetwork.arduinoprojects.desktop",
     "com.endlessnetwork.blendertutorials.desktop",
     "com.endlessnetwork.csstutorials.desktop",
+    "com.endlessnetwork.drawingtutorials.desktop",
     "com.endlessnetwork.htmltutorials.desktop",
     "com.endlessnetwork.raspberrypiprojects.desktop",
     "com.endlessnetwork.sciencesnacks.desktop",
-    "com.endlessnetwork.shortfilms.desktop"
+    "com.endlessnetwork.shortfilms.desktop",
+    "com.endlessnetwork.videogamestutorials.desktop"
   ],
   "eos-folder-media.directory": [
     "com.endlessm.photos.desktop",

--- a/data/settings/icon-grid-C.json.in
+++ b/data/settings/icon-grid-C.json.in
@@ -22,6 +22,8 @@
     "rhythmbox.desktop"
   ],
   "eos-folder-curiosity.directory": [
+    "com.endlessnetwork.sciencesnacks.desktop",
+    "com.endlessnetwork.shortfilms.desktop",
     "com.endlessm.celebrities.en.desktop",
     "com.endlessm.myths.en.desktop",
     "com.endlessm.math.en.desktop",
@@ -62,13 +64,9 @@
   ],
   "eos-folder-learn-to-code.directory": [
     "com.endlessnetwork.arduinoprojects.desktop",
-    "com.endlessnetwork.blendertutorials.desktop",
     "com.endlessnetwork.csstutorials.desktop",
-    "com.endlessnetwork.drawingtutorials.desktop",
     "com.endlessnetwork.htmltutorials.desktop",
     "com.endlessnetwork.raspberrypiprojects.desktop",
-    "com.endlessnetwork.sciencesnacks.desktop",
-    "com.endlessnetwork.shortfilms.desktop",
     "com.endlessnetwork.videogamestutorials.desktop"
   ],
   "eos-folder-media.directory": [
@@ -79,7 +77,9 @@
     "org.tuxpaint.Tuxpaint.desktop",
     "org.audacityteam.Audacity.desktop",
     "com.endlessm.world_literature.en.desktop",
-    "org.gimp.GIMP.desktop"
+    "org.gimp.GIMP.desktop",
+    "com.endlessnetwork.blendertutorials.desktop",
+    "com.endlessnetwork.drawingtutorials.desktop"
   ],
   "eos-folder-social.directory": [
     "eos-link-twitter.desktop",

--- a/data/settings/icon-grid-C.json.in
+++ b/data/settings/icon-grid-C.json.in
@@ -61,13 +61,13 @@
     "eos-unity.desktop"
   ],
   "eos-folder-learn-to-code.directory": [
+    "com.endlessnetwork.arduinoprojects.desktop",
+    "com.endlessnetwork.blendertutorials.desktop",
     "com.endlessnetwork.csstutorials.desktop",
     "com.endlessnetwork.htmltutorials.desktop",
-    "com.endlessnetwork.blendertutorials.desktop",
-    "com.endlessnetwork.shortfilms.desktop",
+    "com.endlessnetwork.raspberrypiprojects.desktop",
     "com.endlessnetwork.sciencesnacks.desktop",
-    "com.endlessnetwork.arduinoprojects.desktop",
-    "com.endlessnetwork.raspberrypiprojects.desktop"
+    "com.endlessnetwork.shortfilms.desktop"
   ],
   "eos-folder-media.directory": [
     "com.endlessm.photos.desktop",


### PR DESCRIPTION
I also moved some of them out of Learn to Code since they have nothing to do with coding.

https://phabricator.endlessm.com/T26235