### PR TITLE
Refresh default icon grids

### DIFF
--- a/data/settings/icon-grid-C.json.in
+++ b/data/settings/icon-grid-C.json.in
@@ -80,6 +80,7 @@
     "org.audacityteam.Audacity.desktop",
     "com.endlessm.world_literature.en.desktop",
     "org.gimp.GIMP.desktop",
+    "org.inkscape.Inkscape.desktop",
     "com.endlessnetwork.blendertutorials.desktop",
     "com.endlessnetwork.drawingtutorials.desktop"
   ],

--- a/data/settings/icon-grid-C.json.in
+++ b/data/settings/icon-grid-C.json.in
@@ -82,6 +82,8 @@
     "com.endlessm.world_literature.en.desktop",
     "org.gimp.GIMP.desktop",
     "org.inkscape.Inkscape.desktop",
+    "org.pitivi.Pitivi.desktop",
+    "org.blender.Blender.desktop",
     "com.endlessnetwork.blendertutorials.desktop",
     "com.endlessnetwork.drawingtutorials.desktop"
   ],

--- a/data/settings/icon-grid-C.json.in
+++ b/data/settings/icon-grid-C.json.in
@@ -57,10 +57,10 @@
     "com.endlessnetwork.dragonsapprentice.desktop",
     "com.endlessnetwork.fablemaker.desktop",
     "com.endlessnetwork.frogsquash.desktop",
+    "com.endlessnetwork.MidnightmareTeddy.desktop",
     "com.endlessnetwork.passage.desktop",
     "com.endlessnetwork.tankwarriors.desktop",
     "com.endlessnetwork.whitehouse.desktop",
