### PR TITLE
Add missing import in eos-save-icon-grid

### DIFF
--- a/data/eos-save-icon-grid.in
+++ b/data/eos-save-icon-grid.in
@@ -17,6 +17,7 @@
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
 const Json = imports.gi.Json;
+const ByteArray = imports.byteArray;
 
 const INSTALL_PATH = '@PKG_DATA_DIR@/icon-grid-defaults';
 const SAVE_PATH = GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_DOCUMENTS);

--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,8 @@ Homepage: http://www.endlessm.com
 Package: eos-shell-content
 Architecture: all
 Depends: ${misc:Depends},
-         eos-shell-content-icon-grid (= ${binary:Version})
+         eos-shell-content-icon-grid (= ${binary:Version}),
+         zenity
 Recommends: eos-theme
 Description: Endless OS Shell Content installation package
  This package will install the content for the app store


### PR DESCRIPTION
This fixes a crash introduced by ede8907.

While I was here I added a missing package dependency.

https://phabricator.endlessm.com/T31616
