### PR TITLE
Replace Rhythmbox with Music in default app grid layouts

### DIFF
--- a/data/settings/icon-grid-C.json.in
+++ b/data/settings/icon-grid-C.json.in
@@ -3,7 +3,7 @@
     "org.endlessos.Key.desktop",
     "org.gnome.Totem.desktop",
     "org.gnome.Shotwell.desktop",
-    "org.gnome.Rhythmbox3.desktop",
+    "org.gnome.Music.desktop",
     "eos-folder-play.directory",
     "eos-folder-create.directory",
     "eos-folder-work.directory",
@@ -132,6 +132,7 @@
     "org.gnome.gedit.desktop",
     "org.gnome.FileRoller.desktop",
     "org.gnome.Tour.desktop",
-    "org.gnome.Epiphany.desktop"
+    "org.gnome.Epiphany.desktop",
+    "com.vixalien.decibels.desktop"
   ]
 }

--- a/data/settings/icon-grid-ar.json.in
+++ b/data/settings/icon-grid-ar.json.in
@@ -14,7 +14,7 @@
     "eos-folder-social.directory",
     "net.minetest.Minetest.desktop",
     "com.endlessm.cooking.ar.desktop",
-    "org.gnome.Rhythmbox3.desktop"
+    "org.gnome.Music.desktop"
   ],
   "eos-folder-curiosity.directory": [
     "com.endlessm.health.ar.desktop"

--- a/data/settings/icon-grid-bn.json.in
+++ b/data/settings/icon-grid-bn.json.in
@@ -14,7 +14,7 @@
     "eos-folder-social.directory",
     "net.minetest.Minetest.desktop",
     "com.endlessm.cooking.bn_BD.desktop",
-    "org.gnome.Rhythmbox3.desktop"
+    "org.gnome.Music.desktop"
   ],
   "eos-folder-curiosity.directory": [
     "com.endlessm.animals.bn_BD.desktop",

--- a/data/settings/icon-grid-es.json.in
+++ b/data/settings/icon-grid-es.json.in
@@ -3,7 +3,7 @@
     "org.endlessos.Key.desktop",
     "org.gnome.Totem.desktop",
     "org.gnome.Loupe.desktop",
-    "org.gnome.Rhythmbox3.desktop",
+    "org.gnome.Music.desktop",
     "org.gnome.Evince.desktop",
     "org.freedesktop.MalcontentControl.desktop",
     "com.endlessm.encyclopedia.es.desktop",
@@ -84,7 +84,8 @@
     "org.gnome.gedit.desktop",
     "org.gnome.FileRoller.desktop",
     "org.gnome.Tour.desktop",
-    "org.gnome.Epiphany.desktop"
+    "org.gnome.Epiphany.desktop",
+    "com.vixalien.decibels.desktop"
   ],
   "Education.directory": [
     "org.learningequality.Kolibri.channel_c1f2b7e6ac9f56a2bb44fa7a48b66dce.desktop",

--- a/data/settings/icon-grid-es_GT.json.in
+++ b/data/settings/icon-grid-es_GT.json.in
@@ -3,7 +3,7 @@
     "org.endlessos.Key.desktop",
     "org.gnome.Totem.desktop",
     "org.gnome.Loupe.desktop",
-    "org.gnome.Rhythmbox3.desktop",
+    "org.gnome.Music.desktop",
     "org.gnome.Evince.desktop",
     "org.freedesktop.MalcontentControl.desktop",
     "com.endlessm.encyclopedia.es.desktop",
@@ -84,7 +84,8 @@
     "org.gnome.gedit.desktop",
     "org.gnome.FileRoller.desktop",
     "org.gnome.Tour.desktop",
-    "org.gnome.Epiphany.desktop"
+    "org.gnome.Epiphany.desktop",
+    "com.vixalien.decibels.desktop"
   ],
   "Education.directory": [
     "org.learningequality.Kolibri.channel_c1f2b7e6ac9f56a2bb44fa7a48b66dce.desktop",

--- a/data/settings/icon-grid-fr.json.in
+++ b/data/settings/icon-grid-fr.json.in
@@ -3,7 +3,7 @@
     "org.endlessos.Key.desktop",
     "org.gnome.Totem.desktop",
     "org.gnome.Shotwell.desktop",
-    "org.gnome.Rhythmbox3.desktop",
+    "org.gnome.Music.desktop",
     "eos-folder-play.directory",
     "eos-folder-create.directory",
     "eos-folder-work.directory",
@@ -131,6 +131,7 @@
     "org.gnome.gedit.desktop",
     "org.gnome.FileRoller.desktop",
     "org.gnome.Tour.desktop",
-    "org.gnome.Epiphany.desktop"
+    "org.gnome.Epiphany.desktop",
+    "com.vixalien.decibels.desktop"
   ]
 }

