### PR TITLE
Download the content zip file from S3.

### DIFF
--- a/download-content
+++ b/download-content
@@ -1,5 +1,4 @@
 #!/bin/bash -e
 
-# Get the current appstore.zip. To regenerate the content, go to
-# http://cms.endlessm.com/admin/generator/appstore
-wget http://cms.endlessm.com/sites/default/files/jsons/zip/appstore.zip
+# Get the latest version of appstore.zip from a backup in S3.
+aws s3 cp s3://backups-endlessm-com/eos-cms-2020-09-15/appstore.zip ./


### PR DESCRIPTION
The CMS instance was backed up and terminated. Instead of downloading
the content zip file from the CMS, download the latest version from a
backup in S3.

https://phabricator.endlessm.com/T30127