### PR TITLE
icon grid: Remove Endless Key from icon grid

### DIFF
--- a/data/settings/icon-grid-C.json.in
+++ b/data/settings/icon-grid-C.json.in
@@ -32,7 +32,6 @@
     "com.endlessm.dinosaurs.en.desktop",
     "com.endlessm.history.en.desktop",
     "com.endlessm.myths.en.desktop",
-    "org.endlessos.Key.desktop",
     "com.endlessm.cooking.en.desktop",
     "com.endlessm.animals.en.desktop"
   ],

--- a/data/settings/icon-grid-ar.json.in
+++ b/data/settings/icon-grid-ar.json.in
@@ -1,6 +1,5 @@
 {
   "desktop": [
-    "org.endlessos.Key.desktop",
     "org.libreoffice.LibreOffice.writer.desktop",
     "org.libreoffice.LibreOffice.calc.desktop",
     "org.libreoffice.LibreOffice.impress.desktop",

--- a/data/settings/icon-grid-bn.json.in
+++ b/data/settings/icon-grid-bn.json.in
@@ -1,6 +1,5 @@
 {
   "desktop": [
-    "org.endlessos.Key.desktop",
     "org.libreoffice.LibreOffice.writer.desktop",
     "org.libreoffice.LibreOffice.calc.desktop",
     "org.libreoffice.LibreOffice.impress.desktop",

--- a/data/settings/icon-grid-es.json.in
+++ b/data/settings/icon-grid-es.json.in
@@ -35,7 +35,6 @@
     "com.endlessm.history.es.desktop",
     "com.endlessm.history.es_GT.desktop",
     "com.endlessm.myths.es.desktop",
-    "org.endlessos.Key.desktop",
     "com.endlessm.cooking.es.desktop",
     "com.endlessm.cooking.es_GT.desktop",
     "com.endlessm.animals.es.desktop",

--- a/data/settings/icon-grid-fr.json.in
+++ b/data/settings/icon-grid-fr.json.in
@@ -1,6 +1,5 @@
 {
   "desktop": [
-    "org.endlessos.Key.desktop",
     "org.gnome.Totem.desktop",
     "org.gnome.Shotwell.desktop",
     "org.gnome.Music.desktop",

--- a/data/settings/icon-grid-id.json.in
+++ b/data/settings/icon-grid-id.json.in
@@ -1,6 +1,5 @@
 {
   "desktop": [
-    "org.endlessos.Key.desktop",
     "org.libreoffice.LibreOffice.writer.desktop",
     "org.libreoffice.LibreOffice.calc.desktop",
     "org.libreoffice.LibreOffice.impress.desktop",

--- a/data/settings/icon-grid-pt.json.in
+++ b/data/settings/icon-grid-pt.json.in
@@ -1,6 +1,5 @@
 {
   "desktop": [
-    "org.endlessos.Key.desktop",
     "org.gnome.Totem.desktop",
     "org.gnome.Shotwell.desktop",
     "org.gnome.Music.desktop",

--- a/data/settings/icon-grid-th.json.in
+++ b/data/settings/icon-grid-th.json.in
@@ -1,6 +1,5 @@
 {
   "desktop": [
-    "org.endlessos.Key.desktop",
     "org.libreoffice.LibreOffice.writer.desktop",
     "org.libreoffice.LibreOffice.calc.desktop",
     "org.libreoffice.LibreOffice.impress.desktop",

--- a/data/settings/icon-grid-vi.json.in
+++ b/data/settings/icon-grid-vi.json.in
@@ -1,6 +1,5 @@
 {
   "desktop": [
-    "org.endlessos.Key.desktop",
     "org.libreoffice.LibreOffice.writer.desktop",
     "org.libreoffice.LibreOffice.calc.desktop",
     "org.libreoffice.LibreOffice.impress.desktop",

--- a/data/settings/icon-grid-zh_CN.json.in
+++ b/data/settings/icon-grid-zh_CN.json.in
@@ -1,6 +1,5 @@
 {
   "desktop": [
-    "org.endlessos.Key.desktop",
     "eos-folder-curiosity.directory",
     "eos-folder-work.directory",
     "eos-folder-tools.directory",


### PR DESCRIPTION
Endless Key is winding down. So, remove it from icon grid.

https://phabricator.endlessm.com/T35871