--- a/data/settings/icon-grid-id.json.in
+++ b/data/settings/icon-grid-id.json.in
@@ -75,7 +75,7 @@
     "org.tuxpaint.Tuxpaint.desktop",
     "org.audacityteam.Audacity.desktop",
     "org.kde.krita.desktop",
-    "org.gnome.Rhythmbox3.desktop",
+    "org.gnome.Music.desktop",
     "org.gimp.GIMP.desktop",
     "org.inkscape.Inkscape.desktop",
     "org.pitivi.Pitivi.desktop",

--- a/data/settings/icon-grid-pt.json.in
+++ b/data/settings/icon-grid-pt.json.in
@@ -3,7 +3,7 @@
     "org.endlessos.Key.desktop",
     "org.gnome.Totem.desktop",
     "org.gnome.Shotwell.desktop",
-    "org.gnome.Rhythmbox3.desktop",
+    "org.gnome.Music.desktop",
     "eos-folder-play.directory",
     "eos-folder-create.directory",
     "eos-folder-work.directory",
@@ -105,6 +105,7 @@
     "org.gnome.gedit.desktop",
     "org.gnome.FileRoller.desktop",
     "org.gnome.Tour.desktop",
-    "org.gnome.Epiphany.desktop"
+    "org.gnome.Epiphany.desktop",
+    "com.vixalien.decibels.desktop"
   ]
 }

--- a/data/settings/icon-grid-th.json.in
+++ b/data/settings/icon-grid-th.json.in
@@ -13,7 +13,7 @@
     "eos-folder-games-to-hack.directory",
     "eos-folder-social.directory",
     "net.minetest.Minetest.desktop",
-    "org.gnome.Rhythmbox3.desktop"
+    "org.gnome.Music.desktop"
   ],
   "eos-folder-curiosity.directory": [
     "com.endlessm.celebrities.th.desktop",

--- a/data/settings/icon-grid-vi.json.in
+++ b/data/settings/icon-grid-vi.json.in
@@ -13,7 +13,7 @@
     "eos-folder-games-to-hack.directory",
     "eos-folder-social.directory",
     "net.minetest.Minetest.desktop",
-    "org.gnome.Rhythmbox3.desktop"
+    "org.gnome.Music.desktop"
   ],
   "eos-folder-curiosity.directory": [
     "com.endlessm.celebrities.vi.desktop",

--- a/data/settings/icon-grid-zh_CN.json.in
+++ b/data/settings/icon-grid-zh_CN.json.in
@@ -50,7 +50,7 @@
     "evolution.desktop"
   ],
   "eos-folder-tools.directory": [
-    "org.gnome.Rhythmbox3.desktop",
+    "org.gnome.Music.desktop",
     "org.gnome.Totem.desktop",
     "org.audacityteam.Audacity.desktop",
     "org.gnome.Shotwell.desktop",


### PR DESCRIPTION
Also add Decibels to Utilities folder so it doesn't clutter up the grid, since it's best used to handle opening files but less useful to open on its own.

https://phabricator.endlessm.com/T32696