### PR TITLE
icon grid: Add game development tools

### DIFF
--- a/data/settings/icon-grid-C.json.in
+++ b/data/settings/icon-grid-C.json.in
@@ -85,6 +85,10 @@
     "io.lmms.LMMS.desktop",
     "org.gimp.GIMP.desktop",
     "org.tuxpaint.Tuxpaint.desktop",
+    "com.orama_interactive.Pixelorama.desktop",
+    "org.godotengine.Godot.desktop",
+    "io.gdevelop.ide.desktop",
+    "com.unity.UnityHub.desktop",
     "org.learningequality.Kolibri.channel_f061fce103ff5d4e9b8433e67802e666.desktop",
     "com.endlessnetwork.blendertutorials.desktop",
     "com.endlessnetwork.drawingtutorials.desktop"

--- a/data/settings/icon-grid-es.json.in
+++ b/data/settings/icon-grid-es.json.in
@@ -40,12 +40,17 @@
     "io.lmms.LMMS.desktop",
     "org.gimp.GIMP.desktop",
     "org.tuxpaint.Tuxpaint.desktop",
+    "com.orama_interactive.Pixelorama.desktop",
+    "org.godotengine.Godot.desktop",
+    "io.gdevelop.ide.desktop",
+    "com.unity.UnityHub.desktop",
     "org.gnome.Shotwell.desktop",
     "com.endlessm.creativity_center.es.desktop"
   ],
   "eos-folder-coding-education.directory": [
     "com.hack_computer.Clubhouse.desktop",
     "edu.mit.Scratch.desktop",
+    "ar.com.pilas_engine.App.desktop",
     "com.hack_computer.OperatingSystemApp.desktop",
     "com.hack_computer.Sidetrack.desktop",
     "cc.arduino.arduinoide.desktop",

--- a/data/settings/icon-grid-es_GT.json.in
+++ b/data/settings/icon-grid-es_GT.json.in
@@ -40,12 +40,17 @@
     "io.lmms.LMMS.desktop",
     "org.gimp.GIMP.desktop",
     "org.tuxpaint.Tuxpaint.desktop",
+    "com.orama_interactive.Pixelorama.desktop",
+    "org.godotengine.Godot.desktop",
+    "io.gdevelop.ide.desktop",
+    "com.unity.UnityHub.desktop",
     "org.gnome.Shotwell.desktop",
     "com.endlessm.creativity_center.es.desktop"
   ],
   "eos-folder-coding-education.directory": [
     "com.hack_computer.Clubhouse.desktop",
     "edu.mit.Scratch.desktop",
+    "ar.com.pilas_engine.App.desktop",
     "com.hack_computer.OperatingSystemApp.desktop",
     "com.hack_computer.Sidetrack.desktop",
     "cc.arduino.arduinoide.desktop",

--- a/data/settings/icon-grid-fr.json.in
+++ b/data/settings/icon-grid-fr.json.in
@@ -85,6 +85,10 @@
     "io.lmms.LMMS.desktop",
     "org.gimp.GIMP.desktop",
     "org.tuxpaint.Tuxpaint.desktop",
+    "com.orama_interactive.Pixelorama.desktop",
+    "org.godotengine.Godot.desktop",
+    "io.gdevelop.ide.desktop",
+    "com.unity.UnityHub.desktop",
     "org.learningequality.Kolibri.channel_f061fce103ff5d4e9b8433e67802e666.desktop",
     "com.endlessnetwork.blendertutorials.desktop",
     "com.endlessnetwork.drawingtutorials.desktop"

--- a/data/settings/icon-grid-pt.json.in
+++ b/data/settings/icon-grid-pt.json.in
@@ -60,6 +60,10 @@
     "io.lmms.LMMS.desktop",
     "org.gimp.GIMP.desktop",
     "org.tuxpaint.Tuxpaint.desktop",
+    "com.orama_interactive.Pixelorama.desktop",
+    "org.godotengine.Godot.desktop",
+    "io.gdevelop.ide.desktop",
+    "com.unity.UnityHub.desktop",
     "com.endlessnetwork.blendertutorials.desktop",
     "com.endlessnetwork.drawingtutorials.desktop"
   ],


### PR DESCRIPTION
Organize some game development tools which are being added to the default applications. For now, these will be placed in the Create and Coding Education directories.

https://phabricator.endlessm.com/T34960

-----

See also:

- [x] https://github.com/endlessm/eos-image-builder/pull/130
- [x] https://github.com/endlessm/eos-image-builder/pull/131
- [x] https://github.com/endlessm/endless-image-config/pull/1159
