### PR TITLE
icon-grids: Explicitly add Hack Clubhouse in first position

### DIFF
--- a/data/settings/icon-grid-C.json.in
+++ b/data/settings/icon-grid-C.json.in
@@ -1,5 +1,6 @@
 {
   "desktop": [
+    "com.hack_computer.Clubhouse.desktop",
     "org.chromium.Chromium.desktop",
     "org.gnome.Nautilus.desktop",
     "org.gnome.Totem.desktop",

--- a/data/settings/icon-grid-ar.json.in
+++ b/data/settings/icon-grid-ar.json.in
@@ -1,5 +1,6 @@
 {
   "desktop": [
+    "com.hack_computer.Clubhouse.desktop",
     "org.chromium.Chromium.desktop",
     "org.gnome.Nautilus.desktop",
     "org.libreoffice.LibreOffice.writer.desktop",

--- a/data/settings/icon-grid-bn.json.in
+++ b/data/settings/icon-grid-bn.json.in
@@ -1,5 +1,6 @@
 {
   "desktop": [
+    "com.hack_computer.Clubhouse.desktop",
     "org.chromium.Chromium.desktop",
     "org.gnome.Nautilus.desktop",
     "org.libreoffice.LibreOffice.writer.desktop",

--- a/data/settings/icon-grid-es.json.in
+++ b/data/settings/icon-grid-es.json.in
@@ -1,5 +1,6 @@
 {
   "desktop": [
+    "com.hack_computer.Clubhouse.desktop",
     "org.chromium.Chromium.desktop",
     "org.gnome.Nautilus.desktop",
     "org.gnome.Totem.desktop",

--- a/data/settings/icon-grid-es_GT.json.in
+++ b/data/settings/icon-grid-es_GT.json.in
@@ -1,5 +1,6 @@
 {
   "desktop": [
+    "com.hack_computer.Clubhouse.desktop",
     "org.chromium.Chromium.desktop",
     "org.gnome.Nautilus.desktop",
     "org.libreoffice.LibreOffice.writer.desktop",

--- a/data/settings/icon-grid-fr.json.in
+++ b/data/settings/icon-grid-fr.json.in
@@ -1,5 +1,6 @@
 {
   "desktop": [
+    "com.hack_computer.Clubhouse.desktop",
     "org.chromium.Chromium.desktop",
     "org.gnome.Nautilus.desktop",
     "org.gnome.Totem.desktop",

--- a/data/settings/icon-grid-id.json.in
+++ b/data/settings/icon-grid-id.json.in
@@ -1,5 +1,6 @@
 {
   "desktop": [
+    "com.hack_computer.Clubhouse.desktop",
     "org.chromium.Chromium.desktop",
     "org.gnome.Nautilus.desktop",
     "org.libreoffice.LibreOffice.writer.desktop",

--- a/data/settings/icon-grid-pt.json.in
+++ b/data/settings/icon-grid-pt.json.in
@@ -1,5 +1,6 @@
 {
   "desktop": [
+    "com.hack_computer.Clubhouse.desktop",
     "org.chromium.Chromium.desktop",
     "org.gnome.Nautilus.desktop",
     "org.gnome.Totem.desktop",

--- a/data/settings/icon-grid-th.json.in
+++ b/data/settings/icon-grid-th.json.in
@@ -1,5 +1,6 @@
 {
   "desktop": [
+    "com.hack_computer.Clubhouse.desktop",
     "org.chromium.Chromium.desktop",
     "org.gnome.Nautilus.desktop",
     "org.libreoffice.LibreOffice.writer.desktop",

--- a/data/settings/icon-grid-vi.json.in
+++ b/data/settings/icon-grid-vi.json.in
@@ -1,5 +1,6 @@
 {
   "desktop": [
+    "com.hack_computer.Clubhouse.desktop",
     "org.chromium.Chromium.desktop",
     "org.gnome.Nautilus.desktop",
     "org.libreoffice.LibreOffice.writer.desktop",

--- a/data/settings/icon-grid-zh_CN.json.in
+++ b/data/settings/icon-grid-zh_CN.json.in
@@ -1,5 +1,6 @@
 {
   "desktop": [
+    "com.hack_computer.Clubhouse.desktop",
     "org.chromium.Chromium.desktop",
     "org.gnome.Nautilus.desktop",
     "eos-folder-curiosity.directory",


### PR DESCRIPTION
This will allow us to remove the special-case in eos-desktop-extension.

https://phabricator.endlessm.com/T32556
