### PR TITLE
icon grid: Remove per-architecture blacklist

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -6,9 +6,9 @@ settings_in_files = $(wildcard settings/icon-grid-*.json.in)
 settings_DATA = $(settings_in_files:.in=)
 dist_noinst_SCRIPTS = settings/write-grid-json.py
 
-%.json: %.json.in settings/arch-blacklist.json settings/write-grid-json.py
+%.json: %.json.in settings/write-grid-json.py
 	$(AM_V_GEN)$(srcdir)/settings/write-grid-json.py -o $@ \
-		$< $(srcdir)/settings/arch-blacklist.json $(host_cpu)
+		$<
 
 do_subst = sed \
 	-e 's|@PKG_DATA_DIR[@]|$(pkgdatadir)|g' \
@@ -21,7 +21,6 @@ eos-save-icon-grid: eos-save-icon-grid.in Makefile
 EXTRA_DIST = \
     $(folders_DATA) \
     $(settings_in_files) \
-    settings/arch-blacklist.json \
     eos-save-icon-grid.in \
     $(NULL)
 

--- a/data/settings/arch-blacklist.json
+++ b/data/settings/arch-blacklist.json
@@ -1,5 +1,0 @@
-{
-  "arm" : [
-      "eos-folder-games-to-hack.directory"
-  ]
-}

--- a/data/settings/write-grid-json.py
+++ b/data/settings/write-grid-json.py
@@ -10,16 +10,12 @@ import sys
 aparser = ArgumentParser(description='Write icon grid json file')
 aparser.add_argument('-o', '--output', help='output file')
 aparser.add_argument('input', help='input template file')
-aparser.add_argument('blacklist', help='blacklist file')
-aparser.add_argument('cpu', help='CPU for blacklisting')
 args = aparser.parse_args()
 
-# Load with template and blacklist. Use OrderedDict for the grid to
+# Load template. Use OrderedDict for the grid to
 # maintain sorting of the keys.
 with open(args.input, 'r') as infile:
     grid = json.load(infile, object_pairs_hook=OrderedDict)
-with open(args.blacklist, 'r') as blfile:
-    blacklist = json.load(blfile)
 
 # Open the a temporary version of the output file if specified, ensuring
 # that leading directories are created first.
@@ -34,15 +30,6 @@ else:
             if err.errno != errno.EEXIST:
                 raise
     outfile = open(args.output + '.tmp', 'w')
-
-# Strip out blacklisted apps
-cpu_blacklist = blacklist.get(args.cpu, [])
-for app in cpu_blacklist:
-    if app in grid:
-        del grid[app]
-    for sect, apps in grid.items():
-        if app in apps:
-            grid[sect].remove(app)
 
 # Check that all directories are in the top-level "desktop" pseudo-directory
 desktop = grid["desktop"]

--- a/data/settings/write-grid-json.py
+++ b/data/settings/write-grid-json.py
@@ -1,21 +1,17 @@
 #!/usr/bin/env python3
 
-from argparse import ArgumentParser
-from collections import OrderedDict
-import errno
+from argparse import ArgumentParser, FileType
 import json
 import os
 import sys
 
 aparser = ArgumentParser(description='Write icon grid json file')
 aparser.add_argument('-o', '--output', help='output file')
-aparser.add_argument('input', help='input template file')
+aparser.add_argument('input', help='input template file', type=FileType("r"))
 args = aparser.parse_args()
 
-# Load template. Use OrderedDict for the grid to
-# maintain sorting of the keys.
-with open(args.input, 'r') as infile:
-    grid = json.load(infile, object_pairs_hook=OrderedDict)
+# Load template
+grid = json.load(args.input)
 
 # Open the a temporary version of the output file if specified, ensuring
 # that leading directories are created first.
@@ -24,11 +20,7 @@ if args.output is None:
 else:
     outdir = os.path.dirname(args.output)
     if len(outdir) > 0:
-        try:
-            os.makedirs(outdir)
-        except OSError as err:
-            if err.errno != errno.EEXIST:
-                raise
+        os.makedirs(outdir, exist_ok=True)
     outfile = open(args.output + '.tmp', 'w')
 
 # Check that all directories are in the top-level "desktop" pseudo-directory


### PR DESCRIPTION
The keys in arch-blacklist.json are the autotools $(host_cpu) variable.
The only key in that file is "arm". But nowadays we only support 64-bit
ARM, for which $(host_cpu) is "aarch64". So this filter now does
nothing.

It doesn't matter, anyway, because the app grid code in Endless OS 3.9
and later just hides empty folders.

Remove the blacklist logic, which also removes some problematic
terminology from our distro.

While I was here I cleaned the JSON-mangling script a bit. You might notice that it is now a fancy `cat` that performs a tiny amount of validation on the JSON. You might then think – can we just rename all the `.json.in` files to `.json`, install them verbatim, and just syntax-check them at build time? And yes, we could, but I ran out of evening and appetite to think about Autotools. **Update** I filed #256 which I have barely tested.