### PR TITLE
Icon grid: Fix Threadbare desktop extension name

### DIFF
--- a/data/settings/icon-grid-C.json.in
+++ b/data/settings/icon-grid-C.json.in
@@ -109,7 +109,7 @@
     "org.learningequality.Kolibri.channel_f061fce103ff5d4e9b8433e67802e666.desktop"
   ],
   "eos-folder-educational-game.directory": [
-    "org.endlessaccess.threadbare",
+    "org.endlessaccess.threadbare.desktop",
     "org.kde.kblocks.desktop",
     "org.gnome.gbrainy.desktop",
     "org.kde.khangman.desktop",


### PR DESCRIPTION
Fix commit 628b1353b8fd ("Icon grid: Add Threadbare").

https://app.asana.com/1/1203676861188277/task/1211319357835612/comment/1211572695922973