### PR TITLE
autogen.sh: Migrate gnome-autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,21 +1,40 @@
 #!/bin/sh
 # Run this to generate all the initial makefiles, etc.
+test -n "$srcdir" || srcdir=$(dirname "$0")
+test -n "$srcdir" || srcdir=.
 
-srcdir=`dirname $0`
-test -z "$srcdir" && srcdir=.
+olddir=$(pwd)
 
-PKG_NAME="eos-shell-content"
+cd $srcdir
 
-(test -f $srcdir/unzip_content.py) || {
-    echo -n "**Error**: Directory "\`$srcdir\'" does not look like the"
-    echo " top-level $PKG_NAME directory"
-    exit 1
+(test -f configure.ac) || {
+        echo "*** ERROR: Directory '$srcdir' does not look like the top-level project directory ***"
+        exit 1
 }
 
-which gnome-autogen.sh || {
-    echo "You need to install the gnome-common package."
-    exit 1
-}
+# shellcheck disable=SC2016
+PKG_NAME=$(autoconf --trace 'AC_INIT:$1' configure.ac)
 
-USE_GNOME2_MACROS=1 . gnome-autogen.sh
+if [ "$#" = 0 -a "x$NOCONFIGURE" = "x" ]; then
+        echo "*** WARNING: I am going to run 'configure' with no arguments." >&2
+        echo "*** If you wish to pass any to it, please specify them on the" >&2
+        echo "*** '$0' command line." >&2
+        echo "" >&2
+fi
+
+autoreconf --verbose --force --install || exit 1
+
+cd "$olddir"
+if [ "$NOCONFIGURE" = "" ]; then
+        $srcdir/configure "$@" || exit 1
+
+        if [ "$1" = "--help" ]; then
+                exit 0
+        else
+                echo "Now type 'make' to compile $PKG_NAME" || exit 1
+        fi
+else
+        echo "Skipping configure process."
+fi
+
 rm -f po/Makevars.template

--- a/debian/eos-acknowledgements.install
+++ b/debian/eos-acknowledgements.install
@@ -1,1 +1,1 @@
-acknowledgements/* usr/share/eos-acknowledgements
+usr/share/eos-acknowledgements


### PR DESCRIPTION
The gnome-common [1] provided gnome-autogen.sh is completely deprecated.
To keep it work in the future, we have to do the migration by following GnomeCommon/Migration [2].

[1]: https://gitlab.gnome.org/Archive/gnome-common
[2]: https://wiki.gnome.org/Projects/GnomeCommon/Migration

Fixes: https://github.com/endlessm/eos-build-meta/issues/39