-    "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],
   "eos-folder-learn-to-code.directory": [

--- a/data/settings/icon-grid-C.json.in
+++ b/data/settings/icon-grid-C.json.in
@@ -56,9 +56,11 @@
   "eos-folder-games-to-hack.directory": [
     "com.endlessnetwork.aqueducts.desktop",
     "com.endlessnetwork.dragonsapprentice.desktop",
+    "com.endlessnetwork.fablemaker.desktop",
     "com.endlessnetwork.frogsquash.desktop",
     "com.endlessnetwork.passage.desktop",
     "com.endlessnetwork.tankwarriors.desktop",
+    "com.endlessnetwork.whitehouse.desktop",
     "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],

--- a/data/settings/icon-grid-C.json.in
+++ b/data/settings/icon-grid-C.json.in
@@ -2,9 +2,9 @@
   "desktop": [
     "chromium-browser.desktop",
     "org.gnome.Nautilus.desktop",
-    "org.libreoffice.LibreOffice-writer.desktop",
-    "org.libreoffice.LibreOffice-calc.desktop",
-    "org.libreoffice.LibreOffice-impress.desktop",
+    "org.libreoffice.LibreOffice.writer.desktop",
+    "org.libreoffice.LibreOffice.calc.desktop",
+    "org.libreoffice.LibreOffice.impress.desktop",
     "com.endlessm.encyclopedia.en.desktop",
     "eos-vlc.desktop",
     "eos-link-facebook.desktop",

--- a/data/settings/icon-grid-C.json.in
+++ b/data/settings/icon-grid-C.json.in
@@ -64,6 +64,8 @@
     "eos-unity.desktop"
   ],
   "eos-folder-learn-to-code.directory": [
+    "edu.mit.Scratch.desktop",
+    "org.laptop.TurtleArtActivity.desktop",
     "com.endlessnetwork.arduinoprojects.desktop",
     "com.endlessnetwork.csstutorials.desktop",
     "com.endlessnetwork.htmltutorials.desktop",

--- a/data/settings/icon-grid-C.json.in
+++ b/data/settings/icon-grid-C.json.in
@@ -32,7 +32,6 @@
     "com.endlessm.health.en.desktop",
     "com.endlessm.dinosaurs.en.desktop",
     "com.endlessm.animals.en.desktop",
-    "com.endlessm.translation.desktop",
     "eos-link-duolingo.desktop"
   ],
   "eos-folder-games.directory": [

--- a/data/settings/icon-grid-ar.json.in
+++ b/data/settings/icon-grid-ar.json.in
@@ -21,7 +21,6 @@
   ],
   "eos-folder-curiosity.directory": [
     "com.endlessm.health.ar.desktop",
-    "com.endlessm.translation.desktop",
     "eos-link-duolingo.desktop"
   ],
   "eos-folder-games.directory": [

--- a/data/settings/icon-grid-ar.json.in
+++ b/data/settings/icon-grid-ar.json.in
@@ -47,10 +47,10 @@
     "com.endlessnetwork.dragonsapprentice.desktop",
     "com.endlessnetwork.fablemaker.desktop",
     "com.endlessnetwork.frogsquash.desktop",
+    "com.endlessnetwork.MidnightmareTeddy.desktop",
     "com.endlessnetwork.passage.desktop",
     "com.endlessnetwork.tankwarriors.desktop",
     "com.endlessnetwork.whitehouse.desktop",
-    "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],
   "eos-folder-media.directory": [

--- a/data/settings/icon-grid-ar.json.in
+++ b/data/settings/icon-grid-ar.json.in
@@ -59,7 +59,8 @@
     "org.gnome.Totem.desktop",
     "org.tuxpaint.Tuxpaint.desktop",
     "org.audacityteam.Audacity.desktop",
-    "org.gimp.GIMP.desktop"
+    "org.gimp.GIMP.desktop",
+    "org.inkscape.Inkscape.desktop"
   ],
   "eos-folder-social.directory": [
     "eos-link-twitter.desktop",

--- a/data/settings/icon-grid-ar.json.in
+++ b/data/settings/icon-grid-ar.json.in
@@ -45,9 +45,11 @@
   "eos-folder-games-to-hack.directory": [
     "com.endlessnetwork.aqueducts.desktop",
     "com.endlessnetwork.dragonsapprentice.desktop",
+    "com.endlessnetwork.fablemaker.desktop",
     "com.endlessnetwork.frogsquash.desktop",
     "com.endlessnetwork.passage.desktop",
     "com.endlessnetwork.tankwarriors.desktop",
+    "com.endlessnetwork.whitehouse.desktop",
     "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],

--- a/data/settings/icon-grid-ar.json.in
+++ b/data/settings/icon-grid-ar.json.in
@@ -2,9 +2,9 @@
   "desktop": [
     "chromium-browser.desktop",
     "org.gnome.Nautilus.desktop",
-    "org.libreoffice.LibreOffice-writer.desktop",
-    "org.libreoffice.LibreOffice-calc.desktop",
-    "org.libreoffice.LibreOffice-impress.desktop",
+    "org.libreoffice.LibreOffice.writer.desktop",
+    "org.libreoffice.LibreOffice.calc.desktop",
+    "org.libreoffice.LibreOffice.impress.desktop",
     "com.endlessm.encyclopedia.ar.desktop",
     "eos-vlc.desktop",
     "eos-link-facebook.desktop",

--- a/data/settings/icon-grid-ar.json.in
+++ b/data/settings/icon-grid-ar.json.in
@@ -13,6 +13,7 @@
     "eos-folder-media.directory",
     "eos-folder-curiosity.directory",
     "eos-folder-games.directory",
+    "eos-folder-learn-to-code.directory",
     "eos-folder-games-to-hack.directory",
     "eos-folder-social.directory",
     "net.minetest.Minetest.desktop",
@@ -66,5 +67,9 @@
     "evolution.desktop",
     "eos-skype.desktop",
     "eos-link-gmail.desktop"
+  ],
+  "eos-folder-learn-to-code.directory": [
+    "edu.mit.Scratch.desktop",
+    "org.laptop.TurtleArtActivity.desktop"
   ]
 }

--- a/data/settings/icon-grid-ar.json.in
+++ b/data/settings/icon-grid-ar.json.in
@@ -60,7 +60,9 @@
     "org.tuxpaint.Tuxpaint.desktop",
     "org.audacityteam.Audacity.desktop",
     "org.gimp.GIMP.desktop",
-    "org.inkscape.Inkscape.desktop"
+    "org.inkscape.Inkscape.desktop",
+    "org.pitivi.Pitivi.desktop",
+    "org.blender.Blender.desktop"
   ],
   "eos-folder-social.directory": [
     "eos-link-twitter.desktop",

--- a/data/settings/icon-grid-bn.json.in
+++ b/data/settings/icon-grid-bn.json.in
@@ -67,7 +67,9 @@
     "org.tuxpaint.Tuxpaint.desktop",
     "org.audacityteam.Audacity.desktop",
     "org.gimp.GIMP.desktop",
-    "org.inkscape.Inkscape.desktop"
+    "org.inkscape.Inkscape.desktop",
+    "org.pitivi.Pitivi.desktop",
+    "org.blender.Blender.desktop"
   ],
   "eos-folder-social.directory": [
     "eos-link-twitter.desktop",

--- a/data/settings/icon-grid-bn.json.in
+++ b/data/settings/icon-grid-bn.json.in
@@ -52,9 +52,11 @@
   "eos-folder-games-to-hack.directory": [
     "com.endlessnetwork.aqueducts.desktop",
     "com.endlessnetwork.dragonsapprentice.desktop",
+    "com.endlessnetwork.fablemaker.desktop",
     "com.endlessnetwork.frogsquash.desktop",
     "com.endlessnetwork.passage.desktop",
     "com.endlessnetwork.tankwarriors.desktop",
+    "com.endlessnetwork.whitehouse.desktop",
     "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],

--- a/data/settings/icon-grid-bn.json.in
+++ b/data/settings/icon-grid-bn.json.in
@@ -2,9 +2,9 @@
   "desktop": [
     "chromium-browser.desktop",
     "org.gnome.Nautilus.desktop",
-    "org.libreoffice.LibreOffice-writer.desktop",
-    "org.libreoffice.LibreOffice-calc.desktop",
-    "org.libreoffice.LibreOffice-impress.desktop",
+    "org.libreoffice.LibreOffice.writer.desktop",
+    "org.libreoffice.LibreOffice.calc.desktop",
+    "org.libreoffice.LibreOffice.impress.desktop",
     "com.endlessm.bengali_curriculum.bn_BD.desktop",
     "eos-vlc.desktop",
     "eos-link-facebook.desktop",

--- a/data/settings/icon-grid-bn.json.in
+++ b/data/settings/icon-grid-bn.json.in
@@ -13,6 +13,7 @@
     "eos-folder-media.directory",
     "eos-folder-curiosity.directory",
     "eos-folder-games.directory",
+    "eos-folder-learn-to-code.directory",
     "eos-folder-games-to-hack.directory",
     "eos-folder-social.directory",
     "net.minetest.Minetest.desktop",
@@ -73,5 +74,9 @@
     "evolution.desktop",
     "eos-skype.desktop",
     "eos-link-gmail.desktop"
+  ],
+  "eos-folder-learn-to-code.directory": [
+    "edu.mit.Scratch.desktop",
+    "org.laptop.TurtleArtActivity.desktop"
   ]
 }

--- a/data/settings/icon-grid-bn.json.in
+++ b/data/settings/icon-grid-bn.json.in
@@ -66,7 +66,8 @@
     "org.gnome.Totem.desktop",
     "org.tuxpaint.Tuxpaint.desktop",
     "org.audacityteam.Audacity.desktop",
-    "org.gimp.GIMP.desktop"
+    "org.gimp.GIMP.desktop",
+    "org.inkscape.Inkscape.desktop"
   ],
   "eos-folder-social.directory": [
     "eos-link-twitter.desktop",

--- a/data/settings/icon-grid-bn.json.in
+++ b/data/settings/icon-grid-bn.json.in
@@ -54,10 +54,10 @@
     "com.endlessnetwork.dragonsapprentice.desktop",
     "com.endlessnetwork.fablemaker.desktop",
     "com.endlessnetwork.frogsquash.desktop",
+    "com.endlessnetwork.MidnightmareTeddy.desktop",
     "com.endlessnetwork.passage.desktop",
     "com.endlessnetwork.tankwarriors.desktop",
     "com.endlessnetwork.whitehouse.desktop",
-    "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],
   "eos-folder-media.directory": [

--- a/data/settings/icon-grid-bn.json.in
+++ b/data/settings/icon-grid-bn.json.in
@@ -28,7 +28,6 @@
     "com.endlessm.history.bn_BD.desktop",
     "com.endlessm.soccer.bn_BD.desktop",
     "com.endlessm.travel.bn_BD.desktop",
-    "com.endlessm.translation.desktop",
     "eos-link-duolingo.desktop"
   ],
   "eos-folder-games.directory": [

--- a/data/settings/icon-grid-es.json.in
+++ b/data/settings/icon-grid-es.json.in
@@ -53,10 +53,10 @@
     "com.endlessnetwork.dragonsapprentice.desktop",
     "com.endlessnetwork.fablemaker.desktop",
     "com.endlessnetwork.frogsquash.desktop",
+    "com.endlessnetwork.MidnightmareTeddy.desktop",
     "com.endlessnetwork.passage.desktop",
     "com.endlessnetwork.tankwarriors.desktop",
     "com.endlessnetwork.whitehouse.desktop",
-    "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],
   "eos-folder-media.directory": [

--- a/data/settings/icon-grid-es.json.in
+++ b/data/settings/icon-grid-es.json.in
@@ -67,7 +67,8 @@
     "org.tuxpaint.Tuxpaint.desktop",
     "org.audacityteam.Audacity.desktop",
     "com.endlessm.world_literature.es.desktop",
-    "org.gimp.GIMP.desktop"
+    "org.gimp.GIMP.desktop",
+    "org.inkscape.Inkscape.desktop"
   ],
   "eos-folder-social.directory": [
     "eos-link-twitter.desktop",

--- a/data/settings/icon-grid-es.json.in
+++ b/data/settings/icon-grid-es.json.in
@@ -2,9 +2,9 @@
   "desktop": [
     "chromium-browser.desktop",
     "org.gnome.Nautilus.desktop",
-    "org.libreoffice.LibreOffice-writer.desktop",
-    "org.libreoffice.LibreOffice-calc.desktop",
-    "org.libreoffice.LibreOffice-impress.desktop",
+    "org.libreoffice.LibreOffice.writer.desktop",
+    "org.libreoffice.LibreOffice.calc.desktop",
+    "org.libreoffice.LibreOffice.impress.desktop",
     "com.endlessm.encyclopedia.es.desktop",
     "eos-vlc.desktop",
     "eos-link-facebook.desktop",

--- a/data/settings/icon-grid-es.json.in
+++ b/data/settings/icon-grid-es.json.in
@@ -68,7 +68,9 @@
     "org.audacityteam.Audacity.desktop",
     "com.endlessm.world_literature.es.desktop",
     "org.gimp.GIMP.desktop",
-    "org.inkscape.Inkscape.desktop"
+    "org.inkscape.Inkscape.desktop",
+    "org.pitivi.Pitivi.desktop",
+    "org.blender.Blender.desktop"
   ],
   "eos-folder-social.directory": [
     "eos-link-twitter.desktop",

--- a/data/settings/icon-grid-es.json.in
+++ b/data/settings/icon-grid-es.json.in
@@ -51,9 +51,11 @@
   "eos-folder-games-to-hack.directory": [
     "com.endlessnetwork.aqueducts.desktop",
     "com.endlessnetwork.dragonsapprentice.desktop",
+    "com.endlessnetwork.fablemaker.desktop",
     "com.endlessnetwork.frogsquash.desktop",
     "com.endlessnetwork.passage.desktop",
     "com.endlessnetwork.tankwarriors.desktop",
+    "com.endlessnetwork.whitehouse.desktop",
     "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],

--- a/data/settings/icon-grid-es.json.in
+++ b/data/settings/icon-grid-es.json.in
@@ -27,7 +27,6 @@
     "com.endlessm.health.es.desktop",
     "com.endlessm.maternity.es.desktop",
     "com.endlessm.dinosaurs.es.desktop",
-    "com.endlessm.translation.desktop",
     "eos-link-duolingo.desktop"
   ],
   "eos-folder-games.directory": [

--- a/data/settings/icon-grid-es.json.in
+++ b/data/settings/icon-grid-es.json.in
@@ -13,6 +13,7 @@
     "eos-folder-media.directory",
     "eos-folder-curiosity.directory",
     "eos-folder-games.directory",
+    "eos-folder-learn-to-code.directory",
     "eos-folder-games-to-hack.directory",
     "eos-folder-social.directory",
     "net.minetest.Minetest.desktop",
@@ -74,5 +75,9 @@
     "evolution.desktop",
     "eos-skype.desktop",
     "eos-link-gmail.desktop"
+  ],
+  "eos-folder-learn-to-code.directory": [
+    "edu.mit.Scratch.desktop",
+    "org.laptop.TurtleArtActivity.desktop"
   ]
 }

--- a/data/settings/icon-grid-es_GT.json.in
+++ b/data/settings/icon-grid-es_GT.json.in
@@ -52,9 +52,11 @@
   "eos-folder-games-to-hack.directory": [
     "com.endlessnetwork.aqueducts.desktop",
     "com.endlessnetwork.dragonsapprentice.desktop",
+    "com.endlessnetwork.fablemaker.desktop",
     "com.endlessnetwork.frogsquash.desktop",
     "com.endlessnetwork.passage.desktop",
     "com.endlessnetwork.tankwarriors.desktop",
+    "com.endlessnetwork.whitehouse.desktop",
     "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],

--- a/data/settings/icon-grid-es_GT.json.in
+++ b/data/settings/icon-grid-es_GT.json.in
@@ -11,6 +11,7 @@
     "eos-folder-media.directory",
     "eos-folder-curiosity.directory",
     "eos-folder-games.directory",
+    "eos-folder-learn-to-code.directory",
     "eos-folder-games-to-hack.directory",
     "eos-folder-social.directory",
     "net.minetest.Minetest.desktop",
@@ -76,5 +77,9 @@
     "eos-link-twitter.desktop",
     "evolution.desktop",
     "eos-link-gmail.desktop"
+  ],
+  "eos-folder-learn-to-code.directory": [
+    "edu.mit.Scratch.desktop",
+    "org.laptop.TurtleArtActivity.desktop"
   ]
 }

--- a/data/settings/icon-grid-es_GT.json.in
+++ b/data/settings/icon-grid-es_GT.json.in
@@ -2,9 +2,9 @@
   "desktop": [
     "chromium-browser.desktop",
     "org.gnome.Nautilus.desktop",
-    "org.libreoffice.LibreOffice-writer.desktop",
-    "org.libreoffice.LibreOffice-calc.desktop",
-    "org.libreoffice.LibreOffice-impress.desktop",
+    "org.libreoffice.LibreOffice.writer.desktop",
+    "org.libreoffice.LibreOffice.calc.desktop",
+    "org.libreoffice.LibreOffice.impress.desktop",
     "com.endlessm.encyclopedia.es.desktop",
     "eos-link-facebook.desktop",
     "eos-link-whatsapp.desktop",

--- a/data/settings/icon-grid-es_GT.json.in
+++ b/data/settings/icon-grid-es_GT.json.in
@@ -71,6 +71,8 @@
     "com.endlessm.world_literature.es.desktop",
     "org.gimp.GIMP.desktop",
     "org.inkscape.Inkscape.desktop",
+    "org.pitivi.Pitivi.desktop",
+    "org.blender.Blender.desktop",
     "eos-link-youtube.desktop"
   ],
   "eos-folder-social.directory": [

--- a/data/settings/icon-grid-es_GT.json.in
+++ b/data/settings/icon-grid-es_GT.json.in
@@ -54,10 +54,10 @@
     "com.endlessnetwork.dragonsapprentice.desktop",
     "com.endlessnetwork.fablemaker.desktop",
     "com.endlessnetwork.frogsquash.desktop",
+    "com.endlessnetwork.MidnightmareTeddy.desktop",
     "com.endlessnetwork.passage.desktop",
     "com.endlessnetwork.tankwarriors.desktop",
     "com.endlessnetwork.whitehouse.desktop",
-    "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],
   "eos-folder-media.directory": [

--- a/data/settings/icon-grid-es_GT.json.in
+++ b/data/settings/icon-grid-es_GT.json.in
@@ -70,6 +70,7 @@
     "org.audacityteam.Audacity.desktop",
     "com.endlessm.world_literature.es.desktop",
     "org.gimp.GIMP.desktop",
+    "org.inkscape.Inkscape.desktop",
     "eos-link-youtube.desktop"
   ],
   "eos-folder-social.directory": [

--- a/data/settings/icon-grid-es_GT.json.in
+++ b/data/settings/icon-grid-es_GT.json.in
@@ -28,7 +28,6 @@
     "com.endlessm.howto.es.desktop",
     "com.endlessm.travel.es_GT.desktop",
     "com.endlessm.health.es.desktop",
-    "com.endlessm.translation.desktop",
     "eos-link-duolingo.desktop"
   ],
   "eos-folder-games.directory": [

--- a/data/settings/icon-grid-fr.json.in
+++ b/data/settings/icon-grid-fr.json.in
@@ -43,9 +43,11 @@
   "eos-folder-games-to-hack.directory": [
     "com.endlessnetwork.aqueducts.desktop",
     "com.endlessnetwork.dragonsapprentice.desktop",
+    "com.endlessnetwork.fablemaker.desktop",
     "com.endlessnetwork.frogsquash.desktop",
     "com.endlessnetwork.passage.desktop",
     "com.endlessnetwork.tankwarriors.desktop",
+    "com.endlessnetwork.whitehouse.desktop",
     "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],

--- a/data/settings/icon-grid-fr.json.in
+++ b/data/settings/icon-grid-fr.json.in
@@ -19,7 +19,6 @@
     "rhythmbox.desktop"
   ],
   "eos-folder-curiosity.directory": [
-    "com.endlessm.translation.desktop",
     "eos-link-duolingo.desktop"
   ],
   "eos-folder-games.directory": [

--- a/data/settings/icon-grid-fr.json.in
+++ b/data/settings/icon-grid-fr.json.in
@@ -13,6 +13,7 @@
     "eos-folder-media.directory",
     "eos-folder-curiosity.directory",
     "eos-folder-games.directory",
+    "eos-folder-learn-to-code.directory",
     "eos-folder-games-to-hack.directory",
     "eos-folder-social.directory",
     "net.minetest.Minetest.desktop",
@@ -65,5 +66,9 @@
     "evolution.desktop",
     "eos-skype.desktop",
     "eos-link-gmail.desktop"
+  ],
+  "eos-folder-learn-to-code.directory": [
+    "edu.mit.Scratch.desktop",
+    "org.laptop.TurtleArtActivity.desktop"
   ]
 }

--- a/data/settings/icon-grid-fr.json.in
+++ b/data/settings/icon-grid-fr.json.in
@@ -2,9 +2,9 @@
   "desktop": [
     "chromium-browser.desktop",
     "org.gnome.Nautilus.desktop",
-    "org.libreoffice.LibreOffice-writer.desktop",
-    "org.libreoffice.LibreOffice-calc.desktop",
-    "org.libreoffice.LibreOffice-impress.desktop",
+    "org.libreoffice.LibreOffice.writer.desktop",
+    "org.libreoffice.LibreOffice.calc.desktop",
+    "org.libreoffice.LibreOffice.impress.desktop",
     "com.endlessm.encyclopedia.fr.desktop",
     "eos-vlc.desktop",
     "eos-link-facebook.desktop",

--- a/data/settings/icon-grid-fr.json.in
+++ b/data/settings/icon-grid-fr.json.in
@@ -58,7 +58,8 @@
     "org.gnome.Totem.desktop",
     "org.tuxpaint.Tuxpaint.desktop",
     "org.audacityteam.Audacity.desktop",
-    "org.gimp.GIMP.desktop"
+    "org.gimp.GIMP.desktop",
+    "org.inkscape.Inkscape.desktop"
   ],
   "eos-folder-social.directory": [
     "eos-link-twitter.desktop",

--- a/data/settings/icon-grid-fr.json.in
+++ b/data/settings/icon-grid-fr.json.in
@@ -45,10 +45,10 @@
     "com.endlessnetwork.dragonsapprentice.desktop",
     "com.endlessnetwork.fablemaker.desktop",
     "com.endlessnetwork.frogsquash.desktop",
+    "com.endlessnetwork.MidnightmareTeddy.desktop",
     "com.endlessnetwork.passage.desktop",
     "com.endlessnetwork.tankwarriors.desktop",
     "com.endlessnetwork.whitehouse.desktop",
-    "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],
   "eos-folder-media.directory": [

--- a/data/settings/icon-grid-fr.json.in
+++ b/data/settings/icon-grid-fr.json.in
@@ -59,7 +59,9 @@
     "org.tuxpaint.Tuxpaint.desktop",
     "org.audacityteam.Audacity.desktop",
     "org.gimp.GIMP.desktop",
-    "org.inkscape.Inkscape.desktop"
+    "org.inkscape.Inkscape.desktop",
+    "org.pitivi.Pitivi.desktop",
+    "org.blender.Blender.desktop"
   ],
   "eos-folder-social.directory": [
     "eos-link-twitter.desktop",

--- a/data/settings/icon-grid-id.json.in
+++ b/data/settings/icon-grid-id.json.in
@@ -68,10 +68,10 @@
     "com.endlessnetwork.dragonsapprentice.desktop",
     "com.endlessnetwork.fablemaker.desktop",
     "com.endlessnetwork.frogsquash.desktop",
+    "com.endlessnetwork.MidnightmareTeddy.desktop",
     "com.endlessnetwork.passage.desktop",
     "com.endlessnetwork.tankwarriors.desktop",
     "com.endlessnetwork.whitehouse.desktop",
-    "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],
   "eos-folder-media.directory": [

--- a/data/settings/icon-grid-id.json.in
+++ b/data/settings/icon-grid-id.json.in
@@ -83,7 +83,8 @@
     "org.audacityteam.Audacity.desktop",
     "org.kde.krita.desktop",
     "rhythmbox.desktop",
-    "org.gimp.GIMP.desktop"
+    "org.gimp.GIMP.desktop",
+    "org.inkscape.Inkscape.desktop"
   ],
   "eos-folder-news.directory": [
     "com.endlessm.detik_news.id.desktop",

--- a/data/settings/icon-grid-id.json.in
+++ b/data/settings/icon-grid-id.json.in
@@ -2,9 +2,9 @@
   "desktop": [
     "chromium-browser.desktop",
     "org.gnome.Nautilus.desktop",
-    "org.libreoffice.LibreOffice-writer.desktop",
-    "org.libreoffice.LibreOffice-calc.desktop",
-    "org.libreoffice.LibreOffice-impress.desktop",
+    "org.libreoffice.LibreOffice.writer.desktop",
+    "org.libreoffice.LibreOffice.calc.desktop",
+    "org.libreoffice.LibreOffice.impress.desktop",
     "com.endlessm.encyclopedia.id.desktop",
     "eos-vlc.desktop",
     "eos-link-facebook.desktop",

--- a/data/settings/icon-grid-id.json.in
+++ b/data/settings/icon-grid-id.json.in
@@ -38,7 +38,6 @@
     "com.endlessm.history.id.desktop",
     "com.endlessm.dianarikasari.id.desktop",
     "com.endlessm.socialsciences.id.desktop",
-    "com.endlessm.translation.desktop",
     "com.endlessm.marischkaprudence.id.desktop",
     "eos-link-duolingo.desktop",
     "com.endlessm.video_kids.desktop",

--- a/data/settings/icon-grid-id.json.in
+++ b/data/settings/icon-grid-id.json.in
@@ -20,6 +20,7 @@
     "eos-folder-news.directory",
     "eos-folder-curiosity.directory",
     "eos-folder-games.directory",
+    "eos-folder-learn-to-code.directory",
     "eos-folder-games-to-hack.directory",
     "eos-folder-social.directory",
     "com.endlessm.video_animal_kingdom.desktop",
@@ -96,5 +97,9 @@
     "evolution.desktop",
     "eos-skype.desktop",
     "eos-link-gmail.desktop"
+  ],
+  "eos-folder-learn-to-code.directory": [
+    "edu.mit.Scratch.desktop",
+    "org.laptop.TurtleArtActivity.desktop"
   ]
 }

--- a/data/settings/icon-grid-id.json.in
+++ b/data/settings/icon-grid-id.json.in
@@ -84,7 +84,9 @@
     "org.kde.krita.desktop",
     "rhythmbox.desktop",
     "org.gimp.GIMP.desktop",
-    "org.inkscape.Inkscape.desktop"
+    "org.inkscape.Inkscape.desktop",
+    "org.pitivi.Pitivi.desktop",
+    "org.blender.Blender.desktop"
   ],
   "eos-folder-news.directory": [
     "com.endlessm.detik_news.id.desktop",

--- a/data/settings/icon-grid-id.json.in
+++ b/data/settings/icon-grid-id.json.in
@@ -66,9 +66,11 @@
   "eos-folder-games-to-hack.directory": [
     "com.endlessnetwork.aqueducts.desktop",
     "com.endlessnetwork.dragonsapprentice.desktop",
+    "com.endlessnetwork.fablemaker.desktop",
     "com.endlessnetwork.frogsquash.desktop",
     "com.endlessnetwork.passage.desktop",
     "com.endlessnetwork.tankwarriors.desktop",
+    "com.endlessnetwork.whitehouse.desktop",
     "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],

--- a/data/settings/icon-grid-pt.json.in
+++ b/data/settings/icon-grid-pt.json.in
@@ -13,6 +13,7 @@
     "eos-folder-media.directory",
     "eos-folder-curiosity.directory",
     "eos-folder-games.directory",
+    "eos-folder-learn-to-code.directory",
     "eos-folder-games-to-hack.directory",
     "eos-folder-social.directory",
     "net.minetest.Minetest.desktop",
@@ -73,5 +74,9 @@
     "evolution.desktop",
     "eos-skype.desktop",
     "eos-link-gmail.desktop"
+  ],
+  "eos-folder-learn-to-code.directory": [
+    "edu.mit.Scratch.desktop",
+    "org.laptop.TurtleArtActivity.desktop"
   ]
 }

--- a/data/settings/icon-grid-pt.json.in
+++ b/data/settings/icon-grid-pt.json.in
@@ -49,9 +49,11 @@
   "eos-folder-games-to-hack.directory": [
     "com.endlessnetwork.aqueducts.desktop",
     "com.endlessnetwork.dragonsapprentice.desktop",
+    "com.endlessnetwork.fablemaker.desktop",
     "com.endlessnetwork.frogsquash.desktop",
     "com.endlessnetwork.passage.desktop",
     "com.endlessnetwork.tankwarriors.desktop",
+    "com.endlessnetwork.whitehouse.desktop",
     "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],

--- a/data/settings/icon-grid-pt.json.in
+++ b/data/settings/icon-grid-pt.json.in
@@ -51,10 +51,10 @@
     "com.endlessnetwork.dragonsapprentice.desktop",
     "com.endlessnetwork.fablemaker.desktop",
     "com.endlessnetwork.frogsquash.desktop",
+    "com.endlessnetwork.MidnightmareTeddy.desktop",
     "com.endlessnetwork.passage.desktop",
     "com.endlessnetwork.tankwarriors.desktop",
     "com.endlessnetwork.whitehouse.desktop",
-    "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],
   "eos-folder-media.directory": [

--- a/data/settings/icon-grid-pt.json.in
+++ b/data/settings/icon-grid-pt.json.in
@@ -66,7 +66,9 @@
     "org.audacityteam.Audacity.desktop",
     "com.endlessm.library.pt.desktop",
     "org.gimp.GIMP.desktop",
-    "org.inkscape.Inkscape.desktop"
+    "org.inkscape.Inkscape.desktop",
+    "org.pitivi.Pitivi.desktop",
+    "org.blender.Blender.desktop"
   ],
   "eos-folder-social.directory": [
     "com.endlessm.extra.pt_BR.desktop",

--- a/data/settings/icon-grid-pt.json.in
+++ b/data/settings/icon-grid-pt.json.in
@@ -2,9 +2,9 @@
   "desktop": [
     "chromium-browser.desktop",
     "org.gnome.Nautilus.desktop",
-    "org.libreoffice.LibreOffice-writer.desktop",
-    "org.libreoffice.LibreOffice-calc.desktop",
-    "org.libreoffice.LibreOffice-impress.desktop",
+    "org.libreoffice.LibreOffice.writer.desktop",
+    "org.libreoffice.LibreOffice.calc.desktop",
+    "org.libreoffice.LibreOffice.impress.desktop",
     "com.endlessm.encyclopedia.pt.desktop",
     "eos-vlc.desktop",
     "eos-link-facebook.desktop",

--- a/data/settings/icon-grid-pt.json.in
+++ b/data/settings/icon-grid-pt.json.in
@@ -25,7 +25,6 @@
     "com.endlessm.howto.pt.desktop",
     "com.endlessm.travel.pt.desktop",
     "com.endlessm.dinosaurs.pt.desktop",
-    "com.endlessm.translation.desktop",
     "eos-link-duolingo.desktop"
   ],
   "eos-folder-games.directory": [

--- a/data/settings/icon-grid-pt.json.in
+++ b/data/settings/icon-grid-pt.json.in
@@ -65,7 +65,8 @@
     "org.tuxpaint.Tuxpaint.desktop",
     "org.audacityteam.Audacity.desktop",
     "com.endlessm.library.pt.desktop",
-    "org.gimp.GIMP.desktop"
+    "org.gimp.GIMP.desktop",
+    "org.inkscape.Inkscape.desktop"
   ],
   "eos-folder-social.directory": [
     "com.endlessm.extra.pt_BR.desktop",

--- a/data/settings/icon-grid-th.json.in
+++ b/data/settings/icon-grid-th.json.in
@@ -52,10 +52,10 @@
     "com.endlessnetwork.dragonsapprentice.desktop",
     "com.endlessnetwork.fablemaker.desktop",
     "com.endlessnetwork.frogsquash.desktop",
+    "com.endlessnetwork.MidnightmareTeddy.desktop",
     "com.endlessnetwork.passage.desktop",
     "com.endlessnetwork.tankwarriors.desktop",
     "com.endlessnetwork.whitehouse.desktop",
-    "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],
   "eos-folder-media.directory": [

--- a/data/settings/icon-grid-th.json.in
+++ b/data/settings/icon-grid-th.json.in
@@ -2,9 +2,9 @@
   "desktop": [
     "chromium-browser.desktop",
     "org.gnome.Nautilus.desktop",
-    "org.libreoffice.LibreOffice-writer.desktop",
-    "org.libreoffice.LibreOffice-calc.desktop",
-    "org.libreoffice.LibreOffice-impress.desktop",
+    "org.libreoffice.LibreOffice.writer.desktop",
+    "org.libreoffice.LibreOffice.calc.desktop",
+    "org.libreoffice.LibreOffice.impress.desktop",
     "com.endlessm.encyclopedia.th.desktop",
     "eos-vlc.desktop",
     "eos-link-facebook.desktop",

--- a/data/settings/icon-grid-th.json.in
+++ b/data/settings/icon-grid-th.json.in
@@ -65,7 +65,9 @@
     "org.tuxpaint.Tuxpaint.desktop",
     "org.audacityteam.Audacity.desktop",
     "org.gimp.GIMP.desktop",
-    "org.inkscape.Inkscape.desktop"
+    "org.inkscape.Inkscape.desktop",
+    "org.pitivi.Pitivi.desktop",
+    "org.blender.Blender.desktop"
   ],
   "eos-folder-social.directory": [
     "eos-link-twitter.desktop",

--- a/data/settings/icon-grid-th.json.in
+++ b/data/settings/icon-grid-th.json.in
@@ -26,7 +26,6 @@
     "com.endlessm.history.th.desktop",
     "com.endlessm.soccer.th.desktop",
     "com.endlessm.socialsciences.th.desktop",
-    "com.endlessm.translation.desktop",
     "eos-link-duolingo.desktop"
   ],
   "eos-folder-games.directory": [

--- a/data/settings/icon-grid-th.json.in
+++ b/data/settings/icon-grid-th.json.in
@@ -50,9 +50,11 @@
   "eos-folder-games-to-hack.directory": [
     "com.endlessnetwork.aqueducts.desktop",
     "com.endlessnetwork.dragonsapprentice.desktop",
+    "com.endlessnetwork.fablemaker.desktop",
     "com.endlessnetwork.frogsquash.desktop",
     "com.endlessnetwork.passage.desktop",
     "com.endlessnetwork.tankwarriors.desktop",
+    "com.endlessnetwork.whitehouse.desktop",
     "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],

--- a/data/settings/icon-grid-th.json.in
+++ b/data/settings/icon-grid-th.json.in
@@ -64,7 +64,8 @@
     "org.gnome.Totem.desktop",
     "org.tuxpaint.Tuxpaint.desktop",
     "org.audacityteam.Audacity.desktop",
-    "org.gimp.GIMP.desktop"
+    "org.gimp.GIMP.desktop",
+    "org.inkscape.Inkscape.desktop"
   ],
   "eos-folder-social.directory": [
     "eos-link-twitter.desktop",

--- a/data/settings/icon-grid-th.json.in
+++ b/data/settings/icon-grid-th.json.in
@@ -13,6 +13,7 @@
     "eos-folder-media.directory",
     "eos-folder-curiosity.directory",
     "eos-folder-games.directory",
+    "eos-folder-learn-to-code.directory",
     "eos-folder-games-to-hack.directory",
     "eos-folder-social.directory",
     "net.minetest.Minetest.desktop",
@@ -71,5 +72,9 @@
     "evolution.desktop",
     "eos-skype.desktop",
     "eos-link-gmail.desktop"
+  ],
+  "eos-folder-learn-to-code.directory": [
+    "edu.mit.Scratch.desktop",
+    "org.laptop.TurtleArtActivity.desktop"
   ]
 }

--- a/data/settings/icon-grid-vi.json.in
+++ b/data/settings/icon-grid-vi.json.in
@@ -67,7 +67,9 @@
     "org.tuxpaint.Tuxpaint.desktop",
     "org.audacityteam.Audacity.desktop",
     "org.gimp.GIMP.desktop",
-    "org.inkscape.Inkscape.desktop"
+    "org.inkscape.Inkscape.desktop",
+    "org.pitivi.Pitivi.desktop",
+    "org.blender.Blender.desktop"
   ],
   "eos-folder-social.directory": [
     "eos-link-twitter.desktop",

--- a/data/settings/icon-grid-vi.json.in
+++ b/data/settings/icon-grid-vi.json.in
@@ -52,9 +52,11 @@
   "eos-folder-games-to-hack.directory": [
     "com.endlessnetwork.aqueducts.desktop",
     "com.endlessnetwork.dragonsapprentice.desktop",
+    "com.endlessnetwork.fablemaker.desktop",
     "com.endlessnetwork.frogsquash.desktop",
     "com.endlessnetwork.passage.desktop",
     "com.endlessnetwork.tankwarriors.desktop",
+    "com.endlessnetwork.whitehouse.desktop",
     "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],

--- a/data/settings/icon-grid-vi.json.in
+++ b/data/settings/icon-grid-vi.json.in
@@ -28,7 +28,6 @@
     "com.endlessm.physics.vi.desktop",
     "com.endlessm.soccer.vi.desktop",
     "com.endlessm.socialsciences.vi.desktop",
-    "com.endlessm.translation.desktop",
     "eos-link-duolingo.desktop"
   ],
   "eos-folder-games.directory": [

--- a/data/settings/icon-grid-vi.json.in
+++ b/data/settings/icon-grid-vi.json.in
@@ -13,6 +13,7 @@
     "eos-folder-media.directory",
     "eos-folder-curiosity.directory",
     "eos-folder-games.directory",
+    "eos-folder-learn-to-code.directory",
     "eos-folder-games-to-hack.directory",
     "eos-folder-social.directory",
     "net.minetest.Minetest.desktop",
@@ -73,5 +74,9 @@
     "evolution.desktop",
     "eos-skype.desktop",
     "eos-link-gmail.desktop"
+  ],
+  "eos-folder-learn-to-code.directory": [
+    "edu.mit.Scratch.desktop",
+    "org.laptop.TurtleArtActivity.desktop"
   ]
 }

--- a/data/settings/icon-grid-vi.json.in
+++ b/data/settings/icon-grid-vi.json.in
@@ -66,7 +66,8 @@
     "org.gnome.Totem.desktop",
     "org.tuxpaint.Tuxpaint.desktop",
     "org.audacityteam.Audacity.desktop",
-    "org.gimp.GIMP.desktop"
+    "org.gimp.GIMP.desktop",
+    "org.inkscape.Inkscape.desktop"
   ],
   "eos-folder-social.directory": [
     "eos-link-twitter.desktop",

--- a/data/settings/icon-grid-vi.json.in
+++ b/data/settings/icon-grid-vi.json.in
@@ -54,10 +54,10 @@
     "com.endlessnetwork.dragonsapprentice.desktop",
     "com.endlessnetwork.fablemaker.desktop",
     "com.endlessnetwork.frogsquash.desktop",
+    "com.endlessnetwork.MidnightmareTeddy.desktop",
     "com.endlessnetwork.passage.desktop",
     "com.endlessnetwork.tankwarriors.desktop",
     "com.endlessnetwork.whitehouse.desktop",
-    "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],
   "eos-folder-media.directory": [

--- a/data/settings/icon-grid-vi.json.in
+++ b/data/settings/icon-grid-vi.json.in
@@ -2,9 +2,9 @@
   "desktop": [
     "chromium-browser.desktop",
     "org.gnome.Nautilus.desktop",
-    "org.libreoffice.LibreOffice-writer.desktop",
-    "org.libreoffice.LibreOffice-calc.desktop",
-    "org.libreoffice.LibreOffice-impress.desktop",
+    "org.libreoffice.LibreOffice.writer.desktop",
+    "org.libreoffice.LibreOffice.calc.desktop",
+    "org.libreoffice.LibreOffice.impress.desktop",
     "com.endlessm.encyclopedia.vi.desktop",
     "eos-vlc.desktop",
     "eos-link-facebook.desktop",

--- a/data/settings/icon-grid-zh_CN.json.in
+++ b/data/settings/icon-grid-zh_CN.json.in
@@ -67,9 +67,9 @@
     "eos-link-bingdict.desktop"
   ],
   "eos-folder-work.directory": [
-    "org.libreoffice.LibreOffice-writer.desktop",
-    "org.libreoffice.LibreOffice-calc.desktop",
-    "org.libreoffice.LibreOffice-impress.desktop"
+    "org.libreoffice.LibreOffice.writer.desktop",
+    "org.libreoffice.LibreOffice.calc.desktop",
+    "org.libreoffice.LibreOffice.impress.desktop"
   ],
   "eos-folder-learn-to-code.directory": [
     "edu.mit.Scratch.desktop",

--- a/data/settings/icon-grid-zh_CN.json.in
+++ b/data/settings/icon-grid-zh_CN.json.in
@@ -62,6 +62,8 @@
     "com.endlessm.photos.desktop",
     "org.gimp.GIMP.desktop",
     "org.inkscape.Inkscape.desktop",
+    "org.pitivi.Pitivi.desktop",
+    "org.blender.Blender.desktop",
     "org.gnome.Calculator.desktop",
     "eos-link-baidudict.desktop",
     "eos-link-bingdict.desktop"

--- a/data/settings/icon-grid-zh_CN.json.in
+++ b/data/settings/icon-grid-zh_CN.json.in
@@ -60,6 +60,7 @@
     "shotwell.desktop",
     "com.endlessm.photos.desktop",
     "org.gimp.GIMP.desktop",
+    "org.inkscape.Inkscape.desktop",
     "org.gnome.Calculator.desktop",
     "eos-link-baidudict.desktop",
     "eos-link-bingdict.desktop"

--- a/data/settings/icon-grid-zh_CN.json.in
+++ b/data/settings/icon-grid-zh_CN.json.in
@@ -6,6 +6,7 @@
     "eos-folder-work.directory",
     "eos-folder-tools.directory",
     "eos-folder-games.directory",
+    "eos-folder-learn-to-code.directory",
     "eos-folder-games-to-hack.directory",
     "eos-folder-social.directory",
     "eos-link-duolingo.desktop",
@@ -69,5 +70,9 @@
     "org.libreoffice.LibreOffice-writer.desktop",
     "org.libreoffice.LibreOffice-calc.desktop",
     "org.libreoffice.LibreOffice-impress.desktop"
+  ],
+  "eos-folder-learn-to-code.directory": [
+    "edu.mit.Scratch.desktop",
+    "org.laptop.TurtleArtActivity.desktop"
   ]
 }

--- a/data/settings/icon-grid-zh_CN.json.in
+++ b/data/settings/icon-grid-zh_CN.json.in
@@ -42,10 +42,10 @@
     "com.endlessnetwork.dragonsapprentice.desktop",
     "com.endlessnetwork.fablemaker.desktop",
     "com.endlessnetwork.frogsquash.desktop",
+    "com.endlessnetwork.MidnightmareTeddy.desktop",
     "com.endlessnetwork.passage.desktop",
     "com.endlessnetwork.tankwarriors.desktop",
     "com.endlessnetwork.whitehouse.desktop",
-    "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],
   "eos-folder-social.directory": [

--- a/data/settings/icon-grid-zh_CN.json.in
+++ b/data/settings/icon-grid-zh_CN.json.in
@@ -39,9 +39,11 @@
   "eos-folder-games-to-hack.directory": [
     "com.endlessnetwork.aqueducts.desktop",
     "com.endlessnetwork.dragonsapprentice.desktop",
+    "com.endlessnetwork.fablemaker.desktop",
     "com.endlessnetwork.frogsquash.desktop",
     "com.endlessnetwork.passage.desktop",
     "com.endlessnetwork.tankwarriors.desktop",
+    "com.endlessnetwork.whitehouse.desktop",
     "com.endlessnetwork.MidnightmareTeddy.desktop",
     "eos-unity.desktop"
   ],


### PR DESCRIPTION
Add some new apps which we are going to start shipping by default, and remove some old stuff.

I made the bulk of the modifications to the icon grids programmatically:

https://gist.github.com/wjt/5fff5946a9cc451abb26dc3590f9275d

We have historically maintained each locale's icon grid by hand but I feel like we should be able to do better.

https://phabricator.endlessm.com/T28705