### PR TITLE
build: Make json.h files during normal build

### DIFF
--- a/content/Makefile.am
+++ b/content/Makefile.am
@@ -37,7 +37,7 @@ content_headers = $(content_files:.json=.json.h)
 
 # Distribute the json.h files so they don't need to be regenerated at
 # build time
-EXTRA_DIST += $(content_headers)
+dist_noinst_DATA = $(content_headers)
 MAINTAINERCLEANFILES += $(content_headers)
 
 eos-app-store-link-content.gresource.xml: Makefile $(default_links_json) $(default_links_images)


### PR DESCRIPTION
Use automake's `dist_noinst_DATA` primary so that the json.h files get
built with make's default targets and not just `dist`. As before the
files are still distributed so that they wouldn't need to be regenerated
in OBS when a tarball is in use. This allows our transifex tooling to
run a normal checkout prepared with `make` instead of the full `make
distcheck`.

https://phabricator.endlessm.com/T27529