### PR TITLE
data/settings: Remove retired/non-existent apps from icon grids

### DIFF
--- a/data/settings/icon-grid-id.json.in
+++ b/data/settings/icon-grid-id.json.in
@@ -41,7 +41,6 @@
     "com.endlessm.translation.desktop",
     "com.endlessm.marischkaprudence.id.desktop",
     "eos-link-duolingo.desktop",
-    "com.endlessm.video_funny_videos.desktop",
     "com.endlessm.video_kids.desktop",
     "com.endlessm.video_movement.desktop",
     "com.endlessm.video_animations.desktop"

--- a/data/settings/icon-grid-pt.json.in
+++ b/data/settings/icon-grid-pt.json.in
@@ -17,7 +17,6 @@
     "eos-folder-social.directory",
     "net.minetest.Minetest.desktop",
     "com.endlessm.cooking.pt.desktop",
-    "com.endlessm.omelete.pt.desktop",
     "rhythmbox.desktop"
   ],
   "eos-folder-curiosity.directory": [
@@ -25,8 +24,6 @@
     "com.endlessm.math.pt.desktop",
     "com.endlessm.howto.pt.desktop",
     "com.endlessm.travel.pt.desktop",
-    "com.endlessm.health.pt.desktop",
-    "com.endlessm.maternity.pt.desktop",
     "com.endlessm.dinosaurs.pt.desktop",
     "com.endlessm.translation.desktop",
     "eos-link-duolingo.desktop"

--- a/data/settings/icon-grid-th.json.in
+++ b/data/settings/icon-grid-th.json.in
@@ -10,7 +10,6 @@
     "eos-link-facebook.desktop",
     "eos-link-whatsapp.desktop",
     "eos-link-youtube.desktop",
-    "com.endlessm.duet_diary.th.desktop",
     "eos-folder-media.directory",
     "eos-folder-curiosity.directory",
     "eos-folder-games.directory",


### PR DESCRIPTION
Never existed:
com.endlessm.health.pt
com.endlessm.maternity.pt

Intentionally retired for quality, maintainence or licence reasons:
com.endlessm.video_funny_videos
com.endlessm.omelete.pt
com.endlessm.duet_diary.th

https://phabricator.endlessm.com/T27026