### PR TITLE
Add Kolibri to default icon grid

### DIFF
--- a/data/settings/icon-grid-C.json.in
+++ b/data/settings/icon-grid-C.json.in
@@ -6,6 +6,7 @@
     "org.libreoffice.LibreOffice.calc.desktop",
     "org.libreoffice.LibreOffice.impress.desktop",
     "com.endlessm.encyclopedia.en.desktop",
+    "org.learningequality.Kolibri.desktop",
     "eos-vlc.desktop",
     "eos-link-facebook.desktop",
     "eos-link-whatsapp.desktop",

--- a/data/settings/icon-grid-ar.json.in
+++ b/data/settings/icon-grid-ar.json.in
@@ -6,6 +6,7 @@
     "org.libreoffice.LibreOffice.calc.desktop",
     "org.libreoffice.LibreOffice.impress.desktop",
     "com.endlessm.encyclopedia.ar.desktop",
+    "org.learningequality.Kolibri.desktop",
     "eos-vlc.desktop",
     "eos-link-facebook.desktop",
     "eos-link-whatsapp.desktop",

--- a/data/settings/icon-grid-bn.json.in
+++ b/data/settings/icon-grid-bn.json.in
@@ -6,6 +6,7 @@
     "org.libreoffice.LibreOffice.calc.desktop",
     "org.libreoffice.LibreOffice.impress.desktop",
     "com.endlessm.bengali_curriculum.bn_BD.desktop",
+    "org.learningequality.Kolibri.desktop",
     "eos-vlc.desktop",
     "eos-link-facebook.desktop",
     "eos-link-whatsapp.desktop",

--- a/data/settings/icon-grid-es.json.in
+++ b/data/settings/icon-grid-es.json.in
@@ -6,6 +6,7 @@
     "org.libreoffice.LibreOffice.calc.desktop",
     "org.libreoffice.LibreOffice.impress.desktop",
     "com.endlessm.encyclopedia.es.desktop",
+    "org.learningequality.Kolibri.desktop",
     "eos-vlc.desktop",
     "eos-link-facebook.desktop",
     "eos-link-whatsapp.desktop",

--- a/data/settings/icon-grid-es_GT.json.in
+++ b/data/settings/icon-grid-es_GT.json.in
@@ -6,6 +6,7 @@
     "org.libreoffice.LibreOffice.calc.desktop",
     "org.libreoffice.LibreOffice.impress.desktop",
     "com.endlessm.encyclopedia.es.desktop",
+    "org.learningequality.Kolibri.desktop",
     "eos-link-facebook.desktop",
     "eos-link-whatsapp.desktop",
     "eos-folder-media.directory",

--- a/data/settings/icon-grid-fr.json.in
+++ b/data/settings/icon-grid-fr.json.in
@@ -6,6 +6,7 @@
     "org.libreoffice.LibreOffice.calc.desktop",
     "org.libreoffice.LibreOffice.impress.desktop",
     "com.endlessm.encyclopedia.fr.desktop",
+    "org.learningequality.Kolibri.desktop",
     "eos-vlc.desktop",
     "eos-link-facebook.desktop",
     "eos-link-whatsapp.desktop",

--- a/data/settings/icon-grid-id.json.in
+++ b/data/settings/icon-grid-id.json.in
@@ -6,6 +6,7 @@
     "org.libreoffice.LibreOffice.calc.desktop",
     "org.libreoffice.LibreOffice.impress.desktop",
     "com.endlessm.encyclopedia.id.desktop",
+    "org.learningequality.Kolibri.desktop",
     "eos-vlc.desktop",
     "eos-link-facebook.desktop",
     "eos-link-whatsapp.desktop",

--- a/data/settings/icon-grid-pt.json.in
+++ b/data/settings/icon-grid-pt.json.in
@@ -6,6 +6,7 @@
     "org.libreoffice.LibreOffice.calc.desktop",
     "org.libreoffice.LibreOffice.impress.desktop",
     "com.endlessm.encyclopedia.pt.desktop",
+    "org.learningequality.Kolibri.desktop",
     "eos-vlc.desktop",
     "eos-link-facebook.desktop",
     "eos-link-whatsapp.desktop",

--- a/data/settings/icon-grid-th.json.in
+++ b/data/settings/icon-grid-th.json.in
@@ -6,6 +6,7 @@
     "org.libreoffice.LibreOffice.calc.desktop",
     "org.libreoffice.LibreOffice.impress.desktop",
     "com.endlessm.encyclopedia.th.desktop",
+    "org.learningequality.Kolibri.desktop",
     "eos-vlc.desktop",
     "eos-link-facebook.desktop",
     "eos-link-whatsapp.desktop",

--- a/data/settings/icon-grid-vi.json.in
+++ b/data/settings/icon-grid-vi.json.in
@@ -6,6 +6,7 @@
     "org.libreoffice.LibreOffice.calc.desktop",
     "org.libreoffice.LibreOffice.impress.desktop",
     "com.endlessm.encyclopedia.vi.desktop",
+    "org.learningequality.Kolibri.desktop",
     "eos-vlc.desktop",
     "eos-link-facebook.desktop",
     "eos-link-whatsapp.desktop",

--- a/data/settings/icon-grid-zh_CN.json.in
+++ b/data/settings/icon-grid-zh_CN.json.in
@@ -16,7 +16,8 @@
   ],
   "eos-folder-curiosity.directory": [
     "com.endlessm.chinese_curriculum_math.zh_CN.desktop",
-    "com.endlessm.chinese_curriculum_english.zh_CN.desktop"
+    "com.endlessm.chinese_curriculum_english.zh_CN.desktop",
+    "org.learningequality.Kolibri.desktop"
   ],
   "eos-folder-games.directory": [
     "com.endlessnetwork.missilemath.desktop",


### PR DESCRIPTION
We will be pre-installing Kolibri and a bunch of content in some
images. Place Kolibri on the desktop, next to the Encyclopedia, or next
to the local curriculum if there is no Encyclopedia.

https://phabricator.endlessm.com/T30160