### PR TITLE
Replace Eye of GNOME with Loupe in default app grid layouts

### DIFF
--- a/data/settings/icon-grid-C.json.in
+++ b/data/settings/icon-grid-C.json.in
@@ -113,7 +113,7 @@
     "gnome-control-center.desktop",
     "org.gnome.Yelp.desktop",
     "org.gnome.Cheese.desktop",
-    "org.gnome.eog.desktop",
+    "org.gnome.Loupe.desktop",
     "org.gnome.Evince.desktop",
     "org.gnome.Screenshot.desktop",
     "org.gnome.Weather.desktop",

--- a/data/settings/icon-grid-es.json.in
+++ b/data/settings/icon-grid-es.json.in
@@ -2,7 +2,7 @@
   "desktop": [
     "org.endlessos.Key.desktop",
     "org.gnome.Totem.desktop",
-    "org.gnome.eog.desktop",
+    "org.gnome.Loupe.desktop",
     "org.gnome.Rhythmbox3.desktop",
     "org.gnome.Evince.desktop",
     "org.freedesktop.MalcontentControl.desktop",

--- a/data/settings/icon-grid-es_GT.json.in
+++ b/data/settings/icon-grid-es_GT.json.in
@@ -2,7 +2,7 @@
   "desktop": [
     "org.endlessos.Key.desktop",
     "org.gnome.Totem.desktop",
-    "org.gnome.eog.desktop",
+    "org.gnome.Loupe.desktop",
     "org.gnome.Rhythmbox3.desktop",
     "org.gnome.Evince.desktop",
     "org.freedesktop.MalcontentControl.desktop",

--- a/data/settings/icon-grid-fr.json.in
+++ b/data/settings/icon-grid-fr.json.in
@@ -112,7 +112,7 @@
     "gnome-control-center.desktop",
     "org.gnome.Yelp.desktop",
     "org.gnome.Cheese.desktop",
-    "org.gnome.eog.desktop",
+    "org.gnome.Loupe.desktop",
     "org.gnome.Evince.desktop",
     "org.gnome.Screenshot.desktop",
     "org.gnome.Weather.desktop",

--- a/data/settings/icon-grid-pt.json.in
+++ b/data/settings/icon-grid-pt.json.in
@@ -86,7 +86,7 @@
     "gnome-control-center.desktop",
     "org.gnome.Yelp.desktop",
     "org.gnome.Cheese.desktop",
-    "org.gnome.eog.desktop",
+    "org.gnome.Loupe.desktop",
     "org.gnome.Evince.desktop",
     "org.gnome.Screenshot.desktop",
     "org.gnome.Weather.desktop",


### PR DESCRIPTION
https://phabricator.endlessm.com/T34908
