### PR TITLE
Remove Brasero from default icon grid.

### DIFF
--- a/data/settings/icon-grid-C.json.in
+++ b/data/settings/icon-grid-C.json.in
@@ -116,7 +116,6 @@
     "org.gnome.Weather.desktop",
     "org.gnome.Gnote.desktop",
     "simple-scan.desktop",
-    "brasero.desktop",
     "org.gnome.Contacts.desktop",
     "org.gnome.Evolution.desktop",
     "org.gnome.font-viewer.desktop",

--- a/data/settings/icon-grid-es.json.in
+++ b/data/settings/icon-grid-es.json.in
@@ -69,7 +69,6 @@
     "org.gnome.Weather.desktop",
     "org.gnome.Gnote.desktop",
     "simple-scan.desktop",
-    "brasero.desktop",
     "org.gnome.Contacts.desktop",
     "org.gnome.Evolution.desktop",
     "org.gnome.font-viewer.desktop",

--- a/data/settings/icon-grid-es_GT.json.in
+++ b/data/settings/icon-grid-es_GT.json.in
@@ -69,7 +69,6 @@
     "org.gnome.Weather.desktop",
     "org.gnome.Gnote.desktop",
     "simple-scan.desktop",
-    "brasero.desktop",
     "org.gnome.Contacts.desktop",
     "org.gnome.Evolution.desktop",
     "org.gnome.font-viewer.desktop",

--- a/data/settings/icon-grid-fr.json.in
+++ b/data/settings/icon-grid-fr.json.in
@@ -116,7 +116,6 @@
     "org.gnome.Weather.desktop",
     "org.gnome.Gnote.desktop",
     "simple-scan.desktop",
-    "brasero.desktop",
     "org.gnome.Contacts.desktop",
     "org.gnome.Evolution.desktop",
     "org.gnome.font-viewer.desktop",

--- a/data/settings/icon-grid-pt.json.in
+++ b/data/settings/icon-grid-pt.json.in
@@ -90,7 +90,6 @@
     "org.gnome.Weather.desktop",
     "org.gnome.Gnote.desktop",
     "simple-scan.desktop",
-    "brasero.desktop",
     "org.gnome.Contacts.desktop",
     "org.gnome.Evolution.desktop",
     "org.gnome.font-viewer.desktop",


### PR DESCRIPTION
For reasons outlined in https://github.com/endlessm/eos-meta/pull/767 we
are removing Brasero from the base OS.

https://phabricator.endlessm.com/T35003
