### PR TITLE
Update Decibels app ID in app grids

### DIFF
--- a/data/settings/icon-grid-C.json.in
+++ b/data/settings/icon-grid-C.json.in
@@ -133,6 +133,6 @@
     "org.gnome.FileRoller.desktop",
     "org.gnome.Tour.desktop",
     "org.gnome.Epiphany.desktop",
-    "com.vixalien.decibels.desktop"
+    "org.gnome.Decibels.desktop"
   ]
 }

--- a/data/settings/icon-grid-es.json.in
+++ b/data/settings/icon-grid-es.json.in
@@ -85,7 +85,7 @@
     "org.gnome.FileRoller.desktop",
     "org.gnome.Tour.desktop",
     "org.gnome.Epiphany.desktop",
-    "com.vixalien.decibels.desktop"
+    "org.gnome.Decibels.desktop"
   ],
   "Education.directory": [
     "org.learningequality.Kolibri.channel_c1f2b7e6ac9f56a2bb44fa7a48b66dce.desktop",

--- a/data/settings/icon-grid-es_GT.json.in
+++ b/data/settings/icon-grid-es_GT.json.in
@@ -85,7 +85,7 @@
     "org.gnome.FileRoller.desktop",
     "org.gnome.Tour.desktop",
     "org.gnome.Epiphany.desktop",
-    "com.vixalien.decibels.desktop"
+    "org.gnome.Decibels.desktop"
   ],
   "Education.directory": [
     "org.learningequality.Kolibri.channel_c1f2b7e6ac9f56a2bb44fa7a48b66dce.desktop",

--- a/data/settings/icon-grid-fr.json.in
+++ b/data/settings/icon-grid-fr.json.in
@@ -132,6 +132,6 @@
     "org.gnome.FileRoller.desktop",
     "org.gnome.Tour.desktop",
     "org.gnome.Epiphany.desktop",
-    "com.vixalien.decibels.desktop"
+    "org.gnome.Decibels.desktop"
   ]
 }

--- a/data/settings/icon-grid-pt.json.in
+++ b/data/settings/icon-grid-pt.json.in
@@ -106,6 +106,6 @@
     "org.gnome.FileRoller.desktop",
     "org.gnome.Tour.desktop",
     "org.gnome.Epiphany.desktop",
-    "com.vixalien.decibels.desktop"
+    "org.gnome.Decibels.desktop"
   ]
 }


### PR DESCRIPTION
The change from com.vixalien.decibels to org.gnome.Decibels has been rolled out on Flathub, so change the app grids accordingly.

https://phabricator.endlessm.com/T32696